### PR TITLE
fix: publish releases from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack
         run: corepack enable
@@ -31,21 +32,46 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           version: 'yarn changeset version'
+          publish: 'yarn changeset publish'
           commit: 'chore: version packages'
           title: 'chore: version packages'
+          createGithubReleases: false
 
-      - name: Create and Push Tag
-        if: "contains(github.event.head_commit.message, 'chore: version packages')"
+      - name: Extract published version
+        if: steps.changesets.outputs.published == 'true'
+        id: version
         run: |
           VERSION=$(node -p "require('./packages/react-native-nitro-geolocation/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and Push Tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "$TAG already exists on origin, skipping tag push."
+            exit 0
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body_path: packages/react-native-nitro-geolocation/CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- make the release workflow publish packages directly when a release PR has already been merged
- create the Git tag and GitHub release in the same workflow after a successful publish
- skip tag push when the tag already exists so the workflow can recover a missed publish

## Why
The current flow creates the version bump commit and pushes  with , but the separate  workflow does not get triggered reliably from that tag push. This leaves  versioned without publishing to npm.

## Recovery
After this merges, re-run the  workflow on  or push a no-op commit to  to let the fixed workflow publish the already-versioned  release.