### PR TITLE
fix: harden geolocation devtools release paths

### DIFF
--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -1,8 +1,3 @@
-import {
-  type Position,
-  createPosition,
-  useGeolocationDevTools
-} from "@react-native-nitro-geolocation/rozenite-plugin";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";
 import React from "react";
@@ -11,24 +6,20 @@ import DefaultScreen from "./screens/DefaultScreen";
 
 const Tab = createBottomTabNavigator();
 
-const initialPosition = createPosition("Los Angeles, USA");
-const customPosition: Position = {
-  coords: {
-    latitude: 34.052235,
-    longitude: -118.243683,
-    accuracy: 100,
-    altitude: 0,
-    altitudeAccuracy: 0,
-    heading: 0,
-    speed: 0
-  },
-  timestamp: Date.now()
-};
+function useExampleGeolocationDevTools() {
+  if (!__DEV__) {
+    return;
+  }
+
+  const { createPosition, useGeolocationDevTools } = require("@react-native-nitro-geolocation/rozenite-plugin") as typeof import("@react-native-nitro-geolocation/rozenite-plugin");
+
+  useGeolocationDevTools({
+    initialPosition: createPosition("Los Angeles, USA")
+  });
+}
 
 export default function App() {
-  useGeolocationDevTools({
-    initialPosition
-  });
+  useExampleGeolocationDevTools();
 
   return (
     <NavigationContainer>

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -1,7 +1,6 @@
 import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
-import { isDevtoolsEnabled } from "../devtools";
-import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
+import { getDevtoolsCurrentPositionIfEnabled } from "../devtools/runtime";
 import type { GeolocationResponse } from "../types";
 
 /**
@@ -33,11 +32,9 @@ import type { GeolocationResponse } from "../types";
 export function getCurrentPosition(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse> {
-  if (isDevtoolsEnabled()) {
-    const devtoolsResult = getDevtoolsCurrentPosition();
-    if (devtoolsResult) {
-      return devtoolsResult;
-    }
+  const devtoolsResult = getDevtoolsCurrentPositionIfEnabled();
+  if (devtoolsResult) {
+    return devtoolsResult;
   }
   return NitroGeolocationHybridObject.getCurrentPosition(options);
 }

--- a/packages/react-native-nitro-geolocation/src/api/unwatch.ts
+++ b/packages/react-native-nitro-geolocation/src/api/unwatch.ts
@@ -1,5 +1,5 @@
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
-import { devtoolsUnwatch } from "../devtools/watchPosition";
+import { unwatchDevtoolsTokenIfEnabled } from "../devtools/runtime";
 
 /**
  * Stop a specific watch subscription.
@@ -15,7 +15,7 @@ import { devtoolsUnwatch } from "../devtools/watchPosition";
  * ```
  */
 export function unwatch(token: string): void {
-  if (devtoolsUnwatch(token)) {
+  if (unwatchDevtoolsTokenIfEnabled(token)) {
     return;
   }
   NitroGeolocationHybridObject.unwatch(token);

--- a/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
@@ -3,8 +3,7 @@ import type {
   LocationRequestOptions
 } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
-import { isDevtoolsEnabled } from "../devtools";
-import { devtoolsWatchPosition } from "../devtools/watchPosition";
+import { watchDevtoolsPositionIfEnabled } from "../devtools/runtime";
 import type { GeolocationResponse } from "../types";
 
 /**
@@ -36,8 +35,9 @@ export function watchPosition(
   error?: (error: LocationError) => void,
   options?: LocationRequestOptions
 ): string {
-  if (isDevtoolsEnabled()) {
-    return devtoolsWatchPosition(success, error);
+  const devtoolsToken = watchDevtoolsPositionIfEnabled(success, error);
+  if (devtoolsToken) {
+    return devtoolsToken;
   }
   return NitroGeolocationHybridObject.watchPosition(success, error, options);
 }

--- a/packages/react-native-nitro-geolocation/src/devtools/runtime.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/runtime.ts
@@ -1,0 +1,52 @@
+import type { LocationError } from "../NitroGeolocation.nitro";
+import type { GeolocationResponse } from "../types";
+
+interface DevtoolsRuntime {
+  isEnabled: () => boolean;
+  getCurrentPosition: () => Promise<GeolocationResponse> | null;
+  watchPosition: (
+    success: (position: GeolocationResponse) => void,
+    error?: (error: LocationError) => void
+  ) => string;
+  unwatch: (token: string) => boolean;
+}
+
+function loadDevtoolsRuntime(): DevtoolsRuntime | null {
+  if (!__DEV__) return null;
+
+  const devtools = require("../devtools") as typeof import("../devtools");
+  if (!devtools.isDevtoolsEnabled()) {
+    return null;
+  }
+
+  const { getDevtoolsCurrentPosition } = require("../devtools/getCurrentPosition") as typeof import("../devtools/getCurrentPosition");
+  const { devtoolsWatchPosition, devtoolsUnwatch } = require("../devtools/watchPosition") as typeof import("../devtools/watchPosition");
+
+  return {
+    isEnabled: devtools.isDevtoolsEnabled,
+    getCurrentPosition: getDevtoolsCurrentPosition,
+    watchPosition: devtoolsWatchPosition,
+    unwatch: devtoolsUnwatch
+  };
+}
+
+export function getDevtoolsCurrentPositionIfEnabled(): Promise<GeolocationResponse> | null {
+  const runtime = loadDevtoolsRuntime();
+  if (!runtime) return null;
+  return runtime.getCurrentPosition();
+}
+
+export function watchDevtoolsPositionIfEnabled(
+  success: (position: GeolocationResponse) => void,
+  error?: (error: LocationError) => void
+): string | null {
+  const runtime = loadDevtoolsRuntime();
+  if (!runtime) return null;
+  return runtime.watchPosition(success, error);
+}
+
+export function unwatchDevtoolsTokenIfEnabled(token: string): boolean {
+  const runtime = loadDevtoolsRuntime();
+  if (!runtime) return false;
+  return runtime.unwatch(token);
+}

--- a/packages/react-native-nitro-geolocation/src/devtools/runtime.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/runtime.ts
@@ -11,27 +11,23 @@ interface DevtoolsRuntime {
   unwatch: (token: string) => boolean;
 }
 
-function loadDevtoolsRuntime(): DevtoolsRuntime | null {
+declare global {
+  var __geolocationDevtoolsRuntime: DevtoolsRuntime | undefined;
+}
+
+function getDevtoolsRuntime(): DevtoolsRuntime | null {
   if (!__DEV__) return null;
 
-  const devtools = require("../devtools") as typeof import("../devtools");
-  if (!devtools.isDevtoolsEnabled()) {
+  const runtime = globalThis.__geolocationDevtoolsRuntime;
+  if (!runtime || !runtime.isEnabled()) {
     return null;
   }
 
-  const { getDevtoolsCurrentPosition } = require("../devtools/getCurrentPosition") as typeof import("../devtools/getCurrentPosition");
-  const { devtoolsWatchPosition, devtoolsUnwatch } = require("../devtools/watchPosition") as typeof import("../devtools/watchPosition");
-
-  return {
-    isEnabled: devtools.isDevtoolsEnabled,
-    getCurrentPosition: getDevtoolsCurrentPosition,
-    watchPosition: devtoolsWatchPosition,
-    unwatch: devtoolsUnwatch
-  };
+  return runtime;
 }
 
 export function getDevtoolsCurrentPositionIfEnabled(): Promise<GeolocationResponse> | null {
-  const runtime = loadDevtoolsRuntime();
+  const runtime = getDevtoolsRuntime();
   if (!runtime) return null;
   return runtime.getCurrentPosition();
 }
@@ -40,13 +36,13 @@ export function watchDevtoolsPositionIfEnabled(
   success: (position: GeolocationResponse) => void,
   error?: (error: LocationError) => void
 ): string | null {
-  const runtime = loadDevtoolsRuntime();
+  const runtime = getDevtoolsRuntime();
   if (!runtime) return null;
   return runtime.watchPosition(success, error);
 }
 
 export function unwatchDevtoolsTokenIfEnabled(token: string): boolean {
-  const runtime = loadDevtoolsRuntime();
+  const runtime = getDevtoolsRuntime();
   if (!runtime) return false;
   return runtime.unwatch(token);
 }

--- a/packages/rozenite-devtools-plugin/src/react-native/devtoolsRuntime.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/devtoolsRuntime.ts
@@ -1,0 +1,119 @@
+import type { Position } from "../shared/types";
+
+const DEVTOOLS_NOT_CONNECTED_ERROR_MESSAGE =
+  "Geolocation devtools not connected. Press 'j' in Metro to open devtools and enable the geolocation plugin.";
+
+interface DevtoolsState {
+  position: Position | null;
+  initialPosition: Position | null;
+}
+
+interface DevtoolsRuntimeLocationError {
+  code: number;
+  message: string;
+}
+
+interface DevtoolsRuntime {
+  isEnabled: () => boolean;
+  getCurrentPosition: () => Promise<Position> | null;
+  watchPosition: (
+    success: (position: Position) => void,
+    error?: (error: DevtoolsRuntimeLocationError) => void
+  ) => string;
+  unwatch: (token: string) => boolean;
+}
+
+declare global {
+  var __geolocationDevtools: DevtoolsState | undefined;
+  var __geolocationDevToolsEnabled: boolean | undefined;
+  var __geolocationDevtoolsRuntime: DevtoolsRuntime | undefined;
+  var __geolocationDevtoolsWatchers:
+    | Record<string, ReturnType<typeof setInterval>>
+    | undefined;
+}
+
+export function getDevtoolsState(): DevtoolsState {
+  if (!globalThis.__geolocationDevtools) {
+    globalThis.__geolocationDevtools = {
+      position: null,
+      initialPosition: null
+    };
+  }
+
+  return globalThis.__geolocationDevtools;
+}
+
+export function installDevtoolsRuntime(): void {
+  globalThis.__geolocationDevtoolsRuntime = {
+    isEnabled: () => globalThis.__geolocationDevToolsEnabled === true,
+    getCurrentPosition: () => {
+      const devtools = getDevtoolsState();
+      if (devtools.position) {
+        return Promise.resolve(devtools.position);
+      }
+
+      return Promise.reject(
+        new Error(DEVTOOLS_NOT_CONNECTED_ERROR_MESSAGE)
+      );
+    },
+    watchPosition: (success, error) => {
+      const devtools = getDevtoolsState();
+
+      if (!devtools.position) {
+        error?.({
+          code: 2,
+          message: DEVTOOLS_NOT_CONNECTED_ERROR_MESSAGE
+        });
+
+        return `devtools-error-${Date.now()}`;
+      }
+
+      let previousPosition = devtools.position;
+      success(devtools.position);
+
+      const interval = setInterval(() => {
+        if (devtools.position && devtools.position !== previousPosition) {
+          previousPosition = devtools.position;
+          success(devtools.position);
+        }
+      }, 100);
+
+      const token = `devtools-${Date.now()}`;
+      globalThis.__geolocationDevtoolsWatchers =
+        globalThis.__geolocationDevtoolsWatchers || {};
+      globalThis.__geolocationDevtoolsWatchers[token] = interval;
+
+      return token;
+    },
+    unwatch: (token) => {
+      if (!token.startsWith("devtools-")) {
+        return false;
+      }
+
+      if (token.startsWith("devtools-error-")) {
+        return true;
+      }
+
+      const watchers = globalThis.__geolocationDevtoolsWatchers;
+      if (watchers?.[token]) {
+        clearInterval(watchers[token]);
+        delete watchers[token];
+        return true;
+      }
+
+      return false;
+    }
+  };
+}
+
+export function uninstallDevtoolsRuntime(): void {
+  const watchers = globalThis.__geolocationDevtoolsWatchers;
+  if (watchers) {
+    for (const token of Object.keys(watchers)) {
+      clearInterval(watchers[token]);
+    }
+  }
+
+  globalThis.__geolocationDevtoolsWatchers = undefined;
+  globalThis.__geolocationDevtoolsRuntime = undefined;
+}

--- a/packages/rozenite-devtools-plugin/src/react-native/hooks/useDevtoolsRN.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/hooks/useDevtoolsRN.ts
@@ -3,26 +3,8 @@ import type {
   Subscription
 } from "@rozenite/plugin-bridge";
 import { useEffect } from "react";
-import type { DevtoolsRNEvents, Position } from "../../shared/types";
-
-declare global {
-  var __geolocationDevtools:
-    | {
-        position: Position | null;
-        initialPosition: Position | null;
-      }
-    | undefined;
-}
-
-function getDevtoolsState() {
-  if (!globalThis.__geolocationDevtools) {
-    globalThis.__geolocationDevtools = {
-      position: null,
-      initialPosition: null
-    };
-  }
-  return globalThis.__geolocationDevtools;
-}
+import type { DevtoolsRNEvents } from "../../shared/types";
+import { getDevtoolsState } from "../devtoolsRuntime";
 
 interface UseDevtoolsRNOptions {
   client: RozeniteDevToolsClient<DevtoolsRNEvents> | null;

--- a/packages/rozenite-devtools-plugin/src/react-native/hooks/useInitialPosition.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/hooks/useInitialPosition.ts
@@ -1,24 +1,6 @@
 import { useEffect } from "react";
 import type { Position } from "../../shared/types";
-
-declare global {
-  var __geolocationDevtools:
-    | {
-        position: Position | null;
-        initialPosition: Position | null;
-      }
-    | undefined;
-}
-
-function getDevtoolsState() {
-  if (!globalThis.__geolocationDevtools) {
-    globalThis.__geolocationDevtools = {
-      position: null,
-      initialPosition: null
-    };
-  }
-  return globalThis.__geolocationDevtools;
-}
+import { getDevtoolsState } from "../devtoolsRuntime";
 
 export function useInitialPosition(initialPosition?: Position) {
   useEffect(() => {

--- a/packages/rozenite-devtools-plugin/src/react-native/hooks/useSetDevToolsEnabled.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/hooks/useSetDevToolsEnabled.ts
@@ -1,7 +1,17 @@
 import { useEffect } from "react";
+import {
+  installDevtoolsRuntime,
+  uninstallDevtoolsRuntime
+} from "../devtoolsRuntime";
 
 export const useSetDevToolsEnabled = () => {
   useEffect(() => {
+    installDevtoolsRuntime();
     globalThis.__geolocationDevToolsEnabled = true;
+
+    return () => {
+      globalThis.__geolocationDevToolsEnabled = false;
+      uninstallDevtoolsRuntime();
+    };
   }, []);
 };

--- a/packages/rozenite-devtools-plugin/src/react-native/useGeolocationDevTools.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/useGeolocationDevTools.ts
@@ -4,16 +4,6 @@ import { useDevtoolsRN } from "./hooks/useDevtoolsRN";
 import { useInitialPosition } from "./hooks/useInitialPosition";
 import { useSetDevToolsEnabled } from "./hooks/useSetDevToolsEnabled";
 
-declare global {
-  var __geolocationDevtools:
-    | {
-        position: Position | null;
-        initialPosition: Position | null;
-      }
-    | undefined;
-  var __geolocationDevToolsEnabled: boolean | undefined;
-}
-
 interface UseGeolocationDevToolsOptions {
   initialPosition?: Position;
 }


### PR DESCRIPTION
## Summary
- guard the example app's Rozenite setup behind `__DEV__`
- move the geolocation devtools runtime behind a plugin-installed global adapter so release bundles stop pulling in the core devtools modules
- keep devtools state and watch cleanup in the Rozenite plugin runtime

## Verification
- `yarn typecheck`
- `yarn lint`
- `env WITH_ROZENITE=true npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output /tmp/rnng-with-rozenite.bundle --assets-dest /tmp/rnng-with-rozenite-assets --reset-cache`
- confirmed the rebuilt release bundle no longer contains `__geolocationDevToolsEnabled`, `__geolocationDevtools`, `isDevtoolsEnabled`, `getDevtoolsCurrentPosition`, `devtoolsWatchPosition`, or the devtools error string