### PR TITLE
docs: fix repository links

### DIFF
--- a/.changeset/docs-repo-links.md
+++ b/.changeset/docs-repo-links.md
@@ -1,0 +1,5 @@
+---
+"@react-native-nitro-geolocation/rozenite-plugin": patch
+---
+
+Fix repository links in the DevTools plugin documentation.

--- a/docs/docs/guide/devtools.md
+++ b/docs/docs/guide/devtools.md
@@ -224,5 +224,5 @@ The plugin integrates seamlessly with both Modern and Legacy APIs. No code chang
 ## Source Code
 
 View the full source code on GitHub:
-- [Plugin Repository](https://github.com/mrousavy/react-native-nitro-geolocation/tree/main/packages/rozenite-devtools-plugin)
-- [Report Issues](https://github.com/mrousavy/react-native-nitro-geolocation/issues)
+- [Plugin Repository](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/packages/rozenite-devtools-plugin)
+- [Report Issues](https://github.com/jingjing2222/react-native-nitro-geolocation/issues)

--- a/packages/rozenite-devtools-plugin/README.md
+++ b/packages/rozenite-devtools-plugin/README.md
@@ -1,6 +1,6 @@
 # @react-native-nitro-geolocation/rozenite-plugin
 
-Rozenite DevTools Plugin for [react-native-nitro-geolocation](https://github.com/mrousavy/react-native-nitro-geolocation). Mock geolocation data in development with an interactive map interface.
+Rozenite DevTools Plugin for [react-native-nitro-geolocation](https://github.com/jingjing2222/react-native-nitro-geolocation). Mock geolocation data in development with an interactive map interface.
 
 > **⚠️ Prerequisites**: This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) to configure DevTools before using this plugin.
 


### PR DESCRIPTION
## Summary

- Updates DevTools documentation links from the old `mrousavy/react-native-nitro-geolocation` repository to `jingjing2222/react-native-nitro-geolocation`.
- Keeps the generated Nitro upstream comments untouched.
