### PR TITLE
feat: guard geolocation devtools with __DEV__

### DIFF
--- a/.changeset/devtools-dev-gate.md
+++ b/.changeset/devtools-dev-gate.md
@@ -1,0 +1,6 @@
+---
+"@react-native-nitro-geolocation/rozenite-plugin": patch
+"react-native-nitro-geolocation": patch
+---
+
+Guard geolocation devtools activation behind React Native `__DEV__`.

--- a/packages/react-native-nitro-geolocation/src/devtools/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/index.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isDevtoolsEnabled } from "./index";
+
+const globalState = globalThis as typeof globalThis & {
+  __DEV__?: boolean;
+  __geolocationDevToolsEnabled?: boolean;
+};
+
+const originalState = {
+  hasDev: Object.prototype.hasOwnProperty.call(globalState, "__DEV__"),
+  dev: globalState.__DEV__,
+  hasDevtoolsEnabled: Object.prototype.hasOwnProperty.call(
+    globalState,
+    "__geolocationDevToolsEnabled"
+  ),
+  devtoolsEnabled: globalState.__geolocationDevToolsEnabled
+};
+
+describe("isDevtoolsEnabled", () => {
+  afterEach(() => {
+    if (originalState.hasDev) {
+      globalState.__DEV__ = originalState.dev;
+    } else {
+      globalState.__DEV__ = undefined;
+    }
+
+    if (originalState.hasDevtoolsEnabled) {
+      globalState.__geolocationDevToolsEnabled = originalState.devtoolsEnabled;
+    } else {
+      globalState.__geolocationDevToolsEnabled = undefined;
+    }
+  });
+
+  it("enables devtools only when React Native __DEV__ and the devtools flag are true", () => {
+    globalState.__DEV__ = true;
+    globalState.__geolocationDevToolsEnabled = true;
+
+    expect(isDevtoolsEnabled()).toBe(true);
+  });
+
+  it("ignores the devtools flag outside React Native __DEV__", () => {
+    globalState.__DEV__ = false;
+    globalState.__geolocationDevToolsEnabled = true;
+
+    expect(isDevtoolsEnabled()).toBe(false);
+  });
+
+  it("stays disabled when __DEV__ is unavailable", () => {
+    globalState.__DEV__ = undefined;
+    globalState.__geolocationDevToolsEnabled = true;
+
+    expect(isDevtoolsEnabled()).toBe(false);
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/devtools/index.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/index.ts
@@ -1,5 +1,7 @@
 import type { GeolocationResponse } from "../types";
 
+declare const __DEV__: boolean;
+
 declare global {
   var __geolocationDevToolsEnabled: boolean | undefined;
   var __geolocationDevtools: DevtoolsState | undefined;
@@ -18,6 +20,10 @@ export function getDevtoolsState(): DevtoolsState {
   return globalThis.__geolocationDevtools;
 }
 
+function isReactNativeDev(): boolean {
+  return typeof __DEV__ !== "undefined" && __DEV__ === true;
+}
+
 export function isDevtoolsEnabled(): boolean {
-  return globalThis.__geolocationDevToolsEnabled === true;
+  return isReactNativeDev() && globalThis.__geolocationDevToolsEnabled === true;
 }

--- a/packages/rozenite-devtools-plugin/react-native.ts
+++ b/packages/rozenite-devtools-plugin/react-native.ts
@@ -2,6 +2,8 @@ export let useGeolocationDevTools: typeof import(
   "./src/react-native/useGeolocationDevTools"
 ).useGeolocationDevTools;
 
+declare const __DEV__: boolean;
+
 export {
   LOCATION_PRESETS,
   createPosition,
@@ -11,12 +13,12 @@ export {
 
 export type { Position, GeolocationCoordinates } from "./src/shared/types";
 
+const isReactNativeDev = typeof __DEV__ !== "undefined" && __DEV__ === true;
 const isWeb =
   typeof window !== "undefined" && window.navigator.product !== "ReactNative";
-const isDev = process.env.NODE_ENV !== "production";
 const isServer = typeof window === "undefined";
 
-if (isDev && !isWeb && !isServer) {
+if (isReactNativeDev && !isWeb && !isServer) {
   useGeolocationDevTools =
     require("./src/react-native/useGeolocationDevTools").useGeolocationDevTools;
 } else {

--- a/packages/rozenite-devtools-plugin/src/react-native/hooks/useSetDevToolsEnabled.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/hooks/useSetDevToolsEnabled.ts
@@ -1,7 +1,13 @@
 import { useEffect } from "react";
 
+declare const __DEV__: boolean;
+
 export const useSetDevToolsEnabled = () => {
   useEffect(() => {
+    if (typeof __DEV__ === "undefined" || __DEV__ !== true) {
+      return;
+    }
+
     globalThis.__geolocationDevToolsEnabled = true;
   }, []);
 };

--- a/packages/rozenite-devtools-plugin/src/react-native/useGeolocationDevTools.ts
+++ b/packages/rozenite-devtools-plugin/src/react-native/useGeolocationDevTools.ts
@@ -4,6 +4,8 @@ import { useDevtoolsRN } from "./hooks/useDevtoolsRN";
 import { useInitialPosition } from "./hooks/useInitialPosition";
 import { useSetDevToolsEnabled } from "./hooks/useSetDevToolsEnabled";
 
+declare const __DEV__: boolean;
+
 declare global {
   var __geolocationDevtools:
     | {
@@ -18,9 +20,16 @@ interface UseGeolocationDevToolsOptions {
   initialPosition?: Position;
 }
 
+const isReactNativeDev = () =>
+  typeof __DEV__ !== "undefined" && __DEV__ === true;
+
 export const useGeolocationDevTools = (
   options?: UseGeolocationDevToolsOptions
 ) => {
+  if (!isReactNativeDev()) {
+    return;
+  }
+
   const client = useRozeniteDevToolsClient<DevtoolsRNEvents>({
     pluginId: "@react-native-nitro-geolocation/rozenite-plugin"
   });


### PR DESCRIPTION
## Summary

- Guard the Rozenite React Native entry point with React Native `__DEV__` instead of `NODE_ENV`.
- Make `useGeolocationDevTools` and the enabled flag effect no-op outside `__DEV__`.
- Require `__DEV__` in `isDevtoolsEnabled()` so a stale/global flag cannot route geolocation APIs through devtools in production.
- Add a unit test for the devtools enabled gate and a patch changeset for both affected packages.
