### PR TITLE
fix: avoid blocking provider status lookup

### DIFF
--- a/.changeset/nonblocking-location-settings.md
+++ b/.changeset/nonblocking-location-settings.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Avoid blocking the UI thread when Android resolves provider status after a successful location settings request by checking Google Location Accuracy asynchronously.

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationSettings.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationSettings.kt
@@ -8,6 +8,8 @@ import android.content.IntentSender
 import android.content.pm.PackageManager
 import android.location.LocationManager as AndroidLocationManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.BaseActivityEventListener
 import com.facebook.react.bridge.ReactApplicationContext
@@ -18,11 +20,10 @@ import com.google.android.gms.location.LocationRequest as GmsLocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.Priority
-import com.google.android.gms.tasks.Tasks
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 private const val LOCATION_SETTINGS_REQUEST_CODE = 8948
-private const val GOOGLE_LOCATION_ACCURACY_TIMEOUT_SECONDS = 2L
+private const val GOOGLE_LOCATION_ACCURACY_TIMEOUT_MS = 2_000L
 
 internal class AndroidLocationSettings(
     private val reactContext: ReactApplicationContext,
@@ -81,6 +82,7 @@ internal class AndroidLocationSettings(
     )
 
     private var pendingLocationSettingsRequest: PendingLocationSettingsRequest? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     private val activityEventListener = object : BaseActivityEventListener() {
         override fun onActivityResult(
@@ -119,14 +121,22 @@ internal class AndroidLocationSettings(
         }
     }
 
-    fun getProviderStatus(): LocationProviderStatus {
+    fun getProviderStatus(success: (LocationProviderStatus) -> Unit) {
+        getGoogleLocationAccuracyEnabled { googleLocationAccuracyEnabled ->
+            success(createProviderStatus(googleLocationAccuracyEnabled))
+        }
+    }
+
+    private fun createProviderStatus(
+        googleLocationAccuracyEnabled: Boolean?
+    ): LocationProviderStatus {
         return LocationProviderStatus(
             locationServicesEnabled = hasServicesEnabled(),
             backgroundModeEnabled = hasBackgroundLocationPermission(),
             gpsAvailable = isProviderEnabled(AndroidLocationManager.GPS_PROVIDER),
             networkAvailable = isProviderEnabled(AndroidLocationManager.NETWORK_PROVIDER),
             passiveAvailable = isProviderEnabled(AndroidLocationManager.PASSIVE_PROVIDER),
-            googleLocationAccuracyEnabled = getGoogleLocationAccuracyEnabled()
+            googleLocationAccuracyEnabled = googleLocationAccuracyEnabled
         )
     }
 
@@ -165,7 +175,7 @@ internal class AndroidLocationSettings(
         settingsClient
             .checkLocationSettings(buildLocationSettingsRequest(pendingRequest.options))
             .addOnSuccessListener {
-                pendingRequest.success(getProviderStatus())
+                getProviderStatus(pendingRequest.success)
             }
             .addOnFailureListener { exception ->
                 if (shouldShowResolution && exception is ResolvableApiException) {
@@ -246,19 +256,43 @@ internal class AndroidLocationSettings(
         ) == PackageManager.PERMISSION_GRANTED
     }
 
-    private fun getGoogleLocationAccuracyEnabled(): Boolean? {
-        if (!isGooglePlayServicesAvailable()) return null
+    private fun getGoogleLocationAccuracyEnabled(success: (Boolean?) -> Unit) {
+        if (!isGooglePlayServicesAvailable()) {
+            success(null)
+            return
+        }
 
-        return try {
-            Tasks.await(
-                LocationServices
-                    .getSettingsClient(reactContext)
-                    .isGoogleLocationAccuracyEnabled,
-                GOOGLE_LOCATION_ACCURACY_TIMEOUT_SECONDS,
-                TimeUnit.SECONDS
-            )
+        val didComplete = AtomicBoolean(false)
+        val timeoutRunnable = Runnable {
+            if (didComplete.compareAndSet(false, true)) {
+                success(null)
+            }
+        }
+
+        fun complete(value: Boolean?) {
+            if (didComplete.compareAndSet(false, true)) {
+                mainHandler.removeCallbacks(timeoutRunnable)
+                success(value)
+            }
+        }
+
+        mainHandler.postDelayed(timeoutRunnable, GOOGLE_LOCATION_ACCURACY_TIMEOUT_MS)
+
+        try {
+            LocationServices
+                .getSettingsClient(reactContext)
+                .isGoogleLocationAccuracyEnabled
+                .addOnSuccessListener { enabled ->
+                    complete(enabled)
+                }
+                .addOnFailureListener {
+                    complete(null)
+                }
+                .addOnCanceledListener {
+                    complete(null)
+                }
         } catch (e: Exception) {
-            null
+            complete(null)
         }
     }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -195,9 +195,11 @@ class NitroGeolocation(
     }
 
     override fun getProviderStatus(): Promise<LocationProviderStatus> {
-        return Promise.async {
-            locationSettings.getProviderStatus()
+        val promise = Promise<LocationProviderStatus>()
+        locationSettings.getProviderStatus { status ->
+            promise.resolve(status)
         }
+        return promise
     }
 
     override fun requestLocationSettings(


### PR DESCRIPTION
## Summary
- Avoid blocking `Tasks.await` while resolving Android provider status after location settings checks.
- Keep the public `getProviderStatus()` Promise contract while fetching Google Location Accuracy through Play Services listeners.
- Add a minor Changeset for the Android behavior improvement.

## Changes
- Converted Google Location Accuracy lookup to non-blocking Play Services task callbacks with a timeout fallback.
- Resolves `requestLocationSettings()` success only after the async provider status snapshot is ready.
- Updated `NitroGeolocation.getProviderStatus()` to resolve a manual Nitro Promise from the async status callback.

## SSoT / Cleanup
- Checked adjacent provider/settings API references, types, and docs for stale duplicated behavior.
- No docs changes were needed because the public Promise API and documented status fields remain unchanged.

## Changeset
- Added a minor Changeset for `react-native-nitro-geolocation`.

## Verification
- `yarn workspace react-native-nitro-geolocation typecheck`
- `yarn workspace react-native-nitro-geolocation test`
- `./gradlew :react-native-nitro-geolocation:compileDebugKotlin --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a`
