### PR TITLE
chore: document release validation guidance

### DIFF
--- a/.changeset/release-validation-docs.md
+++ b/.changeset/release-validation-docs.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Align release validation documentation with the v1.2 native geolocation flows and use a deterministic geocoding fixture in examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ For documentation-only changes, you can skip this section.
 Run the following command in the example app:
 ```bash
 cd examples/v0.81.1
+yarn ios:release  # or yarn android:release
 yarn test:e2e:ios  # or yarn test:e2e:android
 ```
 -->

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const cached = await getLastKnownPosition({
 });
 
 // v1.2+: convert between addresses and coordinates with native geocoders
-const locations = await geocode("Seoul City Hall");
+const locations = await geocode("City Hall, Seoul, South Korea");
 const addresses = await reverseGeocode({
   latitude: 37.5665,
   longitude: 126.978,

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -35,7 +35,7 @@ const position = await getCurrentPosition({
 });
 
 // Convert between addresses and coordinates
-const locations = await geocode('Seoul City Hall');
+const locations = await geocode('City Hall, Seoul, South Korea');
 const addresses = await reverseGeocode({
   latitude: 37.5665,
   longitude: 126.978

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -427,7 +427,7 @@ import {
   reverseGeocode
 } from 'react-native-nitro-geolocation';
 
-const locations = await geocode('Seoul City Hall');
+const locations = await geocode('City Hall, Seoul, South Korea');
 // locations: Array<{ latitude: number; longitude: number; accuracy?: number }>
 
 const addresses = await reverseGeocode({

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -178,7 +178,7 @@ import {
   reverseGeocode
 } from 'react-native-nitro-geolocation';
 
-const locations = await geocode('Seoul City Hall');
+const locations = await geocode('City Hall, Seoul, South Korea');
 const firstLocation = locations[0];
 
 const addresses = await reverseGeocode({

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -58,7 +58,24 @@ yarn test:e2e:android
 yarn test:e2e:ios
 ```
 
-The Android and iOS package scripts install the Release build first (`yarn android:release` or `yarn ios:release`), then run `.maestro/all-tests.yaml` with the matching Maestro platform flag. Android-only flows are selected inside the master flow with `when.platform`.
+Build and install the Release app before running Maestro when validating a
+release candidate:
+
+```bash
+# iOS release candidate
+yarn ios:release
+yarn test:e2e:ios
+
+# Android release candidate
+yarn android:release
+yarn test:e2e:android
+```
+
+`test:e2e:ios` runs `.maestro/all-tests.yaml` with the iOS platform flag.
+`test:e2e:android` runs the same master flow with the Android platform flag,
+then runs `provider-settings-not-ready.yaml` after disabling Android location
+services and restores the device state afterward. Platform-only flows are
+selected inside the master flow with `when.platform`.
 
 ## Test Files
 
@@ -80,6 +97,12 @@ The Android and iOS package scripts install the Release build first (`yarn andro
 ### `location-simulation.yaml`
 - Tests behavior at different locations
 - Simulates locations: San Francisco, New York, Seoul
+
+### `geocoding.yaml`
+- Tests `geocode(address)` and `reverseGeocode(coords)` through native platform geocoders
+- Uses a specific Seoul address query and validates the returned coordinate candidate is near the Seoul fixture
+- Reverse geocodes deterministic Seoul fixture coordinates and verifies a readable address is returned
+- Verifies invalid inputs reject through the Modern API structured `INTERNAL_ERROR` contract
 
 ### `accuracy-presets.yaml`
 - Tests `accuracy.android` and `accuracy.ios` through real Modern API native requests
@@ -224,7 +247,7 @@ London: 51.5074, -0.1278
 1. Run tests locally:
    ```bash
    cd examples/v0.81.1
-   yarn ios  # or yarn android
+   yarn ios:release  # or yarn android:release
    yarn test:e2e:ios  # or yarn test:e2e:android
    ```
 
@@ -242,37 +265,30 @@ London: 51.5074, -0.1278
 ✅ Run current-position.yaml
 ✅ Run watch-position.yaml
 ✅ Run location-simulation.yaml
+✅ Run accuracy-presets.yaml
+✅ Run last-known-position.yaml
+✅ Run geocoding.yaml
+✅ Run location-availability.yaml
+✅ Run heading.yaml
 ✅ Run issue-67-android-coarse-location.yaml
+✅ Run android-request-options.yaml
+✅ Run provider-settings.yaml
 ✅ Run mocked-metadata-android-true.yaml
-✅ Run mocked-metadata-ios-true.yaml
+✅ Run api-errors.yaml
+✅ Run compat-api.yaml
+✅ Run provider-settings-not-ready.yaml
 
 **Platform tested:**
 - [x] Android 16
 ```
 
-For iOS results, omit Android-only flows from the list.
+For iOS results, include the iOS-only flows and omit Android-only flows.
 
-### Automated CI (Main Branch Only)
+### Automated CI
 
-A GitHub Actions workflow runs E2E tests automatically on the `main` branch.
-
-- **Manual trigger**: Actions → E2E Tests → Run workflow
-- **Automatic**: Runs on push to `main` branch
-- **Not for PRs**: To save time and costs
-
-### Quick CI Setup
-
-The workflow file is at `.github/workflows/e2e-tests.yml`.
-
-To enable CI tests on PRs (not recommended due to cost):
-
-```yaml
-on:
-  push:
-    branches: [main]
-  pull_request:  # Add this
-    branches: [main]
-```
+There is no checked-in GitHub Actions workflow for Maestro E2E tests at the
+moment. Run E2E locally on the target simulator/device and paste the release
+build results into the PR.
 
 ## Writing Tests - Best Practices
 

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -79,7 +79,7 @@ const cached = await getLastKnownPosition({
 });
 
 // v1.2+: convert between addresses and coordinates with native geocoders
-const locations = await geocode("Seoul City Hall");
+const locations = await geocode("City Hall, Seoul, South Korea");
 const addresses = await reverseGeocode({
   latitude: 37.5665,
   longitude: 126.978,


### PR DESCRIPTION
## Summary
- Keep the root README and package README in sync while switching the geocoding example to a deterministic Seoul query.
- Clarify that release-candidate E2E validation should install a Release build before running Maestro.
- Document the expanded v1.2 Maestro coverage and add a patch changeset for the package README/docs update.

## Validation
- `yarn format:check && yarn lint`
- `yarn workspace react-native-nitro-geolocation typecheck`
- `yarn workspace react-native-nitro-geolocation-example typecheck`
- `yarn workspace react-native-nitro-geolocation test`
- `yarn workspace docs typecheck`
- `yarn workspace docs build`
- `diff -u README.md packages/react-native-nitro-geolocation/README.md`
- iOS Release build/install: `yarn workspace react-native-nitro-geolocation-example ios:release --simulator "iPhone 17 Pro"`
- iOS Release E2E: `maestro test --platform ios --udid 8AA89091-DA19-4C6B-BF23-2E0FC0B55A9F .maestro/all-tests.yaml`
- Android Release build/install: `yarn workspace react-native-nitro-geolocation-example android:release --deviceId emulator-5554`
- Android Release E2E: `yarn workspace react-native-nitro-geolocation-example test:e2e:android`