### PR TITLE
chore: clarify Android provider auto default

### DIFF
--- a/.changeset/android-provider-default-docs.md
+++ b/.changeset/android-provider-default-docs.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Clarify that Android `locationProvider: "auto"` currently uses the platform `LocationManager` by default, while `playServices` explicitly opts into Google Play Services fused location.

--- a/docs/docs/guide/compat-api.md
+++ b/docs/docs/guide/compat-api.md
@@ -53,7 +53,7 @@ Supported options:
 - `skipPermissionRequests` (boolean) - Defaults to `false`. If `true`, you must request permissions before using Geolocation APIs.
 - `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
 - `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggle wether to automatically enableBackgroundLocationUpdates. Defaults to true.
-- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`.  Determines wether to use `Google’s Location Services API` or `Android’s Location API`. The `"auto"` mode defaults to `android`, and falls back to Android's Location API if play services aren't available.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Determines whether to use Google Play Services location APIs or Android's platform `LocationManager`. The `"auto"` mode currently defaults to Android's platform provider; set `"playServices"` explicitly to use Google Play Services when available.
 
 ### `requestAuthorization()`
 

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -45,7 +45,7 @@ setConfiguration({
 - `autoRequestPermission?: boolean` - Deprecated compatibility option. `setConfiguration()` does not request permission; call `requestPermission()` explicitly when the app is ready to show the native prompt.
 - `authorizationLevel?: 'whenInUse' | 'always' | 'auto'` - iOS: Authorization level
 - `enableBackgroundLocationUpdates?: boolean` - iOS: Enable background location
-- `locationProvider?: 'playServices' | 'android' | 'auto'` - Android: Location provider
+- `locationProvider?: 'playServices' | 'android' | 'auto'` - Android: Location provider. `auto` currently uses Android's platform `LocationManager`; set `playServices` explicitly to use Google Play Services fused location.
 
 **Type**:
 
@@ -55,6 +55,7 @@ export type GeolocationConfiguration = {
   autoRequestPermission?: boolean;
   authorizationLevel?: 'always' | 'whenInUse' | 'auto';
   enableBackgroundLocationUpdates?: boolean;
+  /** `auto` currently uses Android's platform LocationManager. */
   locationProvider?: 'playServices' | 'android' | 'auto';
 };
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -747,6 +747,8 @@ class NitroGeolocation(
     // MARK: - Helper Functions - Provider Selection
 
     private fun requiresPlayServices(): Boolean {
+        // TODO: Switch auto/default Android provider selection to prefer
+        // Google Play Services when available.
         return configuration?.locationProvider == LocationProvider.PLAYSERVICES
     }
 

--- a/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
@@ -67,7 +67,7 @@ export interface GeolocationConfiguration {
    * Android: Location provider
    * - 'playServices': Use Google Play Services (fused location)
    * - 'android_platform': Use Android platform LocationManager
-   * - 'auto': Auto-select (prefer Play Services if available)
+   * - 'auto': Use Android platform LocationManager by default
    */
   locationProvider?: LocationProvider;
 }

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -79,6 +79,12 @@ export type GeolocationConfiguration = Omit<
    */
   autoRequestPermission?: boolean;
 
+  /**
+   * Android location provider.
+   *
+   * `auto` currently uses Android's platform `LocationManager` by default.
+   * Set `playServices` explicitly to use Google Play Services fused location.
+   */
   locationProvider?: LocationProvider;
 };
 
@@ -92,5 +98,11 @@ export type CompatGeolocationConfiguration = Omit<
   CompatGeolocationConfigurationInternal,
   "locationProvider"
 > & {
+  /**
+   * Android location provider.
+   *
+   * `auto` currently uses Android's platform `LocationManager` by default.
+   * Set `playServices` explicitly to use Google Play Services fused location.
+   */
   locationProvider?: LocationProvider;
 };


### PR DESCRIPTION
## Summary
- Clarify that Android `locationProvider: "auto"` currently uses the platform `LocationManager` by default.
- Document that `locationProvider: "playServices"` is the explicit opt-in for Google Play Services fused location.
- Add a native TODO for switching auto/default Android provider selection to prefer Google Play Services later.
- Add a patch changeset for the documentation correction.

## Validation
- `yarn format:check && yarn lint`
- `yarn workspace react-native-nitro-geolocation typecheck`
- `yarn workspace docs typecheck`
- `yarn workspace docs build`