### PR TITLE
chore: add Modern API migration skill

### DIFF
--- a/.changeset/modern-api-migration-skill.md
+++ b/.changeset/modern-api-migration-skill.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Add an Agent Skills-compatible Modern API migration playbook with a package-manager-aware compat bootstrap script for migrations from legacy geolocation APIs.

--- a/README.md
+++ b/README.md
@@ -291,7 +291,29 @@ Geolocation.clearWatch(watchId);
 
 ## 🔄 Migration from `@react-native-community/geolocation`
 
-Change the import to use `/compat` — 100% API compatible:
+For Modern API migration, install the Agent Skills-compatible migration
+playbook from this repository. It is migration assistance for coding agents, not
+a fully automatic migration. The skill first runs a package-manager-aware
+compat bootstrap script that installs the Nitro packages, rewrites legacy import
+sources to `/compat`, and removes `@react-native-community/geolocation`. After
+that safe mechanical step, it guides the agent to refactor compat call sites to
+Modern API best practices using explicit criteria for permission timing, React
+lifecycle ownership, watch cleanup, cache-vs-fresh location reads, accuracy, and
+Android provider/settings handling.
+
+With the Vercel Labs `skills` CLI:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill react-native-nitro-geolocation-modern-migration
+```
+
+The skill source is
+[`skills/react-native-nitro-geolocation-modern-migration/SKILL.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/react-native-nitro-geolocation-modern-migration).
+The bundled bootstrap script is
+[`skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs).
+
+For a drop-in compatibility migration, change the import to use `/compat`:
+
 ```diff
 - import Geolocation from '@react-native-community/geolocation';
 + import Geolocation from 'react-native-nitro-geolocation/compat';

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -807,6 +807,29 @@ const status = await requestPermission();
 
 ## Migration from Compat
 
+### Modern API Migration Assistance
+
+This repository publishes an Agent Skills-compatible migration playbook for
+coding agents:
+[`react-native-nitro-geolocation-modern-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/react-native-nitro-geolocation-modern-migration).
+
+It is not a fully automatic migration. The skill first runs a
+package-manager-aware compat bootstrap script that installs the Nitro packages,
+rewrites `@react-native-community/geolocation` import sources to `/compat`, and
+removes the legacy package. After that safe mechanical step, it guides an agent
+to inspect `navigator.geolocation` and `/compat` usage; convert callback APIs
+to Promises; replace `requestAuthorization` with `requestPermission`; replace
+`setRNConfiguration` with `setConfiguration`; and choose `useWatchPosition` or
+the low-level `watchPosition`/`unwatch` APIs based on explicit criteria for
+permission timing, React lifecycle ownership, cache-vs-fresh reads, accuracy,
+and Android provider/settings handling.
+
+Install it with the Vercel Labs `skills` CLI:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill react-native-nitro-geolocation-modern-migration
+```
+
 **Before (Compat API)**:
 
 ```tsx

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -291,7 +291,29 @@ Geolocation.clearWatch(watchId);
 
 ## 🔄 Migration from `@react-native-community/geolocation`
 
-Change the import to use `/compat` — 100% API compatible:
+For Modern API migration, install the Agent Skills-compatible migration
+playbook from this repository. It is migration assistance for coding agents, not
+a fully automatic migration. The skill first runs a package-manager-aware
+compat bootstrap script that installs the Nitro packages, rewrites legacy import
+sources to `/compat`, and removes `@react-native-community/geolocation`. After
+that safe mechanical step, it guides the agent to refactor compat call sites to
+Modern API best practices using explicit criteria for permission timing, React
+lifecycle ownership, watch cleanup, cache-vs-fresh location reads, accuracy, and
+Android provider/settings handling.
+
+With the Vercel Labs `skills` CLI:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill react-native-nitro-geolocation-modern-migration
+```
+
+The skill source is
+[`skills/react-native-nitro-geolocation-modern-migration/SKILL.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/react-native-nitro-geolocation-modern-migration).
+The bundled bootstrap script is
+[`skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs).
+
+For a drop-in compatibility migration, change the import to use `/compat`:
+
 ```diff
 - import Geolocation from '@react-native-community/geolocation';
 + import Geolocation from 'react-native-nitro-geolocation/compat';

--- a/skills/react-native-nitro-geolocation-modern-migration/SKILL.md
+++ b/skills/react-native-nitro-geolocation-modern-migration/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: react-native-nitro-geolocation-modern-migration
+description: Migrate React Native apps from @react-native-community/geolocation, navigator.geolocation, or react-native-nitro-geolocation/compat to react-native-nitro-geolocation. Use when installing the Nitro packages, running the bundled compat bootstrap codemod, removing the legacy package, then refactoring callback-based compat usage to the Modern API with Promise functions, requestPermission, setConfiguration, useWatchPosition, watchPosition, and unwatch.
+---
+
+# React Native Nitro Geolocation Modern Migration
+
+Use a two-phase migration:
+
+1. Bootstrap safely to `/compat` so the app stops depending on
+   `@react-native-community/geolocation`.
+2. Refactor from `/compat` to the Modern API best-practice shape.
+
+Do not start by hand-converting every callback call site. First make the
+mechanical package/import migration small and reversible, verify it, then do
+the semantic Modern API refactor.
+
+## Workflow
+
+1. Inspect the target app root and check the worktree state.
+2. Resolve `scripts/migrate-to-compat.mjs` relative to this `SKILL.md`.
+3. Run a dry run from the target app root:
+   ```bash
+   node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root> --dry-run
+   ```
+4. If the dry run is expected, run it for real:
+   ```bash
+   node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
+   ```
+   The script detects `packageManager` or lockfiles, installs missing
+   `react-native-nitro-modules` and `react-native-nitro-geolocation`, rewrites
+   `@react-native-community/geolocation` import sources to
+   `react-native-nitro-geolocation/compat`, removes
+   `@react-native-community/geolocation`, and prints package-manager-specific
+   validation commands that exist in the app's `package.json`.
+5. Run the printed validation commands. Do not hardcode `yarn`, `npm`, `pnpm`,
+   or `bun`; use the detected package manager and only scripts that exist.
+6. Refresh the public docs context when network is available:
+   ```bash
+   curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms.txt
+   curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms-full.txt
+   ```
+   Read `llms.txt` first as the docs index. Use `llms-full.txt` only when you
+   need exact API names, option semantics, or examples for the Modern API,
+   Compat API, quick start, or platform setup. If the app already pins an older
+   `react-native-nitro-geolocation` version, confirm an API exists in
+   `node_modules/react-native-nitro-geolocation` or the installed package types
+   before using docs-only APIs.
+7. Find remaining geolocation usage:
+   ```bash
+   rg "@react-native-community/geolocation|navigator\\.geolocation|react-native-nitro-geolocation/compat|setRNConfiguration|requestAuthorization|watchPosition|clearWatch|stopObserving"
+   ```
+8. Inspect each call site before refactoring. Identify whether it is in a React
+   function component, class component, hook, service module, background task, or
+   test.
+9. Replace compat imports with named Modern API imports from
+   `react-native-nitro-geolocation`. Remove `Geolocation` default-object usage
+   when the migrated file no longer needs it.
+10. Convert one-shot and permission APIs to `async`/`await` or explicit Promise
+   chains. Preserve existing loading, state, and error behavior.
+11. Migrate watches to `useWatchPosition` only where React hook rules allow it.
+   Use `watchPosition` plus `unwatch` for non-component code, class components,
+   callbacks, conditionals, and services.
+12. Flag unsupported or semantic changes in comments or the final report instead
+    of guessing.
+13. Run the target app's relevant detected validation commands again. If
+    validating an actual migrated app flow on device, use `agent-device` when
+    available.
+
+## Docs Reference
+
+Use these docs endpoints as the source of truth during the Modern refactor:
+
+- `https://react-native-nitro-geolocation.pages.dev/llms.txt` - concise index
+  of available docs pages.
+- `https://react-native-nitro-geolocation.pages.dev/llms-full.txt` - complete
+  rendered docs content for agent consumption.
+
+Prefer `llms.txt` for navigation and `llms-full.txt` for exact API details. Do
+not paste or load the full docs into the final answer; use them to check facts
+before editing. If network is unavailable, fall back to local package docs,
+README files, and TypeScript declarations in the installed package.
+
+## Best Practice Target
+
+The final migration is not just "no type errors." Prefer this target state:
+
+- No app runtime imports from `@react-native-community/geolocation`,
+  `navigator.geolocation`, or `react-native-nitro-geolocation/compat`. Keep
+  `/compat` only in deliberate compatibility examples, tests, or migration
+  fallback code the user explicitly wants to preserve.
+- Configure once near app startup with `setConfiguration()`. Do not leave
+  `setRNConfiguration()` or `skipPermissionRequests` in migrated runtime code.
+- Use explicit permission flow. Use `checkPermission()` only to read status
+  without prompting; call `requestPermission()` from a user-understandable app
+  moment before location work needs permission.
+- Use Promise APIs for one-shot work. Prefer `getCurrentPosition()` when the
+  app needs a fresh position, and `getLastKnownPosition()` only for cache-first
+  UI where stale data is acceptable.
+- Use lifecycle-safe watches. In function components or custom hooks, prefer
+  `useWatchPosition({ enabled })`; outside hook-safe code, use
+  `watchPosition()` with scoped `unwatch(token)` cleanup.
+- Use explicit `accuracy` presets instead of `enableHighAccuracy`. Preserve
+  existing timeout, distance, interval, and cache semantics unless the old code
+  was clearly relying on deprecated defaults.
+- Keep permission, provider/settings, and watch cleanup behavior visible in the
+  code. Do not hide prompts or global cleanup in utility functions unless that
+  is already the app's architecture.
+- Use typed Modern errors where handling is specific. Match on
+  `LocationErrorCode` for permission denied, timeout, settings-not-satisfied,
+  or provider/setup failures instead of parsing error messages.
+
+## Selection Criteria
+
+Apply these criteria at each call site, in this order:
+
+1. Preserve user-visible behavior first: same trigger, same loading state, same
+   success/error UI, same cleanup timing.
+2. Respect React rules: never introduce hooks in classes, callbacks,
+   conditionals, loops, services, or non-React modules.
+3. Prefer the narrowest lifecycle: hook-managed watch for component state,
+   token-managed watch for services, one-shot Promise for button/request flows.
+4. Prefer explicit user consent: do not convert old implicit permission behavior
+   into an app-start permission prompt.
+5. Prefer battery-aware defaults: only request high accuracy, frequent
+   intervals, background updates, or settings dialogs when the old code or app
+   feature justifies it.
+6. Prefer type-safe Modern API names at module boundaries: avoid passing a
+   `Geolocation` object through app code after refactoring.
+
+Use this API choice table:
+
+| Legacy pattern | Modern target | Choose it when | Avoid it when |
+| --- | --- | --- | --- |
+| `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` | A user action or flow needs a fresh position. | The UI can start from cached location only; consider `getLastKnownPosition()`. |
+| Cached/stale startup read via `maximumAge` | `await getLastKnownPosition(options)` | Startup UI, stale-while-refresh, or cache-only flows can tolerate no fresh request. | The feature needs a fresh fix or should prompt provider/settings resolution. |
+| `requestAuthorization(success, error)` | `await requestPermission()` | The app is ready to show the native permission prompt. | You only need to display current status; use `checkPermission()`. |
+| `setRNConfiguration(config)` | `setConfiguration(config)` | App startup or native bootstrap code sets global location config once. | A screen-level call would repeatedly mutate global config. |
+| `watchPosition` in a function component | `useWatchPosition({ enabled, ...options })` | Position drives React render state and the call can be at hook-safe top level. | The code is a class component, event callback, conditional branch, or service. |
+| `watchPosition` in services/classes/tasks | `watchPosition(...)` + `unwatch(token)` | A non-React lifecycle owns the subscription. | A React function component can express the lifecycle with `enabled`. |
+| `clearWatch(id)` | `unwatch(token)` | Stopping one known Modern watch. | The old code intentionally stopped every watcher; review `stopObserving()`. |
+| `enableHighAccuracy: true` | `accuracy: { android: "high", ios: "best" }` | The feature needs precise location. | Low-power or approximate location is enough. |
+| Android precise flow that can fail due to settings | `getLocationAvailability()` / `requestLocationSettings()` before location request | The UX can ask users to enable provider/settings for navigation or precise location. | Passive/background or approximate flows should not interrupt users. |
+
+## Import Patterns
+
+The bootstrap script handles this mechanical source rewrite:
+
+```ts
+import Geolocation from "@react-native-community/geolocation";
+```
+
+to:
+
+```ts
+import Geolocation from "react-native-nitro-geolocation/compat";
+```
+
+After verification, refactor compat imports to named Modern imports:
+
+```ts
+import {
+  getCurrentPosition,
+  requestPermission,
+  setConfiguration,
+  useWatchPosition,
+  watchPosition,
+  unwatch
+} from "react-native-nitro-geolocation";
+```
+
+Import only the symbols each file needs.
+
+`navigator.geolocation` usage is reported by the script but not rewritten. It
+needs manual inspection because it is often a global shim or browser fallback.
+
+## API Mappings
+
+### getCurrentPosition
+
+Before:
+
+```ts
+Geolocation.getCurrentPosition(
+  (position) => setPosition(position),
+  (error) => setError(error),
+  { enableHighAccuracy: true, timeout: 15000 }
+);
+```
+
+After:
+
+```ts
+try {
+  const position = await getCurrentPosition({
+    accuracy: { android: "high", ios: "best" },
+    timeout: 15000
+  });
+  setPosition(position);
+} catch (error) {
+  setError(error);
+}
+```
+
+If the containing function cannot become `async`, keep the Promise chain:
+
+```ts
+getCurrentPosition(options).then(onSuccess).catch(onError);
+```
+
+### requestAuthorization
+
+Replace `requestAuthorization(success?, error?)` with `requestPermission()`.
+Move success callback behavior after a granted result and move error callback
+behavior into `catch`.
+
+```ts
+const status = await requestPermission();
+if (status === "granted") {
+  onGranted();
+}
+```
+
+### setRNConfiguration
+
+Replace `setRNConfiguration` with `setConfiguration` at app startup.
+
+```ts
+setConfiguration({
+  authorizationLevel: "whenInUse",
+  enableBackgroundLocationUpdates: false,
+  locationProvider: "auto"
+});
+```
+
+Do not migrate `skipPermissionRequests`; Modern API has no equivalent because
+permission requests must be explicit through `requestPermission()`.
+
+### watchPosition in React Components
+
+Use `useWatchPosition` in function components or custom hooks only. Preserve
+the old start/stop condition through `enabled`.
+
+Before:
+
+```tsx
+useEffect(() => {
+  const watchId = Geolocation.watchPosition(onPosition, onError, {
+    enableHighAccuracy: true,
+    distanceFilter: 10
+  });
+
+  return () => Geolocation.clearWatch(watchId);
+}, []);
+```
+
+After:
+
+```tsx
+const { position, error, isWatching } = useWatchPosition({
+  enabled: true,
+  accuracy: { android: "high", ios: "best" },
+  distanceFilter: 10
+});
+```
+
+Wire `position`, `error`, and `isWatching` into the component's existing state
+or render path. If callbacks perform side effects, add a separate `useEffect`
+that reacts to `position` or `error`.
+
+### watchPosition Outside Hook-Safe Code
+
+Use the low-level Modern watch API outside function component top level:
+
+```ts
+const token = watchPosition(onPosition, onError, {
+  accuracy: { android: "high", ios: "best" },
+  distanceFilter: 10
+});
+
+unwatch(token);
+```
+
+Replace `clearWatch(watchId)` with `unwatch(token)`. Keep `stopObserving()`
+only when the old code intentionally stopped all geolocation subscriptions;
+otherwise prefer targeted `unwatch(token)`.
+
+## Options
+
+- Replace `enableHighAccuracy: true` with
+  `accuracy: { android: "high", ios: "best" }`.
+- For `enableHighAccuracy: false`, prefer omitting accuracy unless the old code
+  clearly required reduced precision. If reduced precision matters, choose an
+  explicit preset and note the semantic decision.
+- Preserve `timeout`, `maximumAge`, `distanceFilter`, `interval`,
+  `fastestInterval`, and `useSignificantChanges` when present.
+- Prefer Modern platform options such as `granularity`,
+  `waitForAccurateLocation`, `activityType`, and
+  `pausesLocationUpdatesAutomatically` only when the migrated code already has
+  an equivalent requirement.
+
+## Do Not Guess
+
+Flag these for the user instead of silently rewriting:
+
+- Code that relies on `skipPermissionRequests`.
+- Class components where a hook migration would require a component refactor.
+- Watch callbacks with side effects that need ordering guarantees.
+- Global `navigator.geolocation` monkey patches.
+- Tests that assert exact legacy callback timing or watch id types.
+- Permission flows that depend on iOS "always" vs "when in use" copy or timing.
+
+## Verification
+
+Use the target app's detected package manager and existing scripts. The
+bootstrap script prints commands for available `typecheck`, `lint`, and `test`
+scripts, for example `pnpm typecheck`, `npm run lint`, `bun run test`, or
+`yarn test`.
+
+Do not invent missing scripts. If a project has no standard validation scripts,
+run the nearest equivalent documented by that app. For device-sensitive
+behavior, verify at least one permission request, one current-position request,
+and one watch start/stop flow on iOS or Android.

--- a/skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs
+++ b/skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { lstat, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const LEGACY_PACKAGE = "@react-native-community/geolocation";
+const COMPAT_IMPORT = "react-native-nitro-geolocation/compat";
+const REQUIRED_PACKAGES = [
+  "react-native-nitro-modules",
+  "react-native-nitro-geolocation"
+];
+const SOURCE_EXTENSIONS = new Set([
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".tsx"
+]);
+const IGNORED_DIRS = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  ".next",
+  ".expo",
+  ".turbo",
+  ".yarn",
+  "android",
+  "build",
+  "coverage",
+  "dist",
+  "ios",
+  "lib",
+  "node_modules",
+  "Pods"
+]);
+
+function parseArgs(argv) {
+  const options = {
+    root: process.cwd(),
+    dryRun: false,
+    skipInstall: false,
+    skipRemove: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--root") {
+      options.root = argv[index + 1];
+      index += 1;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--skip-install") {
+      options.skipInstall = true;
+    } else if (arg === "--skip-remove") {
+      options.skipRemove = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  options.root = path.resolve(options.root);
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: node migrate-to-compat.mjs [options]
+
+Options:
+  --root <path>      App root to migrate. Defaults to the current directory.
+  --dry-run          Show package commands and file changes without writing.
+  --skip-install     Do not install react-native-nitro packages.
+  --skip-remove      Do not remove @react-native-community/geolocation.
+  -h, --help         Show this help.
+`);
+}
+
+function readPackageJson(root) {
+  const packageJsonPath = path.join(root, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`No package.json found at ${packageJsonPath}`);
+  }
+
+  return {
+    path: packageJsonPath,
+    data: JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  };
+}
+
+function packageManagerFromPackageManagerField(packageJson) {
+  const value = packageJson.packageManager;
+  if (typeof value !== "string") return null;
+
+  const name = value.split("@")[0];
+  return ["bun", "npm", "pnpm", "yarn"].includes(name) ? name : null;
+}
+
+function parentDirectories(start) {
+  const directories = [];
+  let current = start;
+
+  while (true) {
+    directories.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) return directories;
+    current = parent;
+  }
+}
+
+const LOCKFILES = [
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["bun.lockb", "bun"],
+  ["bun.lock", "bun"],
+  ["package-lock.json", "npm"],
+  ["npm-shrinkwrap.json", "npm"]
+];
+
+function packageManagerFromLockfile(directory) {
+  for (const [lockfile, manager] of LOCKFILES) {
+    if (existsSync(path.join(directory, lockfile))) return manager;
+  }
+
+  return null;
+}
+
+function packageManagerFromPackageJsonFile(directory) {
+  const packageJsonPath = path.join(directory, "package.json");
+  if (!existsSync(packageJsonPath)) return null;
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return packageManagerFromPackageManagerField(packageJson);
+}
+
+function detectPackageManager(root, packageJson) {
+  const fromField = packageManagerFromPackageManagerField(packageJson);
+  if (fromField) return fromField;
+
+  const rootLockfile = packageManagerFromLockfile(root);
+  if (rootLockfile) return rootLockfile;
+
+  for (const directory of parentDirectories(path.dirname(root))) {
+    const parentLockfile = packageManagerFromLockfile(directory);
+    if (parentLockfile) return parentLockfile;
+
+    const parentField = packageManagerFromPackageJsonFile(directory);
+    if (parentField) return parentField;
+  }
+
+  return "npm";
+}
+
+function dependencyMap(packageJson) {
+  return {
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+    ...(packageJson.peerDependencies ?? {}),
+    ...(packageJson.optionalDependencies ?? {})
+  };
+}
+
+function commandForInstall(manager, packages) {
+  if (packages.length === 0) return null;
+  if (manager === "npm") return ["npm", ["install", ...packages]];
+  if (manager === "pnpm") return ["pnpm", ["add", ...packages]];
+  if (manager === "bun") return ["bun", ["add", ...packages]];
+  return ["yarn", ["add", ...packages]];
+}
+
+function commandForRemove(manager, packageName) {
+  if (manager === "npm") return ["npm", ["uninstall", packageName]];
+  if (manager === "pnpm") return ["pnpm", ["remove", packageName]];
+  if (manager === "bun") return ["bun", ["remove", packageName]];
+  return ["yarn", ["remove", packageName]];
+}
+
+function commandForScript(manager, scriptName) {
+  if (manager === "npm") return `npm run ${scriptName}`;
+  if (manager === "bun") return `bun run ${scriptName}`;
+  if (manager === "pnpm") return `pnpm ${scriptName}`;
+  return `yarn ${scriptName}`;
+}
+
+function runCommand(command, args, { cwd, dryRun }) {
+  const printable = [command, ...args].join(" ");
+  if (dryRun) {
+    console.log(`[dry-run] ${printable}`);
+    return;
+  }
+
+  console.log(`$ ${printable}`);
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+    shell: process.platform === "win32"
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${printable}`);
+  }
+}
+
+async function collectSourceFiles(root) {
+  const files = [];
+
+  async function walk(directory) {
+    const entries = await readdir(directory);
+    for (const entry of entries) {
+      if (IGNORED_DIRS.has(entry)) continue;
+
+      const fullPath = path.join(directory, entry);
+      const info = await lstat(fullPath);
+      if (info.isSymbolicLink()) continue;
+
+      if (info.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+
+      if (SOURCE_EXTENSIONS.has(path.extname(entry))) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await walk(root);
+  return files;
+}
+
+function migrateImports(files, { dryRun }) {
+  const changedFiles = [];
+  const navigatorHits = [];
+
+  for (const file of files) {
+    const original = readFileSync(file, "utf8");
+    const migrated = original
+      .replaceAll(`"${LEGACY_PACKAGE}"`, `"${COMPAT_IMPORT}"`)
+      .replaceAll(`'${LEGACY_PACKAGE}'`, `'${COMPAT_IMPORT}'`)
+      .replaceAll(`\`${LEGACY_PACKAGE}\``, `\`${COMPAT_IMPORT}\``);
+
+    if (migrated !== original) {
+      changedFiles.push(file);
+      if (!dryRun) {
+        writeFileSync(file, migrated);
+      }
+    }
+
+    if (original.includes("navigator.geolocation")) {
+      navigatorHits.push(file);
+    }
+  }
+
+  return { changedFiles, navigatorHits };
+}
+
+function printNextChecks(manager, packageJson) {
+  const scripts = packageJson.scripts ?? {};
+  const checkNames = ["typecheck", "lint", "test"];
+  const commands = checkNames
+    .filter((scriptName) => scripts[scriptName])
+    .map((scriptName) => commandForScript(manager, scriptName));
+
+  if (commands.length === 0) {
+    console.log("No typecheck/lint/test scripts were found in package.json.");
+    console.log(
+      "Run the target app's equivalent validation commands manually."
+    );
+    return;
+  }
+
+  console.log("Suggested validation commands:");
+  for (const command of commands) {
+    console.log(`  ${command}`);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { data: packageJson } = readPackageJson(options.root);
+  const manager = detectPackageManager(options.root, packageJson);
+  const dependencies = dependencyMap(packageJson);
+  const missingPackages = REQUIRED_PACKAGES.filter(
+    (packageName) => !dependencies[packageName]
+  );
+  const hasLegacyPackage = Boolean(dependencies[LEGACY_PACKAGE]);
+
+  console.log(`App root: ${options.root}`);
+  console.log(`Detected package manager: ${manager}`);
+
+  if (!options.skipInstall && missingPackages.length > 0) {
+    const [command, args] = commandForInstall(manager, missingPackages);
+    runCommand(command, args, { cwd: options.root, dryRun: options.dryRun });
+  } else if (missingPackages.length === 0) {
+    console.log("Required Nitro packages are already present.");
+  }
+
+  const files = await collectSourceFiles(options.root);
+  const { changedFiles, navigatorHits } = migrateImports(files, {
+    dryRun: options.dryRun
+  });
+
+  if (changedFiles.length > 0) {
+    console.log(
+      `${options.dryRun ? "Would update" : "Updated"} ${changedFiles.length} file(s):`
+    );
+    for (const file of changedFiles) {
+      console.log(`  ${path.relative(options.root, file)}`);
+    }
+  } else {
+    console.log("No @react-native-community/geolocation imports were found.");
+  }
+
+  if (!options.skipRemove && hasLegacyPackage) {
+    const [command, args] = commandForRemove(manager, LEGACY_PACKAGE);
+    runCommand(command, args, { cwd: options.root, dryRun: options.dryRun });
+  } else if (!hasLegacyPackage) {
+    console.log(`${LEGACY_PACKAGE} is not listed in package.json.`);
+  }
+
+  if (navigatorHits.length > 0) {
+    console.log("Manual review required for navigator.geolocation usage:");
+    for (const file of navigatorHits) {
+      console.log(`  ${path.relative(options.root, file)}`);
+    }
+  }
+
+  printNextChecks(manager, packageJson);
+  console.log("Next: refactor compat call sites to the Modern API.");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add a Vercel Agent Skills-compatible `react-native-nitro-geolocation-modern-migration` skill under `skills/` for distribution to users.
- Add a package-manager-aware bootstrap script that installs Nitro packages, rewrites legacy geolocation imports to `/compat`, removes `@react-native-community/geolocation`, and prints detected validation commands.
- Document the migration skill in the root README, package README, and Modern API docs, including the `skills` CLI install command.
- Add a patch changeset for the package-facing documentation update.

## Validation

- `node skills/react-native-nitro-geolocation-modern-migration/scripts/migrate-to-compat.mjs --root examples/benchmark --dry-run`
- `npx skills-ref validate skills/react-native-nitro-geolocation-modern-migration`
- `npx skills add . --list`
- `yarn format:check`
- `yarn lint`
- `yarn workspace docs typecheck`
- `yarn workspace docs build`
- `yarn typecheck`