### PR TITLE
fix(ios): resolve ambiguous abs overload in angularDistance

### DIFF
--- a/.changeset/fix-abs-ambiguity.md
+++ b/.changeset/fix-abs-ambiguity.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix iOS build error caused by ambiguous `abs` overload in `angularDistance`. Qualify with `Swift.abs(...)` so the compiler picks the generic signed-numeric overload instead of conflicting with Foundation's `fabs`.

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -947,7 +947,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     }
 
     private func angularDistance(_ first: Double, _ second: Double) -> Double {
-        let distance = abs(first - second).truncatingRemainder(dividingBy: 360)
+        let distance = Swift.abs(first - second).truncatingRemainder(dividingBy: 360)
         return distance > 180 ? 360 - distance : distance
     }
 


### PR DESCRIPTION
## Summary

The expression `abs(first - second)` in `angularDistance` (NitroGeolocation.swift:950) fails to compile on recent Swift toolchains:

```
NitroGeolocation.swift:950:24: ambiguous use of 'abs'
    let distance = abs(first - second).truncatingRemainder(dividingBy: 360)
```

The compiler can't disambiguate between Swift's generic `abs<T: SignedNumeric>` and Foundation's `fabs` overload set in this context (Foundation + CoreLocation both in scope). Qualifying with `Swift.abs(...)` locks in the intended overload.

## Repro

Build any consumer app on Xcode 16+ with `react-native-nitro-geolocation@1.2.2`. Building the example app in this repo on the same toolchain reproduces it.

## Fix

One-line change: `abs(...)` → `Swift.abs(...)`.

Behaviorally identical — `Swift.abs` on `Double` is the same operation; this just removes the ambiguity for the type checker.

## Test plan

- [x] Patched locally (via patch-package) in a downstream RN app — iOS build succeeds.
- [ ] CI green on this PR.