### PR TITLE
fix(ios): default headingFilter to 1° instead of 0°

### DIFF
--- a/.changeset/fix-heading-filter-defaults.md
+++ b/.changeset/fix-heading-filter-defaults.md
@@ -2,6 +2,6 @@
 "react-native-nitro-geolocation": patch
 ---
 
-Fix iOS heading firehose: default `headingFilter` to 1° (Apple's documented default) instead of 0°, and apply the filter on the same `trueHeading ?? magneticHeading` value JS consumers actually receive.
+Fix iOS heading firehose: default `headingFilter` to 1° (Apple's documented default) instead of 0°.
 
-Before this fix, callers who didn't supply `headingFilter` (or whose options didn't reach native) hit `kCLHeadingFilterNone` (-1) — every CLHeading tick fired the success callback, producing sub-degree firehose updates on a stationary device. The JS-side delta gate also compared on `magneticHeading` only, so a non-zero filter value could still pass while JS-visible `trueHeading` deltas were tiny.
+Before this fix, callers who didn't supply `headingFilter` (or whose options didn't reach native) hit `kCLHeadingFilterNone` (-1) — every CLHeading tick fired the success callback, producing sub-degree firehose updates on a stationary device.

--- a/.changeset/fix-heading-filter-defaults.md
+++ b/.changeset/fix-heading-filter-defaults.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix iOS heading firehose: default `headingFilter` to 1° (Apple's documented default) instead of 0°, and apply the filter on the same `trueHeading ?? magneticHeading` value JS consumers actually receive.
+
+Before this fix, callers who didn't supply `headingFilter` (or whose options didn't reach native) hit `kCLHeadingFilterNone` (-1) — every CLHeading tick fired the success callback, producing sub-degree firehose updates on a stationary device. The JS-side delta gate also compared on `magneticHeading` only, so a non-zero filter value could still pass while JS-visible `trueHeading` deltas were tiny.

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -148,9 +148,15 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     private struct ParsedHeadingOptions {
         let headingFilter: CLLocationDegrees
 
+        // Apple's documented `CLLocationManager.headingFilter` default is 1°.
+        // Defaulting to `0` here propagates through `mergeHeadingFilter` into
+        // `kCLHeadingFilterNone` (-1), which fires the delegate on every
+        // CLHeading tick (sub-degree firehose for stationary users). 1° matches
+        // CL's documented behavior and lets the delegate fire only on
+        // perceptible changes.
         static func parse(from options: HeadingOptions?) -> ParsedHeadingOptions {
             return ParsedHeadingOptions(
-                headingFilter: options?.headingFilter ?? 0
+                headingFilter: options?.headingFilter ?? 1
             )
         }
     }
@@ -772,6 +778,14 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     fileprivate func handleHeadingUpdate(_ clHeading: CLHeading) {
         let heading = headingToResponse(clHeading)
+        // Filter on the same value JS consumers see. The `Heading` payload
+        // exposes both `magneticHeading` and `trueHeading`, and idiomatic
+        // consumers prefer `trueHeading` when available. Comparing only on
+        // magneticHeading meant `headingFilter` could pass the magnetic
+        // delta gate while the JS-visible trueHeading delta was tiny — a
+        // user-visible firehose. Using `trueHeading ?? magneticHeading`
+        // here aligns the gate with what callers actually receive.
+        let deliveredHeading = heading.trueHeading ?? heading.magneticHeading
 
         for (id, request) in Array(pendingHeadingRequests) {
             request.timer?.cancel()
@@ -784,7 +798,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             if let lastDeliveredHeading = subscription.lastDeliveredHeading {
                 shouldDeliver = angularDistance(
                     lastDeliveredHeading,
-                    heading.magneticHeading
+                    deliveredHeading
                 ) >= subscription.options.headingFilter
             } else {
                 shouldDeliver = true
@@ -792,7 +806,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
             if shouldDeliver {
                 var nextSubscription = subscription
-                nextSubscription.lastDeliveredHeading = heading.magneticHeading
+                nextSubscription.lastDeliveredHeading = deliveredHeading
                 headingSubscriptions[token] = nextSubscription
                 nextSubscription.success(heading)
             }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -778,14 +778,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     fileprivate func handleHeadingUpdate(_ clHeading: CLHeading) {
         let heading = headingToResponse(clHeading)
-        // Filter on the same value JS consumers see. The `Heading` payload
-        // exposes both `magneticHeading` and `trueHeading`, and idiomatic
-        // consumers prefer `trueHeading` when available. Comparing only on
-        // magneticHeading meant `headingFilter` could pass the magnetic
-        // delta gate while the JS-visible trueHeading delta was tiny — a
-        // user-visible firehose. Using `trueHeading ?? magneticHeading`
-        // here aligns the gate with what callers actually receive.
-        let deliveredHeading = heading.trueHeading ?? heading.magneticHeading
 
         for (id, request) in Array(pendingHeadingRequests) {
             request.timer?.cancel()
@@ -798,7 +790,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             if let lastDeliveredHeading = subscription.lastDeliveredHeading {
                 shouldDeliver = angularDistance(
                     lastDeliveredHeading,
-                    deliveredHeading
+                    heading.magneticHeading
                 ) >= subscription.options.headingFilter
             } else {
                 shouldDeliver = true
@@ -806,7 +798,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
             if shouldDeliver {
                 var nextSubscription = subscription
-                nextSubscription.lastDeliveredHeading = deliveredHeading
+                nextSubscription.lastDeliveredHeading = heading.magneticHeading
                 headingSubscriptions[token] = nextSubscription
                 nextSubscription.success(heading)
             }


### PR DESCRIPTION
## Summary

`ParsedHeadingOptions.parse` defaults `headingFilter` to `0` when no options reach `parse(from:)`. Through `mergeHeadingFilter`, `0` collapses into `kCLHeadingFilterNone` (`-1`) and `CLLocationManager` fires the delegate on every magnetometer tick — sub-degree firehose for stationary users.

Apple's [documented default](https://developer.apple.com/documentation/corelocation/cllocationmanager/headingfilter) is **1°**:

> Specifies the minimum amount of change in degrees needed for a heading service update. Client will not be notified of updates less than the stated filter value. Pass in kCLHeadingFilterNone to be notified of all updates. **By default, 1 degree is used.**

This PR matches that documented default.

## Repro (real device, iOS)

Before:
```
manager.headingFilter = -1.0  (kCLHeadingFilterNone)
delivered: 287.10263 → 287.10284 → 287.10293 → 287.10310  // <0.001° apart
```

After (no caller changes):
```
manager.headingFilter = 1.0
delegate fires only on >=1° changes
```

## Test plan

- [x] Patched locally via patch-package in a downstream RN app — sub-degree firehose stops with caller default.
- [ ] CI green on this PR.

## Notes

This is a one-line behavior fix at the parse default. The deeper question of why `HeadingOptions` round-trips as `nil` to Swift even when callers do supply `{ headingFilter: 5 }` is likely a separate Nitro codegen issue and is out of scope here.