### PR TITLE
chore: add sideEffects false to enable tree shaking

### DIFF
--- a/.changeset/add-sideeffects-false.md
+++ b/.changeset/add-sideeffects-false.md
@@ -1,0 +1,6 @@
+---
+"react-native-nitro-geolocation": patch
+"@react-native-nitro-geolocation/rozenite-plugin": patch
+---
+
+Add `sideEffects: false` to enable tree shaking in bundlers.

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -84,6 +84,7 @@
     "react-native": ">=0.75.0",
     "react-native-nitro-modules": "*"
   },
+  "sideEffects": false,
   "create-react-native-library": {
     "languages": "kotlin-swift",
     "type": "nitro-module",

--- a/packages/rozenite-devtools-plugin/package.json
+++ b/packages/rozenite-devtools-plugin/package.json
@@ -58,6 +58,7 @@
     "react": "*",
     "react-native": "*"
   },
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Description

Add sideEffects: false to `package.json` in both `react-native-nitro-geolocation` and `@react-native-nitro-geolocation/rozenite-plugin`.

This field tells bundlers (webpack, Metro, etc.) that no files in these packages have side effects at import time, enabling dead code elimination for unused exports.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] My code follows the project style
- [ ] I've tested my changes locally
- [x] Documentation updated (if needed)

## E2E Test Results

N/A for docs-only changes

**Platform tested:**
- [ ] iOS
- [ ] Android
- [x] N/A (docs only)

---

## Additional Notes

Neither package contains polyfills or top-level side-effectful code, so false is safe. Bundlers that respect this field will be able to tree-shake unused exports from both packages, reducing the final bundle size for users.
