### PR TITLE
feat: Modern API web geolocation support

### DIFF
--- a/.changeset/modern-web-geolocation.md
+++ b/.changeset/modern-web-geolocation.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add Modern API web support through a browser conditional export backed by `navigator.geolocation`.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Full documentation available at:
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use `@react-native-community/geolocation` or `expo-location` for now |
+| Web support required | Use the Modern API root import |
 | Full background tracking / geofencing | Use a dedicated background-location library |
 
-Web is not supported in `v1.2.x`. The community package handles web by
-delegating to the browser `navigator.geolocation` API; this package currently
-targets native Nitro bindings. A `/compat` web fallback is planned for `v1.3`.
+Web support is available for the Modern API root import. Browser builds resolve
+the package root to a web entry that uses `navigator.geolocation` and does not
+load Nitro native bindings. The `/compat` subpath remains native-only.
 
 ---
 
@@ -168,8 +168,8 @@ Geolocation.clearWatch(watchId);
 | `watchPosition` | Supported | Returns a numeric watch id. |
 | `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
 | `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
-| `navigator.geolocation` polyfill | Not supported in `v1.2.x` | Planned for `v1.3`. |
-| Web | Not supported in `v1.2.x` | Planned as a `/compat` browser fallback in `v1.3`. |
+| `navigator.geolocation` polyfill | Not supported | Use the Modern API root import for web. |
+| Web | Native-only for `/compat` | Modern API root import supports web through `navigator.geolocation`. |
 
 ---
 

--- a/docs/docs/guide/compat-api.md
+++ b/docs/docs/guide/compat-api.md
@@ -34,12 +34,11 @@ Promise/function API.
 | `watchPosition` | Supported | Returns a numeric watch id. |
 | `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
 | `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
-| `navigator.geolocation` polyfill | Not supported in `v1.2.x` | Planned for `v1.3`. |
-| Web | Not supported in `v1.2.x` | Planned as a `/compat` browser fallback in `v1.3`. |
+| `navigator.geolocation` polyfill | Not supported | Use the Modern API root import for web. |
+| Web | Native-only for `/compat` | Modern API root import supports web through `navigator.geolocation`. |
 
-The community package supports web by delegating to the browser
-`navigator.geolocation` API. `react-native-nitro-geolocation` currently targets
-native Nitro bindings and does not include that browser fallback in `v1.2.x`.
+The root Modern API supports web by delegating to the browser
+`navigator.geolocation` API. The `/compat` subpath remains native-only.
 
 ## Summary
 

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -19,12 +19,12 @@ to a typed Modern API.
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use `@react-native-community/geolocation` or `expo-location` for now |
+| Web support required | Use the Modern API root import |
 | Full background tracking / geofencing | Use a dedicated background-location library |
 
-Web is not supported in `v1.2.x`. The community package handles web by
-delegating to the browser `navigator.geolocation` API; this package currently
-targets native Nitro bindings. A `/compat` web fallback is planned for `v1.3`.
+Web support is available for the Modern API root import. Browser builds resolve
+the package root to a web entry that uses `navigator.geolocation` and does not
+load Nitro native bindings. The `/compat` subpath remains native-only.
 
 React Native Nitro Geolocation provides **two APIs** to fit your needs:
 

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -71,6 +71,15 @@ export type ModernGeolocationConfiguration = GeolocationConfiguration;
 - Once at app startup (e.g., in `App.tsx` or `index.js`)
 - Before making any location requests
 
+**Web behavior**:
+
+- Browser builds resolve the root import to a web entry that uses
+  `navigator.geolocation`.
+- `setConfiguration()` is a no-op on web. Browser permission prompts are driven
+  by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
+  request API.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, and
+  `locationProvider` are ignored on web.
 
 ## Permission Functions
 
@@ -146,6 +155,9 @@ function PermissionButton() {
 - Shows system permission dialog if `undetermined`
 - Returns immediately if already `granted` or `denied`
 - On iOS, uses `authorizationLevel` from configuration
+- On web, triggers the browser prompt by making a one-shot
+  `navigator.geolocation.getCurrentPosition()` call, then returns the mapped
+  browser permission state.
 
 
 ## Location Functions
@@ -219,6 +231,40 @@ current Core Location service status and does not show a settings dialog.
   starting a fresh native request.
 - Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
+
+### Web Notes
+
+Modern API web support uses the browser standard `navigator.geolocation` API.
+It requires a secure context (`https://`, `localhost`, or another browser-trusted
+origin). Unsupported browsers or unavailable providers reject location requests
+with `POSITION_UNAVAILABLE`.
+
+Supported on web:
+
+- `checkPermission()` maps `navigator.permissions.query({ name:
+  'geolocation' })` to `granted`, `denied`, or `undetermined` when the
+  Permissions API is available.
+- `requestPermission()` performs a one-shot browser geolocation request because
+  browsers do not expose a standalone geolocation permission request API.
+- `getCurrentPosition()` wraps `navigator.geolocation.getCurrentPosition()`.
+- `watchPosition()` wraps `navigator.geolocation.watchPosition()` and returns a
+  string token.
+- `unwatch()` and `stopObserving()` clear browser watch IDs.
+
+Web option behavior:
+
+- `enableHighAccuracy`, `timeout`, and `maximumAge` are forwarded to the
+  browser.
+- `distanceFilter` is applied in JavaScript for watch updates after the first
+  emitted position.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`,
+  `interval`, `fastestInterval`, `useSignificantChanges`, Android granularity
+  options, and iOS tuning options are ignored because browsers do not provide
+  matching controls.
+- Geocoding, heading, Android settings, and temporary full-accuracy APIs are
+  native-focused. On web, provider/status helpers return browser availability
+  where possible; unsupported sensor/geocoder calls reject with
+  `POSITION_UNAVAILABLE`.
 
 ### getCurrentPosition()
 

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -351,8 +351,10 @@ geolocation API. You'll get:
 - Improved permission consistency
 - TypeScript definitions out of the box
 
-Web and `navigator.geolocation` polyfill behavior are not supported in `v1.2.x`.
-They are planned for a `/compat` browser fallback in `v1.3`.
+The root Modern API supports web through the browser `navigator.geolocation`
+API. The `/compat` subpath remains native-only. Web location requires a secure
+context and browser permission; unsupported provider/sensor APIs reject with the
+Modern API `POSITION_UNAVAILABLE` error shape.
 
 ### From Compat to Modern API (Recommended)
 

--- a/docs/docs/guide/react-native-directory.md
+++ b/docs/docs/guide/react-native-directory.md
@@ -13,7 +13,7 @@ Native Directory.
 | --- | --- |
 | iOS | Supported |
 | Android | Supported |
-| Web | Not supported in `v1.2.x`; `/compat` fallback planned for `v1.3` |
+| Web | Modern API root import supported through `navigator.geolocation`; `/compat` remains native-only |
 | New Architecture | Required target; implemented through Nitro Modules |
 | Expo Go | Not supported |
 | Expo development builds | Supported with native setup |
@@ -30,16 +30,16 @@ Nitro-powered native geolocation for React Native 0.75+. Use /compat to replace 
 Recommended caveat:
 
 ```txt
-Targets bare React Native, RN CLI, and Expo development/custom native builds. Expo Go and web are not supported in v1.2.x.
+Targets bare React Native, RN CLI, Expo development/custom native builds, and Modern API web through navigator.geolocation. Expo Go and `/compat` web are not supported.
 ```
 
 ## Pre-Submission Checklist
 
 - README explains when to use the package and when not to use it.
-- README includes compat coverage and web/Expo limitations.
+- README includes compat coverage, Modern API web behavior, and Expo limitations.
 - npm package has discoverability keywords.
 - Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
 - Docs include Expo development build guidance.
 - Docs include community and service migration paths.
 - Benchmark docs clearly state cached-read and JS-native latency scope.
-- Roadmap issue tracks `v1.3` compatibility matrix, web fallback, extra benchmarks, and real migration examples.
+- Roadmap issue tracks compatibility matrix, `/compat` web fallback, extra benchmarks, and real migration examples.

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -44,4 +44,5 @@ appId: nitrogeolocation.example
       platform: iOS
     file: mocked-metadata-ios-true.yaml
 - runFlow: api-errors.yaml
+- runFlow: web-e2e.yaml
 - runFlow: compat-api.yaml

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -1,6 +1,7 @@
 appId: nitrogeolocation.example
 ---
 # Run platform-compatible geolocation tests in sequence.
+# Web E2E is intentionally separate because it requires a local web server.
 
 - runFlow: permission-check.yaml
 - runFlow: current-position.yaml
@@ -44,5 +45,4 @@ appId: nitrogeolocation.example
       platform: iOS
     file: mocked-metadata-ios-true.yaml
 - runFlow: api-errors.yaml
-- runFlow: web-e2e.yaml
 - runFlow: compat-api.yaml

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -1,0 +1,37 @@
+appId: nitrogeolocation.example
+---
+# Web Modern API provider-disabled contract through react-native-webview.
+# Android runner disables device location before invoking this flow.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 20000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/web-e2e?autorun=unavailable
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Web E2E"
+    timeout: 20000
+
+- tapOn:
+    text: "Reload"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Nitro Geolocation Web E2E"
+    timeout: 60000
+
+- extendedWaitUntil:
+    visible: "position-unavailable: (pass|manual)"
+    timeout: 20000

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -24,38 +24,65 @@ appId: nitrogeolocation.example
     text: "열기|Open"
     optional: true
 
+- tapOn:
+    text: "Allow"
+    optional: true
+
+- tapOn:
+    text: "Allow"
+    optional: true
+
 - extendedWaitUntil:
-    visible: "Nitro Geolocation Web E2E"
-    timeout: 20000
+    visible: "get-current-position: running: move-for-get-current-position"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5671
+    longitude: 126.9786
+
+- extendedWaitUntil:
+    visible: "watch-position: running: move-for-watch-position"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5678
+    longitude: 126.9793
+
+- extendedWaitUntil:
+    visible: "unwatch: running: move-for-unwatch-initial"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5685
+    longitude: 126.98
 
 - extendedWaitUntil:
     visible: "unwatch: running: move-after-unwatch"
     timeout: 40000
 
 - setLocation:
-    latitude: 37.5675
-    longitude: 126.9790
+    latitude: 37.5692
+    longitude: 126.9807
+
+- extendedWaitUntil:
+    visible: "stop-observing: running: move-for-stop-observing-initial"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5699
+    longitude: 126.9814
 
 - extendedWaitUntil:
     visible: "stop-observing: running: move-after-stop-observing"
     timeout: 40000
 
 - setLocation:
-    latitude: 37.5685
-    longitude: 126.9800
+    latitude: 37.5706
+    longitude: 126.9821
 
 - extendedWaitUntil:
-    visible: "stop-observing: pass"
+    visible: "success-suite: pass"
     timeout: 20000
-
-- assertVisible: "API availability"
-- assertVisible: "checkPermission"
-- assertVisible: "requestPermission"
-- assertVisible: "getCurrentPosition"
-- assertVisible: "watchPosition emits update"
-- assertVisible: "unwatch stops watcher"
-- assertVisible: "stopObserving clears watchers"
-- assertVisible: "PASS"
 
 - launchApp:
     clearState: true
@@ -72,6 +99,10 @@ appId: nitrogeolocation.example
     link: nitrogeolocation://app/web-e2e?autorun=denied
 - tapOn:
     text: "열기|Open"
+    optional: true
+
+- tapOn:
+    text: "Don’t allow|Don't allow"
     optional: true
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -1,0 +1,89 @@
+appId: nitrogeolocation.example
+---
+# Web Modern API contract through react-native-webview.
+# Requires examples/web-e2e dev server on port 4173.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.9780
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 20000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/web-e2e?autorun=success
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Nitro Geolocation Web E2E"
+    timeout: 20000
+
+- extendedWaitUntil:
+    visible: "unwatch: running: move-after-unwatch"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5675
+    longitude: 126.9790
+
+- extendedWaitUntil:
+    visible: "stop-observing: running: move-after-stop-observing"
+    timeout: 40000
+
+- setLocation:
+    latitude: 37.5685
+    longitude: 126.9800
+
+- extendedWaitUntil:
+    visible: "stop-observing: pass"
+    timeout: 20000
+
+- assertVisible: "API availability"
+- assertVisible: "checkPermission"
+- assertVisible: "requestPermission"
+- assertVisible: "getCurrentPosition"
+- assertVisible: "watchPosition emits update"
+- assertVisible: "unwatch stops watcher"
+- assertVisible: "stopObserving clears watchers"
+- assertVisible: "PASS"
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: deny
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 20000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/web-e2e?autorun=denied
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Nitro Geolocation Web E2E"
+    timeout: 20000
+
+- tapOn:
+    text: "Don’t allow|Don't allow"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "permission-denied: pass"
+    timeout: 20000
+
+- assertVisible: "permission denied -> PERMISSION_DENIED"

--- a/examples/v0.81.1/android/app/src/main/AndroidManifest.xml
+++ b/examples/v0.81.1/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme"
-      android:supportsRtl="true">
+      android:supportsRtl="true"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/examples/v0.81.1/ios/Podfile.lock
+++ b/examples/v0.81.1/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroGeolocation (1.2.4):
+  - NitroGeolocation (1.2.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1922,6 +1922,34 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - react-native-webview (13.16.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - React-NativeModulesApple (0.81.1):
     - boost
     - DoubleConversion
@@ -2535,6 +2563,7 @@ DEPENDENCIES:
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -2663,6 +2692,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/geolocation"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -2736,7 +2767,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroGeolocation: adc07ff7511ed8fa5fb7d13a2adc6aa32507b2a5
+  NitroGeolocation: 923a4c6a8e42a102c4ee9c0fa2fc484985666016
   NitroModules: 1dc73273d6e3aee937eec41ef3ed9470804b9884
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
@@ -2773,6 +2804,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
   react-native-geolocation: 95e48fe2687e5a8280103085372fa62c2297c5d6
   react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
+  react-native-webview: 8407aaaf6b539b1e38b72fabb55d6885de03beaf
   React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
   React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -16,7 +16,9 @@
     "build:ios:release": "react-native build-ios --mode Release",
     "typecheck": "tsc --noEmit",
     "test:e2e:android": "bash ./scripts/test-e2e-android.sh",
-    "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh"
+    "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh",
+    "test:e2e:web:android": "bash ./scripts/test-e2e-web-android.sh",
+    "test:e2e:web:ios": "bash ./scripts/test-e2e-web-ios.sh"
   },
   "dependencies": {
     "@react-native-community/geolocation": "^3.4.0",

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -16,7 +16,7 @@
     "build:ios:release": "react-native build-ios --mode Release",
     "typecheck": "tsc --noEmit",
     "test:e2e:android": "bash ./scripts/test-e2e-android.sh",
-    "test:e2e:ios": "maestro test --platform ios .maestro/all-tests.yaml"
+    "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh"
   },
   "dependencies": {
     "@react-native-community/geolocation": "^3.4.0",
@@ -29,7 +29,8 @@
     "react-native-nitro-geolocation": "workspace: *",
     "react-native-nitro-modules": "^0.35.0",
     "react-native-safe-area-context": "^5.5.2",
-    "react-native-screens": "4.19.0"
+    "react-native-screens": "4.19.0",
+    "react-native-webview": "13.16.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -3,10 +3,30 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
+WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
+
+WEB_SERVER_PID=""
+
+start_web_e2e_server() {
+  (cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+  WEB_SERVER_PID="$!"
+
+  for _ in {1..60}; do
+    if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+      "$ADB_BIN" reverse "tcp:$WEB_E2E_PORT" "tcp:$WEB_E2E_PORT" >/dev/null
+      return
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
+  exit 1
+}
 
 set_location_enabled() {
   "$ADB_BIN" shell cmd location set-location-enabled "$1" >/dev/null
@@ -14,12 +34,18 @@ set_location_enabled() {
 
 restore_location() {
   set_location_enabled true || true
+  "$ADB_BIN" reverse --remove "tcp:$WEB_E2E_PORT" >/dev/null 2>&1 || true
+  if [[ -n "$WEB_SERVER_PID" ]]; then
+    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
+  fi
 }
 
 trap restore_location EXIT
 
-restore_location
+start_web_e2e_server
+set_location_enabled true
 "$MAESTRO_BIN" test --platform android "$FLOW_DIR/all-tests.yaml"
 
 set_location_enabled false
 "$MAESTRO_BIN" test --platform android "$FLOW_DIR/provider-settings-not-ready.yaml"
+"$MAESTRO_BIN" test --platform android "$FLOW_DIR/web-e2e-unavailable.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -3,30 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
-WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
-
-WEB_SERVER_PID=""
-
-start_web_e2e_server() {
-  (cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
-  WEB_SERVER_PID="$!"
-
-  for _ in {1..60}; do
-    if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
-      "$ADB_BIN" reverse "tcp:$WEB_E2E_PORT" "tcp:$WEB_E2E_PORT" >/dev/null
-      return
-    fi
-    sleep 1
-  done
-
-  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
-  exit 1
-}
 
 set_location_enabled() {
   "$ADB_BIN" shell cmd location set-location-enabled "$1" >/dev/null
@@ -34,18 +14,12 @@ set_location_enabled() {
 
 restore_location() {
   set_location_enabled true || true
-  "$ADB_BIN" reverse --remove "tcp:$WEB_E2E_PORT" >/dev/null 2>&1 || true
-  if [[ -n "$WEB_SERVER_PID" ]]; then
-    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
-  fi
 }
 
 trap restore_location EXIT
 
-start_web_e2e_server
 set_location_enabled true
 "$MAESTRO_BIN" test --platform android "$FLOW_DIR/all-tests.yaml"
 
 set_location_enabled false
 "$MAESTRO_BIN" test --platform android "$FLOW_DIR/provider-settings-not-ready.yaml"
-"$MAESTRO_BIN" test --platform android "$FLOW_DIR/web-e2e-unavailable.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+FLOW_DIR="$EXAMPLE_DIR/.maestro"
+
+MAESTRO_BIN="${MAESTRO:-maestro}"
+WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
+WEB_SERVER_PID=""
+
+cleanup() {
+  if [[ -n "$WEB_SERVER_PID" ]]; then
+    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+WEB_SERVER_PID="$!"
+
+for _ in {1..60}; do
+  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
+  exit 1
+fi
+
+"$MAESTRO_BIN" test --platform ios "$FLOW_DIR/all-tests.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -3,34 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
 FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 MAESTRO_BIN="${MAESTRO:-maestro}"
-WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
-WEB_SERVER_PID=""
-
-cleanup() {
-  if [[ -n "$WEB_SERVER_PID" ]]; then
-    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
-  fi
-}
-
-trap cleanup EXIT
-
-(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
-WEB_SERVER_PID="$!"
-
-for _ in {1..60}; do
-  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
-    break
-  fi
-  sleep 1
-done
-
-if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
-  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
-  exit 1
-fi
 
 "$MAESTRO_BIN" test --platform ios "$FLOW_DIR/all-tests.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-web-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-web-android.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+FLOW_DIR="$EXAMPLE_DIR/.maestro"
+
+ADB_BIN="${ADB:-adb}"
+MAESTRO_BIN="${MAESTRO:-maestro}"
+WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
+WEB_SERVER_PID=""
+
+cleanup() {
+  "$ADB_BIN" shell cmd location set-location-enabled true >/dev/null 2>&1 || true
+  "$ADB_BIN" reverse --remove "tcp:$WEB_E2E_PORT" >/dev/null 2>&1 || true
+  if [[ -n "$WEB_SERVER_PID" ]]; then
+    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+WEB_SERVER_PID="$!"
+
+for _ in {1..60}; do
+  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+    "$ADB_BIN" reverse "tcp:$WEB_E2E_PORT" "tcp:$WEB_E2E_PORT" >/dev/null
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
+  exit 1
+fi
+
+"$ADB_BIN" shell cmd location set-location-enabled true >/dev/null
+"$MAESTRO_BIN" test --platform android "$FLOW_DIR/web-e2e.yaml"
+
+"$ADB_BIN" shell cmd location set-location-enabled false >/dev/null
+"$MAESTRO_BIN" test --platform android "$FLOW_DIR/web-e2e-unavailable.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-web-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-web-android.sh
@@ -21,18 +21,32 @@ cleanup() {
 
 trap cleanup EXIT
 
-(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null 2>&1; then
+  echo "Port $WEB_E2E_PORT is already in use. Stop the existing web E2E server before running this script." >&2
+  exit 1
+fi
+
+(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT" --strictPort) &
 WEB_SERVER_PID="$!"
 
 for _ in {1..60}; do
-  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+  if ! kill -0 "$WEB_SERVER_PID" >/dev/null 2>&1; then
+    wait "$WEB_SERVER_PID"
+    exit 1
+  fi
+  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" | grep -q "Nitro Geolocation Web E2E"; then
     "$ADB_BIN" reverse "tcp:$WEB_E2E_PORT" "tcp:$WEB_E2E_PORT" >/dev/null
     break
   fi
   sleep 1
 done
 
-if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+if ! kill -0 "$WEB_SERVER_PID" >/dev/null 2>&1; then
+  wait "$WEB_SERVER_PID"
+  exit 1
+fi
+
+if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" | grep -q "Nitro Geolocation Web E2E"; then
   echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
   exit 1
 fi

--- a/examples/v0.81.1/scripts/test-e2e-web-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-web-ios.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$EXAMPLE_DIR/../.." && pwd)"
+FLOW_DIR="$EXAMPLE_DIR/.maestro"
+
+MAESTRO_BIN="${MAESTRO:-maestro}"
+WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
+WEB_SERVER_PID=""
+
+cleanup() {
+  if [[ -n "$WEB_SERVER_PID" ]]; then
+    kill "$WEB_SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+WEB_SERVER_PID="$!"
+
+for _ in {1..60}; do
+  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+  echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
+  exit 1
+fi
+
+"$MAESTRO_BIN" test --platform ios "$FLOW_DIR/web-e2e.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-web-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-web-ios.sh
@@ -18,17 +18,31 @@ cleanup() {
 
 trap cleanup EXIT
 
-(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT") &
+if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null 2>&1; then
+  echo "Port $WEB_E2E_PORT is already in use. Stop the existing web E2E server before running this script." >&2
+  exit 1
+fi
+
+(cd "$REPO_DIR" && yarn workspace react-native-nitro-geolocation-web-e2e start --port "$WEB_E2E_PORT" --strictPort) &
 WEB_SERVER_PID="$!"
 
 for _ in {1..60}; do
-  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+  if ! kill -0 "$WEB_SERVER_PID" >/dev/null 2>&1; then
+    wait "$WEB_SERVER_PID"
+    exit 1
+  fi
+  if curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" | grep -q "Nitro Geolocation Web E2E"; then
     break
   fi
   sleep 1
 done
 
-if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" >/dev/null; then
+if ! kill -0 "$WEB_SERVER_PID" >/dev/null 2>&1; then
+  wait "$WEB_SERVER_PID"
+  exit 1
+fi
+
+if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" | grep -q "Nitro Geolocation Web E2E"; then
   echo "Timed out waiting for web E2E server on port $WEB_E2E_PORT" >&2
   exit 1
 fi

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -25,6 +25,7 @@ import MockedMetadataScreen from "./screens/MockedMetadataScreen";
 import PermissionCheckScreen from "./screens/PermissionCheckScreen";
 import ProviderSettingsScreen from "./screens/ProviderSettingsScreen";
 import WatchPositionScreen from "./screens/WatchPositionScreen";
+import WebE2EScreen from "./screens/WebE2EScreen";
 
 const Tab = createBottomTabNavigator();
 const linking = {
@@ -49,6 +50,7 @@ const linking = {
       IOSLocationTuning: "ios-location-tuning",
       IOSAccuracyAuthorization: "ios-accuracy-authorization",
       IOSReleaseOptionsBridge: "ios-release-options-bridge",
+      WebE2E: "web-e2e",
       Issue67: "issue-67"
     }
   }
@@ -177,6 +179,11 @@ export default function App() {
         <Tab.Screen
           name="IOSReleaseOptionsBridge"
           component={IOSReleaseOptionsBridgeScreen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="WebE2E"
+          component={WebE2EScreen}
           options={hiddenTabOptions}
         />
         <Tab.Screen

--- a/examples/v0.81.1/src/screens/WebE2EScreen.tsx
+++ b/examples/v0.81.1/src/screens/WebE2EScreen.tsx
@@ -1,0 +1,147 @@
+import { useRoute } from "@react-navigation/native";
+import React, { useMemo, useState } from "react";
+import { Platform, Text, View } from "react-native";
+import { WebView } from "react-native-webview";
+import type { WebViewMessageEvent } from "react-native-webview";
+import { ScenarioButton, ScenarioScreen, sharedStyles } from "./scenario";
+
+const DEFAULT_WEB_E2E_URL = Platform.select({
+  android: "http://localhost:4173",
+  ios: "http://127.0.0.1:4173",
+  default: "http://127.0.0.1:4173"
+});
+
+export default function WebE2EScreen() {
+  const route = useRoute();
+  const [reloadKey, setReloadKey] = useState(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [lastEvent, setLastEvent] = useState("idle");
+  const uri = useMemo(() => DEFAULT_WEB_E2E_URL ?? "", []);
+  const autorun =
+    typeof (route.params as { autorun?: unknown } | undefined)?.autorun ===
+    "string"
+      ? (route.params as { autorun: string }).autorun
+      : undefined;
+  const sourceUri = autorun
+    ? `${uri}?autorun=${encodeURIComponent(autorun)}&reload=${reloadKey}`
+    : `${uri}?reload=${reloadKey}`;
+
+  const handleMessage = (event: WebViewMessageEvent) => {
+    try {
+      const message = JSON.parse(event.nativeEvent.data) as {
+        id?: string;
+        raw?: {
+          phase?: unknown;
+        };
+        status?: string;
+      };
+      if (message.id && message.status) {
+        const phase =
+          typeof message.raw?.phase === "string"
+            ? `: ${message.raw.phase}`
+            : "";
+        setLastEvent(`${message.id}: ${message.status}${phase}`);
+      }
+    } catch {
+      setLastEvent("web-e2e: invalid-message");
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix="web-e2e"
+      title="Web E2E"
+      subtitle="Loads examples/web-e2e through react-native-webview"
+      contentContainerStyle={webE2EStyles.content}
+    >
+      <View style={webE2EStyles.bar}>
+        <Text style={webE2EStyles.url} testID="web-e2e-url">
+          {sourceUri}
+        </Text>
+        <ScenarioButton
+          title="Reload"
+          onPress={() => {
+            setLoadError(null);
+            setReloadKey((current) => current + 1);
+          }}
+          color="#2196F3"
+          containerStyle={webE2EStyles.reloadButton}
+        />
+      </View>
+      {loadError ? (
+        <View style={sharedStyles.errorContainer} testID="web-e2e-load-error">
+          <Text style={sharedStyles.errorText}>{loadError}</Text>
+        </View>
+      ) : null}
+      <View style={webE2EStyles.nativeStatus}>
+        <Text style={webE2EStyles.nativeStatusText} testID="web-e2e-last-event">
+          {lastEvent}
+        </Text>
+      </View>
+      <View style={webE2EStyles.webViewFrame}>
+        <WebView
+          key={reloadKey}
+          testID="web-e2e-webview"
+          source={{ uri: sourceUri }}
+          originWhitelist={["http://*", "https://*"]}
+          javaScriptEnabled={true}
+          domStorageEnabled={true}
+          geolocationEnabled={true}
+          setSupportMultipleWindows={false}
+          onLoadStart={() => setLoadError(null)}
+          onError={(event) => {
+            setLoadError(event.nativeEvent.description);
+          }}
+          onHttpError={(event) => {
+            setLoadError(`HTTP ${event.nativeEvent.statusCode}`);
+          }}
+          onMessage={handleMessage}
+          style={webE2EStyles.webView}
+        />
+      </View>
+    </ScenarioScreen>
+  );
+}
+
+const webE2EStyles = {
+  content: {
+    flexGrow: 1
+  },
+  bar: {
+    alignItems: "center" as const,
+    backgroundColor: "#FFFFFF",
+    borderBottomColor: "#E5E7EB",
+    borderBottomWidth: 1,
+    flexDirection: "row" as const,
+    gap: 8,
+    padding: 12
+  },
+  url: {
+    color: "#374151",
+    flex: 1,
+    fontSize: 13
+  },
+  reloadButton: {
+    minWidth: 96
+  },
+  nativeStatus: {
+    backgroundColor: "#ECFDF5",
+    borderBottomColor: "#10B981",
+    borderBottomWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8
+  },
+  nativeStatusText: {
+    color: "#065F46",
+    fontSize: 14,
+    fontWeight: "700" as const
+  },
+  webViewFrame: {
+    flex: 1,
+    minHeight: 640
+  },
+  webView: {
+    backgroundColor: "#F7F9FC",
+    flex: 1
+  }
+};

--- a/examples/v0.81.1/src/screens/index.ts
+++ b/examples/v0.81.1/src/screens/index.ts
@@ -16,4 +16,5 @@ export { default as LocationSimulationScreen } from "./LocationSimulationScreen"
 export { default as MockedMetadataScreen } from "./MockedMetadataScreen";
 export { default as PermissionCheckScreen } from "./PermissionCheckScreen";
 export { default as ProviderSettingsScreen } from "./ProviderSettingsScreen";
+export { default as WebE2EScreen } from "./WebE2EScreen";
 export { default as WatchPositionScreen } from "./WatchPositionScreen";

--- a/examples/web-e2e/index.html
+++ b/examples/web-e2e/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nitro Geolocation Web E2E</title>
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <h1>Nitro Geolocation Web E2E</h1>
+        <p>
+          Modern API browser adapter contract with real
+          navigator.geolocation calls.
+        </p>
+      </header>
+
+      <section class="toolbar" aria-label="E2E actions">
+        <button id="run-success" type="button">Run Success Suite</button>
+        <button id="run-denied" type="button">Run Denied Check</button>
+        <button id="run-unavailable" type="button">
+          Run Unavailable Check
+        </button>
+        <button id="run-timeout" type="button">Run Timeout Check</button>
+        <button id="clear-results" type="button">Clear</button>
+      </section>
+
+      <section class="status-grid" id="scenario-grid"></section>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/web-e2e/package.json
+++ b/examples/web-e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "react-native-nitro-geolocation-web-e2e",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "vite --host 127.0.0.1",
+    "build": "vite build",
+    "web:e2e": "vite --host 127.0.0.1",
+    "web:e2e:build": "vite build"
+  },
+  "dependencies": {
+    "react-native-nitro-geolocation": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3",
+    "vite": "8.0.10"
+  }
+}

--- a/examples/web-e2e/src/main.ts
+++ b/examples/web-e2e/src/main.ts
@@ -102,6 +102,16 @@ const unavailableButton =
 const timeoutButton = document.querySelector<HTMLButtonElement>("#run-timeout");
 const clearButton = document.querySelector<HTMLButtonElement>("#clear-results");
 
+const expectedLocations = {
+  getCurrentPosition: { latitude: 37.5671, longitude: 126.9786 },
+  watchPosition: { latitude: 37.5678, longitude: 126.9793 },
+  unwatchInitial: { latitude: 37.5685, longitude: 126.98 },
+  unwatchAfterClear: { latitude: 37.5692, longitude: 126.9807 },
+  stopObservingInitial: { latitude: 37.5699, longitude: 126.9814 },
+  stopObservingAfterClear: { latitude: 37.5706, longitude: 126.9821 }
+} as const;
+const expectedLocationTolerance = 0.00015;
+
 function render() {
   if (!grid) {
     return;
@@ -162,6 +172,10 @@ function setScenario(
   }
 }
 
+function postNativeStatus(id: string, status: ScenarioStatus, raw?: unknown) {
+  window.ReactNativeWebView?.postMessage(JSON.stringify({ id, status, raw }));
+}
+
 function assertPosition(position: GeolocationResponse) {
   if (
     typeof position.coords.latitude !== "number" ||
@@ -196,6 +210,180 @@ async function runStep<T>(
     setScenario(id, "fail", error);
     throw error;
   }
+}
+
+async function watchUntilFirstEvent({
+  timeoutMs,
+  clearOnFirst,
+  acceptPosition = () => true,
+  onStarted
+}: {
+  timeoutMs: number;
+  clearOnFirst: boolean;
+  acceptPosition?: (position: GeolocationResponse) => boolean;
+  onStarted?: (token: string) => void;
+}) {
+  const startedAt = Date.now();
+  const events: GeolocationResponse[] = [];
+  const errors: unknown[] = [];
+
+  return new Promise<{
+    token: string;
+    events: GeolocationResponse[];
+    errors: unknown[];
+    position: GeolocationResponse;
+  }>((resolve, reject) => {
+    let activeToken = "";
+    let stopped = false;
+    let resolved = false;
+    const fail = (error: unknown, tokenToClear = activeToken) => {
+      if (stopped || resolved) {
+        return;
+      }
+      stopped = true;
+      window.clearTimeout(timeout);
+      if (tokenToClear) {
+        unwatch(tokenToClear);
+      }
+      reject(error);
+    };
+    const pass = (token: string, position: GeolocationResponse) => {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      window.clearTimeout(timeout);
+      if (clearOnFirst) {
+        stopped = true;
+        unwatch(token);
+      }
+      resolve({ token, events, errors, position });
+    };
+    const timeout = window.setTimeout(() => {
+      fail(
+        new Error(
+          `Timed out waiting for accepted watch event after ${timeoutMs}ms.`
+        )
+      );
+    }, timeoutMs);
+    const startWatch = () => {
+      if (stopped || resolved) {
+        return;
+      }
+      let token = "";
+      token = watchPosition(
+        (nextPosition) => {
+          if (stopped) {
+            return;
+          }
+          events.push(nextPosition);
+          if (!acceptPosition(nextPosition)) {
+            return;
+          }
+          pass(token, nextPosition);
+        },
+        (error) => {
+          if (stopped) {
+            return;
+          }
+          errors.push(error);
+          if (resolved) {
+            return;
+          }
+          if (token) {
+            unwatch(token);
+          }
+          if (Date.now() - startedAt >= timeoutMs) {
+            fail(error, "");
+            return;
+          }
+          window.setTimeout(startWatch, 500);
+        },
+        { maximumAge: 0, timeout: 15000 }
+      );
+      activeToken = token;
+      onStarted?.(token);
+    };
+
+    startWatch();
+  });
+}
+
+async function getCurrentPositionUntilSuccess(timeoutMs: number) {
+  const startedAt = Date.now();
+  const transientErrors: unknown[] = [];
+
+  while (true) {
+    try {
+      const position = await getCurrentPosition({
+        maximumAge: 0,
+        timeout: 15000
+      });
+      return { position, transientErrors };
+    } catch (error) {
+      transientErrors.push(error);
+      const code = getErrorCode(error);
+      if ((code !== 2 && code !== 3) || Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+      await wait(500);
+    }
+  }
+}
+
+async function getCurrentPositionUntilExpected({
+  expected,
+  timeoutMs
+}: {
+  expected: ExpectedLocation;
+  timeoutMs: number;
+}) {
+  const startedAt = Date.now();
+  const transientErrors: unknown[] = [];
+  const ignoredPositions: GeolocationResponse[] = [];
+
+  while (true) {
+    try {
+      const position = await getCurrentPosition({
+        maximumAge: 0,
+        timeout: 15000
+      });
+      if (isNearExpected(position, expected)) {
+        return { position, transientErrors, ignoredPositions };
+      }
+      ignoredPositions.push(position);
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(
+          `getCurrentPosition did not return expected coords ${expected.latitude}, ${expected.longitude}.`
+        );
+      }
+      await wait(500);
+    } catch (error) {
+      transientErrors.push(error);
+      const code = getErrorCode(error);
+      if ((code !== 2 && code !== 3) || Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+      await wait(500);
+    }
+  }
+}
+
+type ExpectedLocation = {
+  latitude: number;
+  longitude: number;
+};
+
+function isNearExpected(
+  position: GeolocationResponse,
+  expected: ExpectedLocation
+) {
+  return (
+    Math.abs(position.coords.latitude - expected.latitude) <=
+      expectedLocationTolerance &&
+    Math.abs(position.coords.longitude - expected.longitude) <=
+      expectedLocationTolerance
+  );
 }
 
 async function runSuccessSuite() {
@@ -236,55 +424,93 @@ async function runSuccessSuite() {
     }
   );
 
-  await runStep(
-    "watch-position",
-    () =>
-      new Promise<GeolocationResponse>((resolve, reject) => {
-        const token = watchPosition(
-          (nextPosition) => {
-            unwatch(token);
-            resolve(nextPosition);
-          },
-          reject,
-          { maximumAge: 0, timeout: 15000 }
-        );
-      }),
-    assertPosition
-  );
-
   const position = await runStep(
     "get-current-position",
-    () => getCurrentPosition({ maximumAge: 0, timeout: 15000 }),
-    assertPosition
+    async () => {
+      const baseline = await getCurrentPositionUntilSuccess(30000);
+      setScenario(
+        "get-current-position",
+        "running",
+        { phase: "move-for-get-current-position", baseline },
+        "Move device location now; one-shot getCurrentPosition should return real coords."
+      );
+      return getCurrentPositionUntilExpected({
+        expected: expectedLocations.getCurrentPosition,
+        timeoutMs: 30000
+      });
+    },
+    (result) => assertPosition(result.position)
+  );
+
+  await runStep(
+    "watch-position",
+    async () => {
+      return watchUntilFirstEvent({
+        clearOnFirst: true,
+        timeoutMs: 30000,
+        acceptPosition: (nextPosition) =>
+          isNearExpected(nextPosition, expectedLocations.watchPosition),
+        onStarted: () => {
+          setScenario(
+            "watch-position",
+            "running",
+            {
+              phase: "move-for-watch-position",
+              baseline: position.position,
+              expected: expectedLocations.watchPosition
+            },
+            "Move device location now; the browser watch should emit the expected coordinate."
+          );
+        }
+      });
+    },
+    (result) => assertPosition(result.position)
   );
 
   await runStep(
     "unwatch",
     async () => {
-      const events: GeolocationResponse[] = [];
-      let token = "";
-      const firstEvent = new Promise<GeolocationResponse>((resolve, reject) => {
-        token = watchPosition(
-          (nextPosition) => {
-            events.push(nextPosition);
-            resolve(nextPosition);
-          },
-          reject,
-          { maximumAge: 0, timeout: 15000 }
-        );
+      const unwatchBaseline = await getCurrentPositionUntilSuccess(30000);
+      const { token, events, errors } = await watchUntilFirstEvent({
+        clearOnFirst: false,
+        timeoutMs: 30000,
+        acceptPosition: (nextPosition) =>
+          isNearExpected(nextPosition, expectedLocations.unwatchInitial),
+        onStarted: () => {
+          setScenario(
+            "unwatch",
+            "running",
+            {
+              phase: "move-for-unwatch-initial",
+              baseline: unwatchBaseline.position,
+              expected: expectedLocations.unwatchInitial
+            },
+            "Move device location now; the watcher should emit the expected coordinate before unwatch."
+          );
+        }
       });
-      await firstEvent;
       unwatch(token);
       const callbackCountAfterUnwatch = events.length;
       setScenario(
         "unwatch",
         "running",
-        { phase: "move-after-unwatch", token, callbackCountAfterUnwatch },
-        "Watcher emitted once and token was cleared. Move device location now; no extra callback should arrive."
+        {
+          phase: "move-after-unwatch",
+          token,
+          callbackCountAfterUnwatch,
+          expected: expectedLocations.unwatchAfterClear,
+          transientErrors: errors
+        },
+        "Watcher emitted once and token was cleared. Move device location now; a one-shot probe should see it without extra watch callbacks."
       );
-      await wait(5000);
+      const probeAfterUnwatch = await getCurrentPositionUntilExpected({
+        expected: expectedLocations.unwatchAfterClear,
+        timeoutMs: 30000
+      });
       return {
         token,
+        transientErrors: errors,
+        probeAfterUnwatch,
         callbackCountAfterUnwatch,
         callbackCount: events.length
       };
@@ -304,53 +530,74 @@ async function runSuccessSuite() {
   await runStep(
     "stop-observing",
     async () => {
-      const firstEvents: GeolocationResponse[] = [];
-      const secondEvents: GeolocationResponse[] = [];
-      let firstToken = "";
-      let secondToken = "";
-      const firstReady = new Promise<GeolocationResponse>((resolve, reject) => {
-        firstToken = watchPosition(
-          (nextPosition) => {
-            firstEvents.push(nextPosition);
-            resolve(nextPosition);
-          },
-          reject,
-          { maximumAge: 0, timeout: 15000 }
-        );
-      });
-      const secondReady = new Promise<GeolocationResponse>(
-        (resolve, reject) => {
-          secondToken = watchPosition(
-            (nextPosition) => {
-              secondEvents.push(nextPosition);
-              resolve(nextPosition);
-            },
-            reject,
-            { maximumAge: 0, timeout: 15000 }
-          );
+      const stopBaseline = await getCurrentPositionUntilSuccess(30000);
+      let startedWatchCount = 0;
+      const postStopInitialMoveRequest = () => {
+        startedWatchCount += 1;
+        if (startedWatchCount !== 2) {
+          return;
         }
-      );
-      await Promise.all([firstReady, secondReady]);
+        setScenario(
+          "stop-observing",
+          "running",
+          {
+            phase: "move-for-stop-observing-initial",
+            baseline: stopBaseline.position,
+            expected: expectedLocations.stopObservingInitial
+          },
+          "Move device location now; both watchers should emit the expected coordinate before stopObserving."
+        );
+      };
+      const [firstWatch, secondWatch] = await Promise.all([
+        watchUntilFirstEvent({
+          clearOnFirst: false,
+          timeoutMs: 30000,
+          acceptPosition: (nextPosition) =>
+            isNearExpected(
+              nextPosition,
+              expectedLocations.stopObservingInitial
+            ),
+          onStarted: postStopInitialMoveRequest
+        }),
+        watchUntilFirstEvent({
+          clearOnFirst: false,
+          timeoutMs: 30000,
+          acceptPosition: (nextPosition) =>
+            isNearExpected(
+              nextPosition,
+              expectedLocations.stopObservingInitial
+            ),
+          onStarted: postStopInitialMoveRequest
+        })
+      ]);
       stopObserving();
-      const callbackCountAfterStop = firstEvents.length + secondEvents.length;
+      const callbackCountAfterStop =
+        firstWatch.events.length + secondWatch.events.length;
       setScenario(
         "stop-observing",
         "running",
         {
           phase: "move-after-stop-observing",
-          firstToken,
-          secondToken,
-          callbackCountAfterStop
+          firstToken: firstWatch.token,
+          secondToken: secondWatch.token,
+          callbackCountAfterStop,
+          expected: expectedLocations.stopObservingAfterClear,
+          transientErrors: [...firstWatch.errors, ...secondWatch.errors]
         },
-        "Both watches emitted once and stopObserving cleared them. Move device location now; no extra callback should arrive."
+        "Both watches emitted once and stopObserving cleared them. Move device location now; a one-shot probe should see it without extra watch callbacks."
       );
-      await wait(5000);
+      const probeAfterStopObserving = await getCurrentPositionUntilExpected({
+        expected: expectedLocations.stopObservingAfterClear,
+        timeoutMs: 30000
+      });
       return {
-        firstToken,
-        secondToken,
+        firstToken: firstWatch.token,
+        secondToken: secondWatch.token,
+        transientErrors: [...firstWatch.errors, ...secondWatch.errors],
+        probeAfterStopObserving,
         callbackCountAfterStop,
-        callbackCount: firstEvents.length + secondEvents.length,
-        baseline: position
+        callbackCount: firstWatch.events.length + secondWatch.events.length,
+        baseline: position.position
       };
     },
     (result) => {
@@ -386,6 +633,7 @@ async function runSuccessSuite() {
         .join(", ")}`
     );
   }
+  postNativeStatus("success-suite", "pass");
 }
 
 async function runDeniedCheck() {

--- a/examples/web-e2e/src/main.ts
+++ b/examples/web-e2e/src/main.ts
@@ -1,0 +1,505 @@
+import {
+  checkPermission,
+  getCurrentPosition,
+  requestPermission,
+  stopObserving,
+  unwatch,
+  watchPosition
+} from "react-native-nitro-geolocation";
+import type {
+  GeolocationResponse,
+  LocationError,
+  PermissionStatus
+} from "react-native-nitro-geolocation";
+import "./styles.css";
+
+type ScenarioStatus = "idle" | "running" | "pass" | "fail" | "manual";
+
+type Scenario = {
+  id: string;
+  title: string;
+  detail: string;
+  status: ScenarioStatus;
+  raw?: unknown;
+};
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage(message: string): void;
+    };
+  }
+}
+
+const scenarios: Scenario[] = [
+  {
+    id: "api-availability",
+    title: "API availability",
+    detail: "Root browser export exposes Modern API functions.",
+    status: "idle"
+  },
+  {
+    id: "check-permission",
+    title: "checkPermission",
+    detail: "Reads browser permission state when Permissions API exists.",
+    status: "idle"
+  },
+  {
+    id: "request-permission",
+    title: "requestPermission",
+    detail: "Triggers browser prompt with one-shot geolocation call.",
+    status: "idle"
+  },
+  {
+    id: "get-current-position",
+    title: "getCurrentPosition",
+    detail: "Returns coords and timestamp from navigator.geolocation.",
+    status: "idle"
+  },
+  {
+    id: "watch-position",
+    title: "watchPosition emits update",
+    detail: "Starts real browser watch and receives normalized coords.",
+    status: "idle"
+  },
+  {
+    id: "unwatch",
+    title: "unwatch stops watcher",
+    detail: "Clears single watch token without later callback.",
+    status: "idle"
+  },
+  {
+    id: "stop-observing",
+    title: "stopObserving clears watchers",
+    detail: "Clears all active web watch tokens.",
+    status: "idle"
+  },
+  {
+    id: "permission-denied",
+    title: "permission denied -> PERMISSION_DENIED",
+    detail: "Run with browser geolocation permission blocked.",
+    status: "idle"
+  },
+  {
+    id: "position-unavailable",
+    title: "provider unavailable -> POSITION_UNAVAILABLE",
+    detail: "Run with permission granted but no browser provider/location.",
+    status: "manual"
+  },
+  {
+    id: "timeout",
+    title: "strict timeout -> TIMEOUT",
+    detail: "Manual/non-blocking because browsers may return cached location.",
+    status: "manual"
+  }
+];
+
+const grid = document.querySelector<HTMLDivElement>("#scenario-grid");
+const successButton = document.querySelector<HTMLButtonElement>("#run-success");
+const deniedButton = document.querySelector<HTMLButtonElement>("#run-denied");
+const unavailableButton =
+  document.querySelector<HTMLButtonElement>("#run-unavailable");
+const timeoutButton = document.querySelector<HTMLButtonElement>("#run-timeout");
+const clearButton = document.querySelector<HTMLButtonElement>("#clear-results");
+
+function render() {
+  if (!grid) {
+    return;
+  }
+
+  grid.innerHTML = scenarios
+    .map(
+      (scenario) => `
+        <article class="scenario ${scenario.status}" data-testid="${scenario.id}">
+          <div>
+            <span class="badge">${scenario.status.toUpperCase()}</span>
+            <h2>${scenario.title}</h2>
+            <p>${scenario.detail}</p>
+          </div>
+          <pre>${escapeHtml(JSON.stringify(scenario.raw ?? null, null, 2))}</pre>
+        </article>
+      `
+    )
+    .join("");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function setScenario(
+  id: string,
+  status: ScenarioStatus,
+  raw?: unknown,
+  detail?: string
+) {
+  const scenario = scenarios.find((item) => item.id === id);
+  if (!scenario) {
+    return;
+  }
+
+  scenario.status = status;
+  scenario.raw = raw;
+  if (detail) {
+    scenario.detail = detail;
+  }
+  render();
+  window.ReactNativeWebView?.postMessage(
+    JSON.stringify({
+      id,
+      status,
+      detail: scenario.detail,
+      raw
+    })
+  );
+  if (status !== "idle") {
+    document
+      .querySelector(`[data-testid="${id}"]`)
+      ?.scrollIntoView({ block: "center", behavior: "auto" });
+  }
+}
+
+function assertPosition(position: GeolocationResponse) {
+  if (
+    typeof position.coords.latitude !== "number" ||
+    typeof position.coords.longitude !== "number" ||
+    typeof position.coords.accuracy !== "number" ||
+    typeof position.timestamp !== "number"
+  ) {
+    throw new Error("Position missing numeric coords/timestamp.");
+  }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getErrorCode(error: unknown): number | undefined {
+  return (error as Partial<LocationError>).code;
+}
+
+async function runStep<T>(
+  id: string,
+  action: () => Promise<T>,
+  validate: (value: T) => void = () => undefined
+) {
+  setScenario(id, "running");
+  try {
+    const result = await action();
+    validate(result);
+    setScenario(id, "pass", result);
+    return result;
+  } catch (error) {
+    setScenario(id, "fail", error);
+    throw error;
+  }
+}
+
+async function runSuccessSuite() {
+  setScenario("api-availability", "running");
+  const apiShape = {
+    checkPermission: typeof checkPermission,
+    requestPermission: typeof requestPermission,
+    getCurrentPosition: typeof getCurrentPosition,
+    watchPosition: typeof watchPosition,
+    unwatch: typeof unwatch,
+    stopObserving: typeof stopObserving
+  };
+  const apiReady = Object.values(apiShape).every((type) => type === "function");
+  setScenario("api-availability", apiReady ? "pass" : "fail", apiShape);
+  if (!apiReady) {
+    throw new Error("Modern API browser export is incomplete.");
+  }
+
+  await runStep<PermissionStatus>(
+    "check-permission",
+    () => checkPermission(),
+    (status) => {
+      if (
+        !["granted", "denied", "restricted", "undetermined"].includes(status)
+      ) {
+        throw new Error(`Unexpected permission status: ${status}`);
+      }
+    }
+  );
+
+  await runStep<PermissionStatus>(
+    "request-permission",
+    () => requestPermission(),
+    (status) => {
+      if (status !== "granted") {
+        throw new Error(`Expected granted permission, got ${status}.`);
+      }
+    }
+  );
+
+  await runStep(
+    "watch-position",
+    () =>
+      new Promise<GeolocationResponse>((resolve, reject) => {
+        const token = watchPosition(
+          (nextPosition) => {
+            unwatch(token);
+            resolve(nextPosition);
+          },
+          reject,
+          { maximumAge: 0, timeout: 15000 }
+        );
+      }),
+    assertPosition
+  );
+
+  const position = await runStep(
+    "get-current-position",
+    () => getCurrentPosition({ maximumAge: 0, timeout: 15000 }),
+    assertPosition
+  );
+
+  await runStep(
+    "unwatch",
+    async () => {
+      const events: GeolocationResponse[] = [];
+      let token = "";
+      const firstEvent = new Promise<GeolocationResponse>((resolve, reject) => {
+        token = watchPosition(
+          (nextPosition) => {
+            events.push(nextPosition);
+            resolve(nextPosition);
+          },
+          reject,
+          { maximumAge: 0, timeout: 15000 }
+        );
+      });
+      await firstEvent;
+      unwatch(token);
+      const callbackCountAfterUnwatch = events.length;
+      setScenario(
+        "unwatch",
+        "running",
+        { phase: "move-after-unwatch", token, callbackCountAfterUnwatch },
+        "Watcher emitted once and token was cleared. Move device location now; no extra callback should arrive."
+      );
+      await wait(5000);
+      return {
+        token,
+        callbackCountAfterUnwatch,
+        callbackCount: events.length
+      };
+    },
+    (result) => {
+      if (result.callbackCountAfterUnwatch < 1) {
+        throw new Error("Expected unwatch scenario to prove an active watch.");
+      }
+      if (result.callbackCount !== result.callbackCountAfterUnwatch) {
+        throw new Error(
+          `Expected unwatch to prevent callbacks, got ${result.callbackCount}.`
+        );
+      }
+    }
+  );
+
+  await runStep(
+    "stop-observing",
+    async () => {
+      const firstEvents: GeolocationResponse[] = [];
+      const secondEvents: GeolocationResponse[] = [];
+      let firstToken = "";
+      let secondToken = "";
+      const firstReady = new Promise<GeolocationResponse>((resolve, reject) => {
+        firstToken = watchPosition(
+          (nextPosition) => {
+            firstEvents.push(nextPosition);
+            resolve(nextPosition);
+          },
+          reject,
+          { maximumAge: 0, timeout: 15000 }
+        );
+      });
+      const secondReady = new Promise<GeolocationResponse>(
+        (resolve, reject) => {
+          secondToken = watchPosition(
+            (nextPosition) => {
+              secondEvents.push(nextPosition);
+              resolve(nextPosition);
+            },
+            reject,
+            { maximumAge: 0, timeout: 15000 }
+          );
+        }
+      );
+      await Promise.all([firstReady, secondReady]);
+      stopObserving();
+      const callbackCountAfterStop = firstEvents.length + secondEvents.length;
+      setScenario(
+        "stop-observing",
+        "running",
+        {
+          phase: "move-after-stop-observing",
+          firstToken,
+          secondToken,
+          callbackCountAfterStop
+        },
+        "Both watches emitted once and stopObserving cleared them. Move device location now; no extra callback should arrive."
+      );
+      await wait(5000);
+      return {
+        firstToken,
+        secondToken,
+        callbackCountAfterStop,
+        callbackCount: firstEvents.length + secondEvents.length,
+        baseline: position
+      };
+    },
+    (result) => {
+      if (result.callbackCountAfterStop < 2) {
+        throw new Error(
+          "Expected stopObserving scenario to prove active watches."
+        );
+      }
+      if (result.callbackCount !== result.callbackCountAfterStop) {
+        throw new Error(
+          `Expected stopObserving to prevent callbacks, got ${result.callbackCount}.`
+        );
+      }
+    }
+  );
+
+  const failedScenarios = scenarios.filter(
+    (scenario) =>
+      [
+        "api-availability",
+        "check-permission",
+        "request-permission",
+        "get-current-position",
+        "watch-position",
+        "unwatch",
+        "stop-observing"
+      ].includes(scenario.id) && scenario.status !== "pass"
+  );
+  if (failedScenarios.length > 0) {
+    throw new Error(
+      `Success suite incomplete: ${failedScenarios
+        .map((scenario) => scenario.id)
+        .join(", ")}`
+    );
+  }
+}
+
+async function runDeniedCheck() {
+  setScenario("permission-denied", "running");
+  try {
+    await getCurrentPosition({ maximumAge: 0, timeout: 5000 });
+    setScenario(
+      "permission-denied",
+      "fail",
+      { code: "resolved" },
+      "Expected browser permission to be blocked, but request resolved."
+    );
+  } catch (error) {
+    const code = getErrorCode(error);
+    setScenario(
+      "permission-denied",
+      code === 1 ? "pass" : "fail",
+      error,
+      code === 1
+        ? "Browser returned PERMISSION_DENIED."
+        : `Expected PERMISSION_DENIED code 1, got ${String(code)}.`
+    );
+  }
+}
+
+async function runUnavailableCheck() {
+  setScenario("position-unavailable", "running");
+  try {
+    const positionResult = await getCurrentPosition({
+      enableHighAccuracy: true,
+      maximumAge: 0,
+      timeout: 10000
+    });
+    setScenario(
+      "position-unavailable",
+      "fail",
+      positionResult,
+      "Expected provider/location services to be unavailable, but browser returned a position."
+    );
+  } catch (error) {
+    const code = getErrorCode(error);
+    const status = code === 2 ? "pass" : code === 3 ? "manual" : "fail";
+    setScenario(
+      "position-unavailable",
+      status,
+      error,
+      code === 2
+        ? "Browser returned POSITION_UNAVAILABLE."
+        : code === 3
+          ? "Browser returned TIMEOUT while provider/location services were disabled. Platform does not expose provider-disabled state."
+          : `Expected POSITION_UNAVAILABLE or platform TIMEOUT, got ${String(code)}.`
+    );
+  }
+}
+
+async function runTimeoutCheck() {
+  setScenario("timeout", "running");
+  try {
+    await getCurrentPosition({
+      enableHighAccuracy: true,
+      maximumAge: 0,
+      timeout: 1
+    });
+    setScenario(
+      "timeout",
+      "manual",
+      { code: "resolved" },
+      "Browser returned cached/fresh location before strict timeout."
+    );
+  } catch (error) {
+    const code = getErrorCode(error);
+    setScenario(
+      "timeout",
+      code === 3 ? "pass" : "manual",
+      error,
+      code === 3
+        ? "Browser returned TIMEOUT."
+        : `Got ${String(code)}. Timeout is browser/provider timing dependent.`
+    );
+  }
+}
+
+successButton?.addEventListener("click", () => {
+  void runSuccessSuite();
+});
+deniedButton?.addEventListener("click", () => {
+  void runDeniedCheck();
+});
+unavailableButton?.addEventListener("click", () => {
+  void runUnavailableCheck();
+});
+timeoutButton?.addEventListener("click", () => {
+  void runTimeoutCheck();
+});
+clearButton?.addEventListener("click", () => {
+  for (const scenario of scenarios) {
+    scenario.status =
+      scenario.id === "position-unavailable" || scenario.id === "timeout"
+        ? "manual"
+        : "idle";
+    scenario.raw = undefined;
+  }
+  render();
+});
+
+render();
+
+const params = new URLSearchParams(location.search);
+if (params.get("autorun") === "success") {
+  void runSuccessSuite();
+} else if (params.get("autorun") === "denied") {
+  void runDeniedCheck();
+} else if (params.get("autorun") === "unavailable") {
+  void runUnavailableCheck();
+} else if (params.get("autorun") === "timeout") {
+  void runTimeoutCheck();
+}

--- a/examples/web-e2e/src/styles.css
+++ b/examples/web-e2e/src/styles.css
@@ -1,0 +1,140 @@
+:root {
+  color: #17202a;
+  background: #f4f7f8;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.shell {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 32px;
+  line-height: 1.15;
+}
+
+header p {
+  color: #4c5963;
+  font-size: 16px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+button {
+  min-height: 40px;
+  border: 1px solid #a9b5bd;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #17202a;
+  cursor: pointer;
+  font: inherit;
+  padding: 0 14px;
+}
+
+button:hover {
+  border-color: #1267a8;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.scenario {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 12px;
+  min-height: 240px;
+  border: 1px solid #cbd4da;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 14px;
+}
+
+.scenario h2 {
+  margin-top: 8px;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.scenario p {
+  margin-top: 6px;
+  color: #52616d;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 999px;
+  background: #e5e9ec;
+  color: #36424c;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 0 9px;
+}
+
+.running .badge {
+  background: #fff1cc;
+  color: #6b4d00;
+}
+
+.pass .badge {
+  background: #d8f5df;
+  color: #146b2e;
+}
+
+.fail .badge {
+  background: #ffe0de;
+  color: #9c2018;
+}
+
+.manual .badge {
+  background: #dbeafe;
+  color: #164a88;
+}
+
+pre {
+  overflow: auto;
+  min-height: 110px;
+  margin: 0;
+  border-radius: 6px;
+  background: #111820;
+  color: #d9e7ef;
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 10px;
+  white-space: pre-wrap;
+}

--- a/examples/web-e2e/vite.config.ts
+++ b/examples/web-e2e/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  resolve: {
+    conditions: ["browser", "import", "module", "default"]
+  }
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "biome ci --formatter-enabled=false --linter-enabled=true .",
     "lint:fix": "biome check --write .",
     "test:unit": "yarn workspace react-native-nitro-geolocation test",
+    "test:e2e:web": "yarn workspace react-native-nitro-geolocation-web-e2e build",
     "test:e2e:android": "yarn workspace react-native-nitro-geolocation-example test:e2e:android",
     "test:e2e:ios": "yarn workspace react-native-nitro-geolocation-example test:e2e:ios"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "lint:fix": "biome check --write .",
     "test:unit": "yarn workspace react-native-nitro-geolocation test",
     "test:e2e:web": "yarn workspace react-native-nitro-geolocation-web-e2e build",
+    "test:e2e:web:android": "yarn workspace react-native-nitro-geolocation-example test:e2e:web:android",
+    "test:e2e:web:ios": "yarn workspace react-native-nitro-geolocation-example test:e2e:web:ios",
     "test:e2e:android": "yarn workspace react-native-nitro-geolocation-example test:e2e:android",
     "test:e2e:ios": "yarn workspace react-native-nitro-geolocation-example test:e2e:ios"
   },

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -4,9 +4,13 @@
   "description": "Nitro-powered native geolocation for modern React Native apps",
   "main": "src/index",
   "source": "src/index",
+  "browser": "src/index.web.tsx",
+  "react-native": "src/index.tsx",
   "exports": {
     ".": {
       "types": "./src/index.tsx",
+      "browser": "./src/index.web.tsx",
+      "react-native": "./src/index.tsx",
       "default": "./src/index.tsx"
     },
     "./compat": {

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -1,0 +1,40 @@
+/**
+ * Browser implementation for the Modern API.
+ *
+ * This entry intentionally avoids Nitro native imports so web bundlers can use
+ * the package root without loading native bindings.
+ */
+
+export * from "./web";
+
+export type {
+  PermissionStatus,
+  LocationRequestOptions,
+  LocationSettingsOptions,
+  LocationError
+} from "./NitroGeolocation.nitro";
+
+export type {
+  GeolocationResponse,
+  GeolocationCoordinates,
+  LocationProviderStatus,
+  LocationAvailability,
+  GeocodingCoordinates,
+  GeocodedLocation,
+  ReverseGeocodedAddress,
+  AndroidAccuracyPreset,
+  AndroidGranularity,
+  IOSAccuracyPreset,
+  AccuracyAuthorization,
+  IOSActivityType,
+  LocationAccuracyOptions,
+  Heading,
+  HeadingOptions,
+  AuthorizationLevel,
+  LocationProvider,
+  LocationProviderUsed,
+  GeolocationConfiguration,
+  ModernGeolocationConfiguration
+} from "./publicTypes";
+
+export * from "./utils";

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  checkPermission,
+  getCurrentPosition,
+  requestPermission,
+  stopObserving,
+  unwatch,
+  watchPosition
+} from ".";
+
+type TestNavigator = {
+  geolocation?: {
+    getCurrentPosition: ReturnType<typeof vi.fn>;
+    watchPosition: ReturnType<typeof vi.fn>;
+    clearWatch: ReturnType<typeof vi.fn>;
+  };
+  permissions?: {
+    query: ReturnType<typeof vi.fn>;
+  };
+};
+
+function setNavigator(navigatorValue: TestNavigator | undefined) {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: navigatorValue
+  });
+}
+
+function createPosition(latitude = 37.5665, longitude = 126.978) {
+  return {
+    coords: {
+      latitude,
+      longitude,
+      altitude: undefined,
+      accuracy: 11,
+      altitudeAccuracy: undefined,
+      heading: undefined,
+      speed: undefined
+    },
+    timestamp: 1779015190000
+  };
+}
+
+afterEach(() => {
+  stopObserving();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(globalThis, "navigator");
+});
+
+describe("web Modern API", () => {
+  it("wraps navigator.geolocation.getCurrentPosition and normalizes nullable coords", async () => {
+    const getCurrentPositionMock = vi.fn((success) => {
+      success(createPosition());
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(
+      getCurrentPosition({ enableHighAccuracy: true, timeout: 1234 })
+    ).resolves.toEqual({
+      coords: {
+        latitude: 37.5665,
+        longitude: 126.978,
+        altitude: null,
+        accuracy: 11,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null
+      },
+      timestamp: 1779015190000,
+      provider: "unknown"
+    });
+    expect(getCurrentPositionMock.mock.calls[0][2]).toEqual({
+      enableHighAccuracy: true,
+      timeout: 1234,
+      maximumAge: undefined
+    });
+  });
+
+  it("maps browser error codes to Modern API LocationError codes", async () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn((_success, error) => {
+          error({ code: 1, message: "denied" });
+        }),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(getCurrentPosition()).rejects.toEqual({
+      code: 1,
+      message: "denied"
+    });
+  });
+
+  it("uses permissions.query when checkPermission can read geolocation state", async () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      },
+      permissions: {
+        query: vi.fn(async () => ({ state: "prompt" }))
+      }
+    });
+
+    await expect(checkPermission()).resolves.toBe("undetermined");
+  });
+
+  it("requests permission with a one-shot geolocation call", async () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn((success) => {
+          success(createPosition());
+        }),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(requestPermission()).resolves.toBe("granted");
+  });
+
+  it("tracks web watch tokens and clears individual/all watchers", () => {
+    const clearWatch = vi.fn();
+    const watchPositionMock = vi
+      .fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(11);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchPositionMock,
+        clearWatch
+      }
+    });
+
+    const firstToken = watchPosition(vi.fn());
+    const secondToken = watchPosition(vi.fn());
+
+    expect(firstToken).toMatch(/^web-/);
+    expect(secondToken).toMatch(/^web-/);
+    unwatch(firstToken);
+    expect(clearWatch).toHaveBeenCalledWith(10);
+
+    stopObserving();
+    expect(clearWatch).toHaveBeenCalledWith(11);
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkPermission,
   getCurrentPosition,
+  getLastKnownPosition,
   requestPermission,
   stopObserving,
   unwatch,
@@ -125,6 +126,28 @@ describe("web Modern API", () => {
     await expect(getCurrentPosition()).rejects.toEqual({
       code: 1,
       message: "denied"
+    });
+  });
+
+  it("maps getLastKnownPosition cache miss to POSITION_UNAVAILABLE", async () => {
+    const getCurrentPositionMock = vi.fn((_success, error) => {
+      error({ code: 3, message: "Timeout expired" });
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(getLastKnownPosition()).rejects.toEqual({
+      code: 2,
+      message: "No cached browser location is available."
+    });
+    expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
+      maximumAge: Number.POSITIVE_INFINITY,
+      timeout: 0
     });
   });
 

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -3,6 +3,7 @@ import {
   checkPermission,
   getCurrentPosition,
   getLastKnownPosition,
+  getLocationAvailability,
   requestPermission,
   stopObserving,
   unwatch,
@@ -184,6 +185,24 @@ describe("web Modern API", () => {
     });
 
     await expect(checkPermission()).resolves.toBe("undetermined");
+  });
+
+  it("marks location unavailable when browser permission is denied", async () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      },
+      permissions: {
+        query: vi.fn(async () => ({ state: "denied" }))
+      }
+    });
+
+    await expect(getLocationAvailability()).resolves.toEqual({
+      available: false,
+      reason: "Browser geolocation permission is denied."
+    });
   });
 
   it("requests permission with a one-shot geolocation call", async () => {

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -82,6 +82,35 @@ describe("web Modern API", () => {
     });
   });
 
+  it("lets explicit Android accuracy override legacy enableHighAccuracy", async () => {
+    const getCurrentPositionMock = vi.fn((success) => {
+      success(createPosition());
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await getCurrentPosition({
+      enableHighAccuracy: false,
+      accuracy: { android: "high" }
+    });
+    expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
+      enableHighAccuracy: true
+    });
+
+    await getCurrentPosition({
+      enableHighAccuracy: true,
+      accuracy: { android: "low" }
+    });
+    expect(getCurrentPositionMock.mock.calls[1][2]).toMatchObject({
+      enableHighAccuracy: false
+    });
+  });
+
   it("maps browser error codes to Modern API LocationError codes", async () => {
     setNavigator({
       geolocation: {

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -79,7 +79,27 @@ describe("web Modern API", () => {
     expect(getCurrentPositionMock.mock.calls[0][2]).toEqual({
       enableHighAccuracy: true,
       timeout: 1234,
-      maximumAge: undefined
+      maximumAge: 0
+    });
+  });
+
+  it("applies Modern API default browser position options", async () => {
+    const getCurrentPositionMock = vi.fn((success) => {
+      success(createPosition());
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await getCurrentPosition();
+    expect(getCurrentPositionMock.mock.calls[0][2]).toEqual({
+      enableHighAccuracy: undefined,
+      timeout: 600000,
+      maximumAge: 0
     });
   });
 
@@ -199,6 +219,11 @@ describe("web Modern API", () => {
 
     expect(firstToken).toMatch(/^web-/);
     expect(secondToken).toMatch(/^web-/);
+    expect(watchPositionMock.mock.calls[0][2]).toEqual({
+      enableHighAccuracy: undefined,
+      timeout: 600000,
+      maximumAge: 0
+    });
     unwatch(firstToken);
     expect(clearWatch).toHaveBeenCalledWith(10);
 

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -285,7 +285,17 @@ export function getLastKnownPosition(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse> {
   const maximumAge = options?.maximumAge ?? Number.POSITIVE_INFINITY;
-  return getCurrentPosition({ ...options, maximumAge, timeout: 0 });
+  return getCurrentPosition({ ...options, maximumAge, timeout: 0 }).catch(
+    (error) => {
+      if ((error as LocationError).code === LocationErrorCode.TIMEOUT) {
+        throw createLocationError(
+          LocationErrorCode.POSITION_UNAVAILABLE,
+          "No cached browser location is available."
+        );
+      }
+      throw error;
+    }
+  );
 }
 
 export function geocode(_address: string): Promise<GeocodedLocation[]> {

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -235,12 +235,23 @@ export function getProviderStatus(): Promise<LocationProviderStatus> {
   });
 }
 
-export function getLocationAvailability(): Promise<LocationAvailability> {
-  const available = Boolean(getGeolocation());
-  return Promise.resolve({
-    available,
-    reason: available ? undefined : createUnsupportedError().message
-  });
+export async function getLocationAvailability(): Promise<LocationAvailability> {
+  if (!getGeolocation()) {
+    return {
+      available: false,
+      reason: createUnsupportedError().message
+    };
+  }
+
+  const permission = await checkPermission();
+  if (permission === "denied" || permission === "restricted") {
+    return {
+      available: false,
+      reason: "Browser geolocation permission is denied."
+    };
+  }
+
+  return { available: true };
 }
 
 export function requestLocationSettings(

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -79,6 +79,7 @@ export interface UseWatchPositionOptions extends LocationRequestOptions {
 }
 
 const activeWatches = new Map<string, number>();
+const defaultTimeoutMs = 600000;
 let nextWatchId = 1;
 
 function getNavigator(): BrowserNavigator | undefined {
@@ -93,20 +94,16 @@ function getGeolocation(): BrowserGeolocation | undefined {
 
 function toPositionOptions(
   options?: LocationRequestOptions
-): BrowserPositionOptions | undefined {
-  if (!options) {
-    return undefined;
-  }
-
-  const androidAccuracy = options.accuracy?.android;
+): BrowserPositionOptions {
+  const androidAccuracy = options?.accuracy?.android;
 
   return {
     enableHighAccuracy:
       androidAccuracy !== undefined
         ? androidAccuracy === "high"
-        : options.enableHighAccuracy,
-    timeout: options.timeout,
-    maximumAge: options.maximumAge
+        : options?.enableHighAccuracy,
+    timeout: options?.timeout ?? defaultTimeoutMs,
+    maximumAge: options?.maximumAge ?? 0
   };
 }
 

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -98,9 +98,13 @@ function toPositionOptions(
     return undefined;
   }
 
+  const androidAccuracy = options.accuracy?.android;
+
   return {
     enableHighAccuracy:
-      options.enableHighAccuracy ?? options.accuracy?.android === "high",
+      androidAccuracy !== undefined
+        ? androidAccuracy === "high"
+        : options.enableHighAccuracy,
     timeout: options.timeout,
     maximumAge: options.maximumAge
   };

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -364,7 +364,20 @@ export function useWatchPosition(options?: UseWatchPositionOptions) {
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);
   const tokenRef = useRef<string | null>(null);
+  const isMountedRef = useRef(true);
+  const optionsRef = useRef(options);
   const enabled = options?.enabled ?? false;
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!enabled) {
@@ -378,15 +391,33 @@ export function useWatchPosition(options?: UseWatchPositionOptions) {
 
     setIsWatching(true);
     setError(null);
-    tokenRef.current = watchPosition(setPosition, setError, options);
+    const token = watchPosition(
+      (nextPosition) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setPosition(nextPosition);
+        setError(null);
+      },
+      (nextError) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setError(nextError);
+      },
+      optionsRef.current
+    );
+    tokenRef.current = token;
 
     return () => {
-      if (tokenRef.current) {
-        unwatch(tokenRef.current);
+      if (token) {
+        unwatch(token);
+      }
+      if (tokenRef.current === token) {
         tokenRef.current = null;
       }
     };
-  }, [enabled, options]);
+  }, [enabled]);
 
   return {
     position,

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -1,0 +1,396 @@
+import { useEffect, useRef, useState } from "react";
+import type {
+  LocationError,
+  LocationRequestOptions,
+  LocationSettingsOptions,
+  PermissionStatus
+} from "../NitroGeolocation.nitro";
+import type {
+  AccuracyAuthorization,
+  GeocodedLocation,
+  GeocodingCoordinates,
+  GeolocationConfiguration,
+  GeolocationResponse,
+  Heading,
+  HeadingOptions,
+  LocationAvailability,
+  LocationProviderStatus,
+  ReverseGeocodedAddress
+} from "../publicTypes";
+import { LocationErrorCode, createLocationError } from "../utils/errors";
+
+type BrowserPermissionState = "granted" | "denied" | "prompt";
+
+type BrowserPermissionStatus = {
+  state: BrowserPermissionState;
+};
+
+type BrowserPermissions = {
+  query(descriptor: { name: "geolocation" }): Promise<BrowserPermissionStatus>;
+};
+
+type BrowserCoordinates = {
+  latitude: number;
+  longitude: number;
+  altitude: number | null;
+  accuracy: number;
+  altitudeAccuracy: number | null;
+  heading: number | null;
+  speed: number | null;
+};
+
+type BrowserPosition = {
+  coords: BrowserCoordinates;
+  timestamp: number;
+};
+
+type BrowserPositionError = {
+  code: number;
+  message: string;
+};
+
+type BrowserGeolocation = {
+  getCurrentPosition(
+    success: (position: BrowserPosition) => void,
+    error?: (error: BrowserPositionError) => void,
+    options?: BrowserPositionOptions
+  ): void;
+  watchPosition(
+    success: (position: BrowserPosition) => void,
+    error?: (error: BrowserPositionError) => void,
+    options?: BrowserPositionOptions
+  ): number;
+  clearWatch(watchId: number): void;
+};
+
+type BrowserPositionOptions = {
+  enableHighAccuracy?: boolean;
+  timeout?: number;
+  maximumAge?: number;
+};
+
+type BrowserNavigator = {
+  geolocation?: BrowserGeolocation;
+  permissions?: BrowserPermissions;
+};
+
+export interface UseWatchPositionOptions extends LocationRequestOptions {
+  enabled?: boolean;
+}
+
+const activeWatches = new Map<string, number>();
+let nextWatchId = 1;
+
+function getNavigator(): BrowserNavigator | undefined {
+  const globalNavigator = (globalThis as { navigator?: BrowserNavigator })
+    .navigator;
+  return globalNavigator;
+}
+
+function getGeolocation(): BrowserGeolocation | undefined {
+  return getNavigator()?.geolocation;
+}
+
+function toPositionOptions(
+  options?: LocationRequestOptions
+): BrowserPositionOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  return {
+    enableHighAccuracy:
+      options.enableHighAccuracy ?? options.accuracy?.android === "high",
+    timeout: options.timeout,
+    maximumAge: options.maximumAge
+  };
+}
+
+function normalizePosition(position: BrowserPosition): GeolocationResponse {
+  return {
+    coords: {
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+      altitude: position.coords.altitude ?? null,
+      accuracy: position.coords.accuracy,
+      altitudeAccuracy: position.coords.altitudeAccuracy ?? null,
+      heading: position.coords.heading ?? null,
+      speed: position.coords.speed ?? null
+    },
+    timestamp: position.timestamp,
+    provider: "unknown"
+  };
+}
+
+function mapPermissionState(state: BrowserPermissionState): PermissionStatus {
+  if (state === "granted") {
+    return "granted";
+  }
+  if (state === "denied") {
+    return "denied";
+  }
+  return "undetermined";
+}
+
+function createUnsupportedError(): LocationError {
+  return createLocationError(
+    LocationErrorCode.POSITION_UNAVAILABLE,
+    "Browser geolocation is unavailable. Use a secure context and a browser that supports navigator.geolocation."
+  );
+}
+
+function mapBrowserError(error: BrowserPositionError): LocationError {
+  switch (error.code) {
+    case 1:
+      return createLocationError(
+        LocationErrorCode.PERMISSION_DENIED,
+        error.message || "User denied geolocation permission."
+      );
+    case 3:
+      return createLocationError(
+        LocationErrorCode.TIMEOUT,
+        error.message || "Geolocation request timed out."
+      );
+    default:
+      return createLocationError(
+        LocationErrorCode.POSITION_UNAVAILABLE,
+        error.message || "Position is unavailable."
+      );
+  }
+}
+
+function rejectUnsupported<T>(): Promise<T> {
+  return Promise.reject(createUnsupportedError());
+}
+
+function distanceMeters(
+  first: GeolocationResponse,
+  second: GeolocationResponse
+): number {
+  const earthRadiusMeters = 6371000;
+  const lat1 = (first.coords.latitude * Math.PI) / 180;
+  const lat2 = (second.coords.latitude * Math.PI) / 180;
+  const deltaLat =
+    ((second.coords.latitude - first.coords.latitude) * Math.PI) / 180;
+  const deltaLon =
+    ((second.coords.longitude - first.coords.longitude) * Math.PI) / 180;
+
+  const a =
+    Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+    Math.cos(lat1) *
+      Math.cos(lat2) *
+      Math.sin(deltaLon / 2) *
+      Math.sin(deltaLon / 2);
+
+  return earthRadiusMeters * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function setConfiguration(_config: GeolocationConfiguration): void {
+  // Browser geolocation has no global configuration API.
+}
+
+export async function checkPermission(): Promise<PermissionStatus> {
+  const browserNavigator = getNavigator();
+  if (!browserNavigator?.geolocation) {
+    return "denied";
+  }
+
+  try {
+    const status = await browserNavigator.permissions?.query({
+      name: "geolocation"
+    });
+    return status ? mapPermissionState(status.state) : "undetermined";
+  } catch {
+    return "undetermined";
+  }
+}
+
+export async function requestPermission(): Promise<PermissionStatus> {
+  const currentStatus = await checkPermission();
+  if (currentStatus === "granted" || currentStatus === "denied") {
+    return currentStatus;
+  }
+
+  try {
+    await getCurrentPosition({ maximumAge: 0, timeout: 10000 });
+    return "granted";
+  } catch (error) {
+    if ((error as LocationError).code === LocationErrorCode.PERMISSION_DENIED) {
+      return "denied";
+    }
+    return checkPermission();
+  }
+}
+
+export function hasServicesEnabled(): Promise<boolean> {
+  return Promise.resolve(Boolean(getGeolocation()));
+}
+
+export function getProviderStatus(): Promise<LocationProviderStatus> {
+  const enabled = Boolean(getGeolocation());
+  return Promise.resolve({
+    locationServicesEnabled: enabled,
+    backgroundModeEnabled: false
+  });
+}
+
+export function getLocationAvailability(): Promise<LocationAvailability> {
+  const available = Boolean(getGeolocation());
+  return Promise.resolve({
+    available,
+    reason: available ? undefined : createUnsupportedError().message
+  });
+}
+
+export function requestLocationSettings(
+  _options?: LocationSettingsOptions
+): Promise<LocationProviderStatus> {
+  return getProviderStatus();
+}
+
+export function getAccuracyAuthorization(): Promise<AccuracyAuthorization> {
+  return checkPermission().then((status) =>
+    status === "granted" ? "full" : "unknown"
+  );
+}
+
+export function requestTemporaryFullAccuracy(
+  _purposeKey: string
+): Promise<AccuracyAuthorization> {
+  return getAccuracyAuthorization();
+}
+
+export function getCurrentPosition(
+  options?: LocationRequestOptions
+): Promise<GeolocationResponse> {
+  const geolocation = getGeolocation();
+  if (!geolocation) {
+    return rejectUnsupported();
+  }
+
+  return new Promise((resolve, reject) => {
+    geolocation.getCurrentPosition(
+      (position) => resolve(normalizePosition(position)),
+      (error) => reject(mapBrowserError(error)),
+      toPositionOptions(options)
+    );
+  });
+}
+
+export function getLastKnownPosition(
+  options?: LocationRequestOptions
+): Promise<GeolocationResponse> {
+  const maximumAge = options?.maximumAge ?? Number.POSITIVE_INFINITY;
+  return getCurrentPosition({ ...options, maximumAge, timeout: 0 });
+}
+
+export function geocode(_address: string): Promise<GeocodedLocation[]> {
+  return rejectUnsupported();
+}
+
+export function reverseGeocode(
+  _coords: GeocodingCoordinates
+): Promise<ReverseGeocodedAddress[]> {
+  return rejectUnsupported();
+}
+
+export function getHeading(): Promise<Heading> {
+  return rejectUnsupported();
+}
+
+export function watchHeading(
+  _success: (heading: Heading) => void,
+  error?: (error: LocationError) => void,
+  _options?: HeadingOptions
+): string {
+  const token = `web-heading-${nextWatchId++}`;
+  error?.(createUnsupportedError());
+  return token;
+}
+
+export function watchPosition(
+  success: (position: GeolocationResponse) => void,
+  error?: (error: LocationError) => void,
+  options?: LocationRequestOptions
+): string {
+  const geolocation = getGeolocation();
+  const token = `web-${nextWatchId++}`;
+
+  if (!geolocation) {
+    error?.(createUnsupportedError());
+    return token;
+  }
+
+  let lastEmitted: GeolocationResponse | null = null;
+  const watchId = geolocation.watchPosition(
+    (position) => {
+      const normalizedPosition = normalizePosition(position);
+      const filter = options?.distanceFilter ?? 0;
+      if (
+        filter <= 0 ||
+        !lastEmitted ||
+        distanceMeters(lastEmitted, normalizedPosition) >= filter
+      ) {
+        lastEmitted = normalizedPosition;
+        success(normalizedPosition);
+      }
+    },
+    (browserError) => error?.(mapBrowserError(browserError)),
+    toPositionOptions(options)
+  );
+
+  activeWatches.set(token, watchId);
+  return token;
+}
+
+export function unwatch(token: string): void {
+  const watchId = activeWatches.get(token);
+  if (watchId === undefined) {
+    return;
+  }
+
+  getGeolocation()?.clearWatch(watchId);
+  activeWatches.delete(token);
+}
+
+export function stopObserving(): void {
+  for (const token of activeWatches.keys()) {
+    unwatch(token);
+  }
+}
+
+export function useWatchPosition(options?: UseWatchPositionOptions) {
+  const [position, setPosition] = useState<GeolocationResponse | null>(null);
+  const [isWatching, setIsWatching] = useState(false);
+  const [error, setError] = useState<LocationError | null>(null);
+  const tokenRef = useRef<string | null>(null);
+  const enabled = options?.enabled ?? false;
+
+  useEffect(() => {
+    if (!enabled) {
+      if (tokenRef.current) {
+        unwatch(tokenRef.current);
+        tokenRef.current = null;
+      }
+      setIsWatching(false);
+      return;
+    }
+
+    setIsWatching(true);
+    setError(null);
+    tokenRef.current = watchPosition(setPosition, setError, options);
+
+    return () => {
+      if (tokenRef.current) {
+        unwatch(tokenRef.current);
+        tokenRef.current = null;
+      }
+    };
+  }, [enabled, options]);
+
+  return {
+    position,
+    error,
+    isWatching
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8565,7 +8565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.4":
+"invariant@npm:2.2.4, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -12361,6 +12361,7 @@ __metadata:
     react-native-nitro-modules: "npm:^0.35.0"
     react-native-safe-area-context: "npm:^5.5.2"
     react-native-screens: "npm:4.19.0"
+    react-native-webview: "npm:13.16.1"
   languageName: unknown
   linkType: soft
 
@@ -12370,6 +12371,16 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.29.7"
     nx: "npm:^22.3.3"
+  languageName: unknown
+  linkType: soft
+
+"react-native-nitro-geolocation-web-e2e@workspace:examples/web-e2e":
+  version: 0.0.0-use.local
+  resolution: "react-native-nitro-geolocation-web-e2e@workspace:examples/web-e2e"
+  dependencies:
+    react-native-nitro-geolocation: "workspace:*"
+    typescript: "npm:5.9.3"
+    vite: "npm:8.0.10"
   languageName: unknown
   linkType: soft
 
@@ -12443,6 +12454,19 @@ __metadata:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
   checksum: 10c0/942f8696281927dfc2970b08939fce62d1dec9486e41ce913f659f132a7fa35d704e18b48d79df9407d17ff51a4986c872c79852616e522f11fa6f41286b6510
+  languageName: node
+  linkType: hard
+
+"react-native-webview@npm:13.16.1":
+  version: 13.16.1
+  resolution: "react-native-webview@npm:13.16.1"
+  dependencies:
+    escape-string-regexp: "npm:^4.0.0"
+    invariant: "npm:2.2.4"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/8fdf14447bc430100d78030b8fdb60df223bd51cdb25c06d58757962fea8ad0cd9cdb13a7aa40ff795c671d2b04a561cbeb2b5795d95780d7f0d3734573ebeeb
   languageName: node
   linkType: hard
 
@@ -14682,62 +14706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0":
-  version: 6.4.1
-  resolution: "vite@npm:6.4.1"
-  dependencies:
-    esbuild: "npm:^0.25.0"
-    fdir: "npm:^6.4.4"
-    fsevents: "npm:~2.3.3"
-    picomatch: "npm:^4.0.2"
-    postcss: "npm:^8.5.3"
-    rollup: "npm:^4.34.9"
-    tinyglobby: "npm:^0.2.13"
-  peerDependencies:
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    jiti: ">=1.21.0"
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/77bb4c5b10f2a185e7859cc9a81c789021bc18009b02900347d1583b453b58e4b19ff07a5e5a5b522b68fc88728460bb45a63b104d969e8c6a6152aea3b849f7
-  languageName: node
-  linkType: hard
-
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+"vite@npm:8.0.10, vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.0.10
   resolution: "vite@npm:8.0.10"
   dependencies:
@@ -14791,6 +14760,61 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/92188b82654f856dbe562a1b679de695bb6ca18c0f43c4c276f84a869fb78e22dedb7c2df83b5617d6afdca979c059d654b5f61a0936a45f49917f352b9325ca
+  languageName: node
+  linkType: hard
+
+"vite@npm:^6.0.0":
+  version: 6.4.1
+  resolution: "vite@npm:6.4.1"
+  dependencies:
+    esbuild: "npm:^0.25.0"
+    fdir: "npm:^6.4.4"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.2"
+    postcss: "npm:^8.5.3"
+    rollup: "npm:^4.34.9"
+    tinyglobby: "npm:^0.2.13"
+  peerDependencies:
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    jiti: ">=1.21.0"
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/77bb4c5b10f2a185e7859cc9a81c789021bc18009b02900347d1583b453b58e4b19ff07a5e5a5b522b68fc88728460bb45a63b104d969e8c6a6152aea3b849f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add a browser conditional root export for `react-native-nitro-geolocation` so web resolves to a native-free Modern API implementation.
- Implement the web Modern API on top of browser `navigator.geolocation`, including permission mapping, normalized coords/errors, watch token cleanup, `stopObserving`, and no-op web configuration.
- Add `examples/web-e2e` and load it from the existing RN example app through `react-native-webview`.
- Keep web E2E separate from the normal example E2E suite because it requires a local web server; run it only with explicit `test:e2e:web:*` scripts.
- Update docs and add a changeset for Modern API web support.

## E2E / Verification
- `yarn workspace react-native-nitro-geolocation typecheck`
- `yarn workspace react-native-nitro-geolocation test` (30 tests passed)
- `yarn workspace react-native-nitro-geolocation-example typecheck`
- `yarn workspace react-native-nitro-geolocation-web-e2e build`
- `bash -n examples/v0.81.1/scripts/test-e2e-web-ios.sh examples/v0.81.1/scripts/test-e2e-web-android.sh`
- `yarn exec biome ci ...` on touched TS/web entry files and `git diff --check`
- Web bundle resolution check: scanned `examples/web-e2e/dist` plus web entry paths for Nitro/native module strings; no matches.
- iOS simulator proof: iPhone 17 Pro / iOS 26.5 passed standalone `test:e2e:web:ios` success + denied flows after latest review fixes.
- Android emulator proof: `NitroGeo_API36` passed standalone `test:e2e:web:android` success + denied flow and `web-e2e-unavailable.yaml` provider-unavailable/manual flow.
- TC separation check: normal example E2E does not include web E2E; local port 4173 / web server / `adb reverse` setup exists only in explicit web E2E scripts.

## Known Web Limitations
- Web support is Modern API only; `/compat` remains native-only.
- Browser geolocation requires a secure context except localhost/dev exemptions.
- Web has no standalone geolocation permission request API; `requestPermission()` may prompt through a one-shot geolocation call.
- Web no-op/unsupported options are documented: `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`, `interval`, `fastestInterval`, `useSignificantChanges`, Android granularity, and iOS-only tuning.
- `distanceFilter` is enforced in JS for web watches.
- Provider-disabled semantics vary by browser/WebView; unsupported/provider-disabled can surface as `POSITION_UNAVAILABLE`, `TIMEOUT`, or manual platform limitation depending on WebView behavior.

## Review Loop
- Addressed PR review: web `useWatchPosition` no longer resubscribes on unstable inline `options`; latest options are kept in a ref and subscription follows `enabled`.
- Fixed additional P1/P2 review-agent findings around stale web server false passes, expected-coordinate E2E proof, watch armed-before-move ordering, post-clear movement proof, helper timeout cleanup, and cleanup callback-count false passes.
- Final P1/P2 review after latest fixes: no remaining P1/P2 findings.