### PR TITLE
Ignore web E2E package in Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,10 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["benchmark", "react-native-nitro-geolocation-example", "docs"]
+  "ignore": [
+    "benchmark",
+    "react-native-nitro-geolocation-example",
+    "react-native-nitro-geolocation-web-e2e",
+    "docs"
+  ]
 }


### PR DESCRIPTION
## Summary
- Keep `react-native-nitro-geolocation-web-e2e` out of Changesets release planning.
- Preserve existing package-level Changeset entries while preventing the private web E2E workspace from being treated as a publish target.

## Validation
- `git diff --check`
- JSON parse check for `.changeset/config.json` and `examples/web-e2e/package.json`
- `npm exec @changesets/cli@2.29.7 -- status --since main` reported no packages to bump

## Notes
- `examples/web-e2e/package.json` already has `private: true`, so this PR only adds the matching Changesets ignore entry.