### PR TITLE
Feat/compat web support

### DIFF
--- a/.changeset/compat-web-support.md
+++ b/.changeset/compat-web-support.md
@@ -1,0 +1,7 @@
+---
+
+"react-native-nitro-geolocation": minor
+
+---
+
+Add Compat API web support through a browser conditional export backed by `navigator.geolocation`.

--- a/examples/web-e2e/index.html
+++ b/examples/web-e2e/index.html
@@ -17,6 +17,7 @@
 
       <section class="toolbar" aria-label="E2E actions">
         <button id="run-success" type="button">Run Success Suite</button>
+        <button id="run-compat" type="button">Run Compat Suite</button>
         <button id="run-denied" type="button">Run Denied Check</button>
         <button id="run-unavailable" type="button">
           Run Unavailable Check

--- a/examples/web-e2e/src/compatRunner.ts
+++ b/examples/web-e2e/src/compatRunner.ts
@@ -1,0 +1,222 @@
+import Geolocation from "react-native-nitro-geolocation/compat";
+import { setScenario } from "./dom";
+import { postNativeStatus } from "./nativeBridge";
+import { scenarios } from "./scenarios";
+
+async function runStep<T>(
+  id: string,
+  action: () => Promise<T>,
+  validate: (value: T) => void = () => undefined
+) {
+  setScenario(id, "running");
+  try {
+    const result = await action();
+    validate(result);
+    setScenario(id, "pass", result);
+    return result;
+  } catch (error) {
+    setScenario(id, "fail", error);
+    throw error;
+  }
+}
+
+export function runCompatApiAvailabilityCheck() {
+  setScenario("compat-api-availability", "running");
+  const compatShape = {
+    getCurrentPosition: typeof Geolocation.getCurrentPosition,
+    watchPosition: typeof Geolocation.watchPosition,
+    clearWatch: typeof Geolocation.clearWatch,
+    stopObserving: typeof Geolocation.stopObserving,
+    requestAuthorization: typeof Geolocation.requestAuthorization,
+    setRNConfiguration: typeof Geolocation.setRNConfiguration
+  };
+  const compatReady = Object.values(compatShape).every(
+    (type) => type === "function"
+  );
+  setScenario(
+    "compat-api-availability",
+    compatReady ? "pass" : "fail",
+    compatShape
+  );
+  if (!compatReady) {
+    throw new Error("Compat API browser export is incomplete.");
+  }
+}
+
+export async function runCompatScenarios() {
+  await runStep("compat-get-current-position", async () => {
+    return new Promise<unknown>((resolve, reject) => {
+      Geolocation.getCurrentPosition(
+        (compatPosition) => {
+          if (
+            typeof compatPosition?.coords?.latitude !== "number" ||
+            typeof compatPosition?.coords?.longitude !== "number" ||
+            typeof compatPosition?.timestamp !== "number"
+          ) {
+            reject(new Error("Compat position missing coords/timestamp."));
+            return;
+          }
+          resolve(compatPosition);
+        },
+        (compatError) => {
+          reject(compatError);
+        },
+        { maximumAge: 0, timeout: 15000 }
+      );
+    });
+  });
+
+  await runStep("compat-watch-position", async () => {
+    return new Promise<unknown>((resolve, reject) => {
+      let watchId = -1;
+      let callbacksAfterClear = 0;
+      let cleared = false;
+      const timeout = window.setTimeout(() => {
+        if (watchId !== -1) {
+          Geolocation.clearWatch(watchId);
+        }
+        reject(new Error("Compat watch did not emit within 15s."));
+      }, 15000);
+      watchId = Geolocation.watchPosition(
+        (compatPosition) => {
+          if (cleared) {
+            callbacksAfterClear += 1;
+            return;
+          }
+          if (
+            typeof compatPosition?.coords?.latitude !== "number" ||
+            typeof compatPosition?.coords?.longitude !== "number" ||
+            typeof compatPosition?.timestamp !== "number"
+          ) {
+            window.clearTimeout(timeout);
+            Geolocation.clearWatch(watchId);
+            reject(
+              new Error("Compat watch position missing coords/timestamp.")
+            );
+            return;
+          }
+          cleared = true;
+          Geolocation.clearWatch(watchId);
+          window.setTimeout(() => {
+            window.clearTimeout(timeout);
+            if (callbacksAfterClear > 0) {
+              reject(
+                new Error(
+                  `Compat watch fired ${callbacksAfterClear} time(s) after clearWatch.`
+                )
+              );
+              return;
+            }
+            resolve({ watchId, sample: compatPosition });
+          }, 1500);
+        },
+        (compatError) => {
+          window.clearTimeout(timeout);
+          if (watchId !== -1) {
+            Geolocation.clearWatch(watchId);
+          }
+          reject(compatError);
+        },
+        { maximumAge: 0, timeout: 15000 }
+      );
+    });
+  });
+
+  await runStep("compat-stop-observing", async () => {
+    return new Promise<unknown>((resolve, reject) => {
+      let firstFired = false;
+      let secondFired = false;
+      let stopped = false;
+      let callbacksAfterStop = 0;
+      const ids: number[] = [];
+      const timeout = window.setTimeout(() => {
+        for (const id of ids) {
+          Geolocation.clearWatch(id);
+        }
+        reject(new Error("Compat watches did not both emit within 15s."));
+      }, 15000);
+      const trySettle = () => {
+        if (!firstFired || !secondFired || stopped) {
+          return;
+        }
+        stopped = true;
+        Geolocation.stopObserving();
+        window.setTimeout(() => {
+          window.clearTimeout(timeout);
+          if (callbacksAfterStop > 0) {
+            reject(
+              new Error(
+                `Compat watch fired ${callbacksAfterStop} time(s) after stopObserving.`
+              )
+            );
+            return;
+          }
+          resolve({ ids, callbacksAfterStop });
+        }, 1500);
+      };
+      ids.push(
+        Geolocation.watchPosition(
+          () => {
+            if (stopped) {
+              callbacksAfterStop += 1;
+              return;
+            }
+            firstFired = true;
+            trySettle();
+          },
+          (compatError) => {
+            window.clearTimeout(timeout);
+            for (const id of ids) {
+              Geolocation.clearWatch(id);
+            }
+            reject(compatError);
+          },
+          { maximumAge: 0, timeout: 15000 }
+        )
+      );
+      ids.push(
+        Geolocation.watchPosition(
+          () => {
+            if (stopped) {
+              callbacksAfterStop += 1;
+              return;
+            }
+            secondFired = true;
+            trySettle();
+          },
+          (compatError) => {
+            window.clearTimeout(timeout);
+            for (const id of ids) {
+              Geolocation.clearWatch(id);
+            }
+            reject(compatError);
+          },
+          { maximumAge: 0, timeout: 15000 }
+        )
+      );
+    });
+  });
+}
+
+export async function runCompatSuite() {
+  runCompatApiAvailabilityCheck();
+  await runCompatScenarios();
+
+  const failedScenarios = scenarios.filter(
+    (scenario) =>
+      [
+        "compat-api-availability",
+        "compat-get-current-position",
+        "compat-watch-position",
+        "compat-stop-observing"
+      ].includes(scenario.id) && scenario.status !== "pass"
+  );
+  if (failedScenarios.length > 0) {
+    throw new Error(
+      `Compat suite incomplete: ${failedScenarios
+        .map((scenario) => scenario.id)
+        .join(", ")}`
+    );
+  }
+  postNativeStatus("compat-suite", "pass");
+}

--- a/examples/web-e2e/src/compatRunner.ts
+++ b/examples/web-e2e/src/compatRunner.ts
@@ -1,7 +1,19 @@
 import Geolocation from "react-native-nitro-geolocation/compat";
+import type { GeolocationResponse } from "react-native-nitro-geolocation/compat";
 import { setScenario } from "./dom";
+import {
+  type ExpectedLocation,
+  assertPosition,
+  expectedLocations,
+  getErrorCode,
+  isNearExpected
+} from "./locationAssertions";
 import { postNativeStatus } from "./nativeBridge";
 import { scenarios } from "./scenarios";
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 async function runStep<T>(
   id: string,
@@ -18,6 +30,149 @@ async function runStep<T>(
     setScenario(id, "fail", error);
     throw error;
   }
+}
+
+function getCurrentPositionAsync(options: {
+  maximumAge: number;
+  timeout: number;
+}) {
+  return new Promise<GeolocationResponse>((resolve, reject) => {
+    Geolocation.getCurrentPosition(
+      (position) => resolve(position),
+      (error) => reject(error),
+      options
+    );
+  });
+}
+
+async function compatGetCurrentPositionUntilSuccess(timeoutMs: number) {
+  const startedAt = Date.now();
+  const transientErrors: unknown[] = [];
+
+  while (true) {
+    try {
+      const position = await getCurrentPositionAsync({
+        maximumAge: 0,
+        timeout: 15000
+      });
+      return { position, transientErrors };
+    } catch (error) {
+      transientErrors.push(error);
+      const code = getErrorCode(error);
+      if ((code !== 2 && code !== 3) || Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+      await wait(500);
+    }
+  }
+}
+
+async function compatGetCurrentPositionUntilExpected({
+  expected,
+  timeoutMs
+}: {
+  expected: ExpectedLocation;
+  timeoutMs: number;
+}) {
+  const startedAt = Date.now();
+  const transientErrors: unknown[] = [];
+  const ignoredPositions: GeolocationResponse[] = [];
+
+  while (true) {
+    try {
+      const position = await getCurrentPositionAsync({
+        maximumAge: 0,
+        timeout: 15000
+      });
+      if (isNearExpected(position, expected)) {
+        return { position, transientErrors, ignoredPositions };
+      }
+      ignoredPositions.push(position);
+      if (Date.now() - startedAt >= timeoutMs) {
+        const last = ignoredPositions[ignoredPositions.length - 1];
+        throw new Error(
+          `Compat getCurrentPosition did not return expected coords ${expected.latitude}, ${expected.longitude}. Last observed: ${last?.coords.latitude}, ${last?.coords.longitude} (samples=${ignoredPositions.length}).`
+        );
+      }
+      await wait(500);
+    } catch (error) {
+      transientErrors.push(error);
+      const code = getErrorCode(error);
+      if ((code !== 2 && code !== 3) || Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+      await wait(500);
+    }
+  }
+}
+
+async function compatWatchUntilFirstEvent({
+  timeoutMs,
+  clearOnFirst,
+  acceptPosition,
+  onStarted
+}: {
+  timeoutMs: number;
+  clearOnFirst: boolean;
+  acceptPosition: (position: GeolocationResponse) => boolean;
+  onStarted?: (watchId: number) => void;
+}) {
+  const events: GeolocationResponse[] = [];
+  const errors: unknown[] = [];
+
+  return new Promise<{
+    watchId: number;
+    events: GeolocationResponse[];
+    errors: unknown[];
+    position: GeolocationResponse;
+  }>((resolve, reject) => {
+    let stopped = false;
+    let resolved = false;
+    let watchId = -1;
+    const timeout = window.setTimeout(() => {
+      if (stopped || resolved) {
+        return;
+      }
+      stopped = true;
+      if (watchId !== -1) {
+        Geolocation.clearWatch(watchId);
+      }
+      reject(
+        new Error(
+          `Timed out waiting for accepted compat watch event after ${timeoutMs}ms.`
+        )
+      );
+    }, timeoutMs);
+    watchId = Geolocation.watchPosition(
+      (position) => {
+        if (stopped) {
+          return;
+        }
+        events.push(position);
+        if (!acceptPosition(position)) {
+          return;
+        }
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        window.clearTimeout(timeout);
+        if (clearOnFirst) {
+          stopped = true;
+          Geolocation.clearWatch(watchId);
+        }
+        resolve({ watchId, events, errors, position });
+      },
+      (error) => {
+        if (stopped || resolved) {
+          return;
+        }
+        errors.push(error);
+      },
+      { maximumAge: 0, timeout: 15000 }
+    );
+    onStarted?.(watchId);
+  });
 }
 
 export function runCompatApiAvailabilityCheck() {
@@ -44,158 +199,174 @@ export function runCompatApiAvailabilityCheck() {
 }
 
 export async function runCompatScenarios() {
-  await runStep("compat-get-current-position", async () => {
-    return new Promise<unknown>((resolve, reject) => {
-      Geolocation.getCurrentPosition(
-        (compatPosition) => {
-          if (
-            typeof compatPosition?.coords?.latitude !== "number" ||
-            typeof compatPosition?.coords?.longitude !== "number" ||
-            typeof compatPosition?.timestamp !== "number"
-          ) {
-            reject(new Error("Compat position missing coords/timestamp."));
-            return;
-          }
-          resolve(compatPosition);
-        },
-        (compatError) => {
-          reject(compatError);
-        },
-        { maximumAge: 0, timeout: 15000 }
+  const baseline = await runStep(
+    "compat-get-current-position",
+    async () => {
+      const initial = await compatGetCurrentPositionUntilSuccess(30000);
+      setScenario(
+        "compat-get-current-position",
+        "running",
+        { phase: "move-for-compat-get-current-position", baseline: initial },
+        "Move device location now; compat getCurrentPosition should return the expected coords."
       );
-    });
-  });
+      return compatGetCurrentPositionUntilExpected({
+        expected: expectedLocations.compatGetCurrentPosition,
+        timeoutMs: 30000
+      });
+    },
+    (result) => assertPosition(result.position)
+  );
 
-  await runStep("compat-watch-position", async () => {
-    return new Promise<unknown>((resolve, reject) => {
-      let watchId = -1;
-      let callbacksAfterClear = 0;
-      let cleared = false;
-      const timeout = window.setTimeout(() => {
-        if (watchId !== -1) {
-          Geolocation.clearWatch(watchId);
+  await runStep(
+    "compat-watch-position",
+    async () => {
+      const watch = await compatWatchUntilFirstEvent({
+        clearOnFirst: false,
+        timeoutMs: 30000,
+        acceptPosition: (position) =>
+          isNearExpected(
+            position,
+            expectedLocations.compatWatchPositionInitial
+          ),
+        onStarted: () => {
+          setScenario(
+            "compat-watch-position",
+            "running",
+            {
+              phase: "move-for-compat-watch-position",
+              baseline: baseline.position,
+              expected: expectedLocations.compatWatchPositionInitial
+            },
+            "Move device location now; compat watch should emit the expected coordinate."
+          );
         }
-        reject(new Error("Compat watch did not emit within 15s."));
-      }, 15000);
-      watchId = Geolocation.watchPosition(
-        (compatPosition) => {
-          if (cleared) {
-            callbacksAfterClear += 1;
-            return;
-          }
-          if (
-            typeof compatPosition?.coords?.latitude !== "number" ||
-            typeof compatPosition?.coords?.longitude !== "number" ||
-            typeof compatPosition?.timestamp !== "number"
-          ) {
-            window.clearTimeout(timeout);
-            Geolocation.clearWatch(watchId);
-            reject(
-              new Error("Compat watch position missing coords/timestamp.")
-            );
-            return;
-          }
-          cleared = true;
-          Geolocation.clearWatch(watchId);
-          window.setTimeout(() => {
-            window.clearTimeout(timeout);
-            if (callbacksAfterClear > 0) {
-              reject(
-                new Error(
-                  `Compat watch fired ${callbacksAfterClear} time(s) after clearWatch.`
-                )
-              );
-              return;
-            }
-            resolve({ watchId, sample: compatPosition });
-          }, 1500);
+      });
+      Geolocation.clearWatch(watch.watchId);
+      const callbackCountAfterClear = watch.events.length;
+      setScenario(
+        "compat-watch-position",
+        "running",
+        {
+          phase: "move-after-compat-watch-position",
+          watchId: watch.watchId,
+          callbackCountAfterClear,
+          expected: expectedLocations.compatWatchPositionAfterClear,
+          transientErrors: watch.errors
         },
-        (compatError) => {
-          window.clearTimeout(timeout);
-          if (watchId !== -1) {
-            Geolocation.clearWatch(watchId);
-          }
-          reject(compatError);
-        },
-        { maximumAge: 0, timeout: 15000 }
+        "Compat watch emitted once and was cleared. Move device location now; a one-shot probe should see it without extra watch callbacks."
       );
-    });
-  });
+      const probeAfterClear = await compatGetCurrentPositionUntilExpected({
+        expected: expectedLocations.compatWatchPositionAfterClear,
+        timeoutMs: 30000
+      });
+      return {
+        watchId: watch.watchId,
+        transientErrors: watch.errors,
+        probeAfterClear,
+        callbackCountAfterClear,
+        callbackCount: watch.events.length,
+        sample: watch.position
+      };
+    },
+    (result) => {
+      assertPosition(result.sample);
+      if (result.callbackCountAfterClear < 1) {
+        throw new Error(
+          "Expected compat watch scenario to prove an active watch."
+        );
+      }
+      if (result.callbackCount !== result.callbackCountAfterClear) {
+        throw new Error(
+          `Expected clearWatch to prevent callbacks, got ${result.callbackCount}.`
+        );
+      }
+    }
+  );
 
-  await runStep("compat-stop-observing", async () => {
-    return new Promise<unknown>((resolve, reject) => {
-      let firstFired = false;
-      let secondFired = false;
-      let stopped = false;
-      let callbacksAfterStop = 0;
-      const ids: number[] = [];
-      const timeout = window.setTimeout(() => {
-        for (const id of ids) {
-          Geolocation.clearWatch(id);
-        }
-        reject(new Error("Compat watches did not both emit within 15s."));
-      }, 15000);
-      const trySettle = () => {
-        if (!firstFired || !secondFired || stopped) {
+  await runStep(
+    "compat-stop-observing",
+    async () => {
+      let startedWatchCount = 0;
+      const requestInitialMove = () => {
+        startedWatchCount += 1;
+        if (startedWatchCount !== 2) {
           return;
         }
-        stopped = true;
-        Geolocation.stopObserving();
-        window.setTimeout(() => {
-          window.clearTimeout(timeout);
-          if (callbacksAfterStop > 0) {
-            reject(
-              new Error(
-                `Compat watch fired ${callbacksAfterStop} time(s) after stopObserving.`
-              )
-            );
-            return;
-          }
-          resolve({ ids, callbacksAfterStop });
-        }, 1500);
+        setScenario(
+          "compat-stop-observing",
+          "running",
+          {
+            phase: "move-for-compat-stop-observing-initial",
+            baseline: baseline.position,
+            expected: expectedLocations.compatStopObservingInitial
+          },
+          "Move device location now; both compat watchers should emit the expected coordinate before stopObserving."
+        );
       };
-      ids.push(
-        Geolocation.watchPosition(
-          () => {
-            if (stopped) {
-              callbacksAfterStop += 1;
-              return;
-            }
-            firstFired = true;
-            trySettle();
-          },
-          (compatError) => {
-            window.clearTimeout(timeout);
-            for (const id of ids) {
-              Geolocation.clearWatch(id);
-            }
-            reject(compatError);
-          },
-          { maximumAge: 0, timeout: 15000 }
-        )
+      const [firstWatch, secondWatch] = await Promise.all([
+        compatWatchUntilFirstEvent({
+          clearOnFirst: false,
+          timeoutMs: 30000,
+          acceptPosition: (position) =>
+            isNearExpected(
+              position,
+              expectedLocations.compatStopObservingInitial
+            ),
+          onStarted: requestInitialMove
+        }),
+        compatWatchUntilFirstEvent({
+          clearOnFirst: false,
+          timeoutMs: 30000,
+          acceptPosition: (position) =>
+            isNearExpected(
+              position,
+              expectedLocations.compatStopObservingInitial
+            ),
+          onStarted: requestInitialMove
+        })
+      ]);
+      Geolocation.stopObserving();
+      const callbackCountAfterStop =
+        firstWatch.events.length + secondWatch.events.length;
+      setScenario(
+        "compat-stop-observing",
+        "running",
+        {
+          phase: "move-after-compat-stop-observing",
+          firstWatchId: firstWatch.watchId,
+          secondWatchId: secondWatch.watchId,
+          callbackCountAfterStop,
+          expected: expectedLocations.compatStopObservingAfterClear,
+          transientErrors: [...firstWatch.errors, ...secondWatch.errors]
+        },
+        "Both compat watches emitted once and stopObserving cleared them. Move device location now; a one-shot probe should see it without extra watch callbacks."
       );
-      ids.push(
-        Geolocation.watchPosition(
-          () => {
-            if (stopped) {
-              callbacksAfterStop += 1;
-              return;
-            }
-            secondFired = true;
-            trySettle();
-          },
-          (compatError) => {
-            window.clearTimeout(timeout);
-            for (const id of ids) {
-              Geolocation.clearWatch(id);
-            }
-            reject(compatError);
-          },
-          { maximumAge: 0, timeout: 15000 }
-        )
-      );
-    });
-  });
+      const probeAfterStop = await compatGetCurrentPositionUntilExpected({
+        expected: expectedLocations.compatStopObservingAfterClear,
+        timeoutMs: 30000
+      });
+      return {
+        firstWatchId: firstWatch.watchId,
+        secondWatchId: secondWatch.watchId,
+        transientErrors: [...firstWatch.errors, ...secondWatch.errors],
+        probeAfterStop,
+        callbackCountAfterStop,
+        callbackCount: firstWatch.events.length + secondWatch.events.length
+      };
+    },
+    (result) => {
+      if (result.callbackCountAfterStop < 2) {
+        throw new Error(
+          "Expected compat stopObserving scenario to prove active watches."
+        );
+      }
+      if (result.callbackCount !== result.callbackCountAfterStop) {
+        throw new Error(
+          `Expected stopObserving to prevent callbacks, got ${result.callbackCount}.`
+        );
+      }
+    }
+  );
 }
 
 export async function runCompatSuite() {

--- a/examples/web-e2e/src/locationAssertions.ts
+++ b/examples/web-e2e/src/locationAssertions.ts
@@ -14,7 +14,12 @@ export const expectedLocations = {
   unwatchInitial: { latitude: 37.5685, longitude: 126.98 },
   unwatchAfterClear: { latitude: 37.5692, longitude: 126.9807 },
   stopObservingInitial: { latitude: 37.5699, longitude: 126.9814 },
-  stopObservingAfterClear: { latitude: 37.5706, longitude: 126.9821 }
+  stopObservingAfterClear: { latitude: 37.5706, longitude: 126.9821 },
+  compatGetCurrentPosition: { latitude: 37.5713, longitude: 126.9828 },
+  compatWatchPositionInitial: { latitude: 37.572, longitude: 126.9835 },
+  compatWatchPositionAfterClear: { latitude: 37.5727, longitude: 126.9842 },
+  compatStopObservingInitial: { latitude: 37.5734, longitude: 126.9849 },
+  compatStopObservingAfterClear: { latitude: 37.5741, longitude: 126.9856 }
 } as const;
 
 const expectedLocationTolerance = 0.00015;

--- a/examples/web-e2e/src/main.ts
+++ b/examples/web-e2e/src/main.ts
@@ -1,3 +1,4 @@
+import { runCompatSuite } from "./compatRunner";
 import { render } from "./dom";
 import {
   runDeniedCheck,
@@ -9,6 +10,7 @@ import { scenarios } from "./scenarios";
 import "./styles.css";
 
 const successButton = document.querySelector<HTMLButtonElement>("#run-success");
+const compatButton = document.querySelector<HTMLButtonElement>("#run-compat");
 const deniedButton = document.querySelector<HTMLButtonElement>("#run-denied");
 const unavailableButton =
   document.querySelector<HTMLButtonElement>("#run-unavailable");
@@ -17,6 +19,9 @@ const clearButton = document.querySelector<HTMLButtonElement>("#clear-results");
 
 successButton?.addEventListener("click", () => {
   void runSuccessSuite();
+});
+compatButton?.addEventListener("click", () => {
+  void runCompatSuite();
 });
 deniedButton?.addEventListener("click", () => {
   void runDeniedCheck();
@@ -43,6 +48,8 @@ render();
 const params = new URLSearchParams(location.search);
 if (params.get("autorun") === "success") {
   void runSuccessSuite();
+} else if (params.get("autorun") === "compat") {
+  void runCompatSuite();
 } else if (params.get("autorun") === "denied") {
   void runDeniedCheck();
 } else if (params.get("autorun") === "unavailable") {

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -1,3 +1,4 @@
+import Geolocation from "react-native-nitro-geolocation/compat";
 import {
   checkPermission,
   getCurrentPosition,
@@ -213,6 +214,23 @@ export async function runSuccessSuite() {
   setScenario("api-availability", apiReady ? "pass" : "fail", apiShape);
   if (!apiReady) {
     throw new Error("Modern API browser export is incomplete.");
+  }
+
+  setScenario("compat-api-availability", "running");
+  const compatShape = {
+    getCurrentPosition: typeof Geolocation.getCurrentPosition,
+    watchPosition: typeof Geolocation.watchPosition,
+    clearWatch: typeof Geolocation.clearWatch,
+    stopObserving: typeof Geolocation.stopObserving,
+    requestAuthorization: typeof Geolocation.requestAuthorization,
+    setRNConfiguration: typeof Geolocation.setRNConfiguration
+  };
+  const compatReady = Object.values(compatShape).every(
+    (type) => type === "function"
+  );
+  setScenario("compat-api-availability", compatReady ? "pass" : "fail", compatShape);
+  if (!compatReady) {
+    throw new Error("Compat API browser export is incomplete.");
   }
 
   await runStep<PermissionStatus>(
@@ -431,6 +449,7 @@ export async function runSuccessSuite() {
     (scenario) =>
       [
         "api-availability",
+        "compat-api-availability",
         "check-permission",
         "request-permission",
         "get-current-position",

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -1,4 +1,3 @@
-import Geolocation from "react-native-nitro-geolocation/compat";
 import {
   checkPermission,
   getCurrentPosition,
@@ -11,6 +10,10 @@ import type {
   GeolocationResponse,
   PermissionStatus
 } from "react-native-nitro-geolocation";
+import {
+  runCompatApiAvailabilityCheck,
+  runCompatScenarios
+} from "./compatRunner";
 import { setScenario } from "./dom";
 import {
   type ExpectedLocation,
@@ -216,22 +219,7 @@ export async function runSuccessSuite() {
     throw new Error("Modern API browser export is incomplete.");
   }
 
-  setScenario("compat-api-availability", "running");
-  const compatShape = {
-    getCurrentPosition: typeof Geolocation.getCurrentPosition,
-    watchPosition: typeof Geolocation.watchPosition,
-    clearWatch: typeof Geolocation.clearWatch,
-    stopObserving: typeof Geolocation.stopObserving,
-    requestAuthorization: typeof Geolocation.requestAuthorization,
-    setRNConfiguration: typeof Geolocation.setRNConfiguration
-  };
-  const compatReady = Object.values(compatShape).every(
-    (type) => type === "function"
-  );
-  setScenario("compat-api-availability", compatReady ? "pass" : "fail", compatShape);
-  if (!compatReady) {
-    throw new Error("Compat API browser export is incomplete.");
-  }
+  runCompatApiAvailabilityCheck();
 
   await runStep<PermissionStatus>(
     "check-permission",
@@ -445,6 +433,8 @@ export async function runSuccessSuite() {
     }
   );
 
+  await runCompatScenarios();
+
   const failedScenarios = scenarios.filter(
     (scenario) =>
       [
@@ -455,7 +445,10 @@ export async function runSuccessSuite() {
         "get-current-position",
         "watch-position",
         "unwatch",
-        "stop-observing"
+        "stop-observing",
+        "compat-get-current-position",
+        "compat-watch-position",
+        "compat-stop-observing"
       ].includes(scenario.id) && scenario.status !== "pass"
   );
   if (failedScenarios.length > 0) {
@@ -520,7 +513,6 @@ export async function runUnavailableCheck() {
     );
   }
 }
-
 export async function runTimeoutCheck() {
   setScenario("timeout", "running");
   try {

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -16,6 +16,12 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
+    id: "compat-api-availability",
+    title: "Compat API availability",
+    detail: "Compat browser export resolves without native bindings.",
+    status: "idle"
+  },
+  {
     id: "check-permission",
     title: "checkPermission",
     detail: "Reads browser permission state when Permissions API exists.",

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -58,6 +58,24 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
+    id: "compat-get-current-position",
+    title: "compat getCurrentPosition",
+    detail: "Compat callback receives normalized coords from real browser.",
+    status: "idle"
+  },
+  {
+    id: "compat-watch-position",
+    title: "compat watchPosition + clearWatch",
+    detail: "Compat watch emits coords, clearWatch stops subsequent callbacks.",
+    status: "idle"
+  },
+  {
+    id: "compat-stop-observing",
+    title: "compat stopObserving clears all watches",
+    detail: "stopObserving clears every active compat watch.",
+    status: "idle"
+  },
+  {
     id: "permission-denied",
     title: "permission denied -> PERMISSION_DENIED",
     detail: "Run with browser geolocation permission blocked.",

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -15,8 +15,8 @@
     },
     "./compat": {
       "types": "./src/compat/index.tsx",
-      "react-native": "./src/compat/index.tsx",
       "browser": "./src/compat/index.web.ts",
+      "react-native": "./src/compat/index.tsx",
       "default": "./src/compat/index.tsx"
     },
     "./background": {

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -15,6 +15,8 @@
     },
     "./compat": {
       "types": "./src/compat/index.tsx",
+      "react-native": "./src/compat/index.tsx",
+      "browser": "./src/compat/index.web.ts",
       "default": "./src/compat/index.tsx"
     },
     "./background": {

--- a/packages/react-native-nitro-geolocation/src/compat/index.web.test.ts
+++ b/packages/react-native-nitro-geolocation/src/compat/index.web.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
+import Geolocation, {
   clearWatch,
   getCurrentPosition,
   requestAuthorization,
@@ -39,6 +39,7 @@ function createBrowserPosition(latitude = 37.5665, longitude = 126.978) {
 }
 
 afterEach(() => {
+  stopObserving();
   vi.restoreAllMocks();
   Reflect.deleteProperty(globalThis, "navigator");
 });
@@ -151,7 +152,203 @@ describe("compat web API", () => {
     ).not.toThrow();
   });
 
-  it("stopObserving is a no-op on web", () => {
+  it("stopObserving clears all active watches", () => {
+    const clearMock = vi.fn();
+    const watchMock = vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(11);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: clearMock
+      }
+    });
+
+    watchPosition(vi.fn());
+    watchPosition(vi.fn());
+    stopObserving();
+
+    expect(clearMock).toHaveBeenCalledWith(10);
+    expect(clearMock).toHaveBeenCalledWith(11);
+    expect(clearMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearWatch removes id from tracking so stopObserving skips it", () => {
+    const clearMock = vi.fn();
+    const watchMock = vi.fn().mockReturnValueOnce(20).mockReturnValueOnce(21);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: clearMock
+      }
+    });
+
+    watchPosition(vi.fn());
+    watchPosition(vi.fn());
+    clearWatch(20);
+    stopObserving();
+
+    expect(clearMock).toHaveBeenCalledWith(20);
+    expect(clearMock).toHaveBeenCalledWith(21);
+    expect(clearMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("watchPosition maps browser position to CompatGeolocationResponse", () => {
+    const watchMock = vi.fn((success) => {
+      success(createBrowserPosition(35.0, 135.0));
+      return 99;
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: vi.fn()
+      }
+    });
+
+    const success = vi.fn();
+    watchPosition(success);
+
+    expect(success).toHaveBeenCalledWith({
+      coords: {
+        latitude: 35.0,
+        longitude: 135.0,
+        altitude: null,
+        accuracy: 11,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null
+      },
+      timestamp: 1779015190000
+    });
+  });
+
+  it("watchPosition forwards mapped error to error callback", () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn((_success, error) => {
+          error({ code: 3, message: "timeout" });
+          return 50;
+        }),
+        clearWatch: vi.fn()
+      }
+    });
+
+    const error = vi.fn();
+    watchPosition(vi.fn(), error);
+
+    expect(error).toHaveBeenCalledWith({
+      code: 3,
+      message: "timeout",
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3
+    });
+  });
+
+  it("watchPosition returns -1 and calls error when geolocation is unavailable", () => {
+    setNavigator({ geolocation: undefined });
+
+    const error = vi.fn();
+    const id = watchPosition(vi.fn(), error);
+
+    expect(id).toBe(-1);
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 2 }));
+  });
+
+  it("getCurrentPosition passes undefined options to browser when omitted", () => {
+    const mock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: mock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    getCurrentPosition(vi.fn());
+
+    expect(mock.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it("watchPosition passes undefined options to browser when omitted", () => {
+    const watchMock = vi.fn(() => 7);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: vi.fn()
+      }
+    });
+
+    watchPosition(vi.fn());
+
+    expect(watchMock.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it("getCurrentPosition passes undefined error callback to browser when omitted", () => {
+    const mock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: mock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    getCurrentPosition(vi.fn());
+
+    expect(mock.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("stopObserving is safe to call with no active watches", () => {
+    const clearMock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: clearMock
+      }
+    });
+
     expect(() => stopObserving()).not.toThrow();
+    expect(clearMock).not.toHaveBeenCalled();
+  });
+
+  it("stopObserving still clears internal tracking when geolocation is unavailable", () => {
+    const watchMock = vi.fn().mockReturnValueOnce(30).mockReturnValueOnce(31);
+    const clearMock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: clearMock
+      }
+    });
+    watchPosition(vi.fn());
+    watchPosition(vi.fn());
+
+    setNavigator({ geolocation: undefined });
+    expect(() => stopObserving()).not.toThrow();
+
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: clearMock
+      }
+    });
+    stopObserving();
+    expect(clearMock).not.toHaveBeenCalled();
+  });
+
+  it("default export exposes all six compat methods", () => {
+    expect(typeof Geolocation.setRNConfiguration).toBe("function");
+    expect(typeof Geolocation.requestAuthorization).toBe("function");
+    expect(typeof Geolocation.getCurrentPosition).toBe("function");
+    expect(typeof Geolocation.watchPosition).toBe("function");
+    expect(typeof Geolocation.clearWatch).toBe("function");
+    expect(typeof Geolocation.stopObserving).toBe("function");
   });
 });

--- a/packages/react-native-nitro-geolocation/src/compat/index.web.test.ts
+++ b/packages/react-native-nitro-geolocation/src/compat/index.web.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearWatch,
+  getCurrentPosition,
+  requestAuthorization,
+  setRNConfiguration,
+  stopObserving,
+  watchPosition
+} from "./index.web";
+
+type TestNavigator = {
+  geolocation?: {
+    getCurrentPosition: ReturnType<typeof vi.fn>;
+    watchPosition: ReturnType<typeof vi.fn>;
+    clearWatch: ReturnType<typeof vi.fn>;
+  };
+};
+
+function setNavigator(value: TestNavigator | undefined) {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value
+  });
+}
+
+function createBrowserPosition(latitude = 37.5665, longitude = 126.978) {
+  return {
+    coords: {
+      latitude,
+      longitude,
+      altitude: null,
+      accuracy: 11,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null
+    },
+    timestamp: 1779015190000
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(globalThis, "navigator");
+});
+
+describe("compat web API", () => {
+  it("getCurrentPosition maps browser position to CompatGeolocationResponse", () => {
+    const mock = vi.fn((success) => success(createBrowserPosition()));
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: mock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    const success = vi.fn();
+    getCurrentPosition(success, undefined, {
+      enableHighAccuracy: true,
+      timeout: 5000
+    });
+
+    expect(success).toHaveBeenCalledWith({
+      coords: {
+        latitude: 37.5665,
+        longitude: 126.978,
+        altitude: null,
+        accuracy: 11,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null
+      },
+      timestamp: 1779015190000
+    });
+    expect(mock.mock.calls[0][2]).toEqual({
+      enableHighAccuracy: true,
+      timeout: 5000,
+      maximumAge: undefined
+    });
+  });
+
+  it("getCurrentPosition forwards mapped error to error callback", () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn((_success, error) => {
+          error({ code: 1, message: "denied" });
+        }),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    const error = vi.fn();
+    getCurrentPosition(vi.fn(), error);
+
+    expect(error).toHaveBeenCalledWith({
+      code: 1,
+      message: "denied",
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3
+    });
+  });
+
+  it("getCurrentPosition calls error callback when geolocation is unavailable", () => {
+    setNavigator({ geolocation: undefined });
+
+    const error = vi.fn();
+    getCurrentPosition(vi.fn(), error);
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 2 }));
+  });
+
+  it("watchPosition returns the browser watch id", () => {
+    const watchMock = vi.fn(() => 42);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: watchMock,
+        clearWatch: vi.fn()
+      }
+    });
+
+    const id = watchPosition(vi.fn());
+    expect(id).toBe(42);
+  });
+
+  it("clearWatch delegates to navigator.geolocation.clearWatch", () => {
+    const clearMock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: clearMock
+      }
+    });
+
+    clearWatch(7);
+    expect(clearMock).toHaveBeenCalledWith(7);
+  });
+
+  it("requestAuthorization calls success immediately on web", () => {
+    const success = vi.fn();
+    requestAuthorization(success);
+    expect(success).toHaveBeenCalledOnce();
+  });
+
+  it("setRNConfiguration is a no-op on web", () => {
+    expect(() =>
+      setRNConfiguration({ skipPermissionRequests: false })
+    ).not.toThrow();
+  });
+
+  it("stopObserving is a no-op on web", () => {
+    expect(() => stopObserving()).not.toThrow();
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/compat/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/compat/index.web.ts
@@ -79,6 +79,8 @@ export function getCurrentPosition(
   );
 }
 
+const activeWatches = new Set<number>();
+
 export function watchPosition(
   success: (position: CompatGeolocationResponse) => void,
   error?: (error: CompatGeolocationError) => void,
@@ -95,7 +97,7 @@ export function watchPosition(
     });
     return -1;
   }
-  return geo.watchPosition(
+  const watchId = geo.watchPosition(
     (pos) => success(mapPosition(pos)),
     error ? (err) => error(mapError(err)) : undefined,
     options
@@ -106,13 +108,26 @@ export function watchPosition(
         }
       : undefined
   );
+  activeWatches.add(watchId);
+  return watchId;
 }
 
 export function clearWatch(watchId: number): void {
   getGeolocation()?.clearWatch(watchId);
+  activeWatches.delete(watchId);
 }
 
-export function stopObserving(): void {}
+export function stopObserving(): void {
+  const geo = getGeolocation();
+  if (!geo) {
+    activeWatches.clear();
+    return;
+  }
+  for (const watchId of activeWatches) {
+    geo.clearWatch(watchId);
+  }
+  activeWatches.clear();
+}
 
 const Geolocation = {
   setRNConfiguration,

--- a/packages/react-native-nitro-geolocation/src/compat/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/compat/index.web.ts
@@ -1,0 +1,126 @@
+import type {
+  CompatGeolocationConfiguration,
+  CompatGeolocationError,
+  CompatGeolocationOptions,
+  CompatGeolocationResponse
+} from "../publicTypes";
+import type { BrowserPosition, BrowserPositionError } from "../web/browser";
+import { getGeolocation } from "../web/browser";
+
+export type {
+  CompatGeolocationConfiguration as GeolocationConfiguration,
+  CompatGeolocationResponse as GeolocationResponse,
+  CompatGeolocationError as GeolocationError,
+  CompatGeolocationOptions as GeolocationOptions
+} from "../publicTypes";
+
+function mapPosition(pos: BrowserPosition): CompatGeolocationResponse {
+  return {
+    coords: {
+      latitude: pos.coords.latitude,
+      longitude: pos.coords.longitude,
+      altitude: pos.coords.altitude,
+      accuracy: pos.coords.accuracy,
+      altitudeAccuracy: pos.coords.altitudeAccuracy,
+      heading: pos.coords.heading,
+      speed: pos.coords.speed
+    },
+    timestamp: pos.timestamp
+  };
+}
+
+function mapError(err: BrowserPositionError): CompatGeolocationError {
+  return {
+    code: err.code,
+    message: err.message,
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3
+  };
+}
+
+export function setRNConfiguration(
+  _config: CompatGeolocationConfiguration
+): void {}
+
+export function requestAuthorization(
+  success?: () => void,
+  _error?: (error: CompatGeolocationError) => void
+): void {
+  success?.();
+}
+
+export function getCurrentPosition(
+  success: (position: CompatGeolocationResponse) => void,
+  error?: (error: CompatGeolocationError) => void,
+  options?: CompatGeolocationOptions
+): void {
+  const geo = getGeolocation();
+  if (!geo) {
+    error?.({
+      code: 2,
+      message: "Browser geolocation is unavailable.",
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3
+    });
+    return;
+  }
+  geo.getCurrentPosition(
+    (pos) => success(mapPosition(pos)),
+    error ? (err) => error(mapError(err)) : undefined,
+    options
+      ? {
+          timeout: options.timeout,
+          maximumAge: options.maximumAge,
+          enableHighAccuracy: options.enableHighAccuracy
+        }
+      : undefined
+  );
+}
+
+export function watchPosition(
+  success: (position: CompatGeolocationResponse) => void,
+  error?: (error: CompatGeolocationError) => void,
+  options?: CompatGeolocationOptions
+): number {
+  const geo = getGeolocation();
+  if (!geo) {
+    error?.({
+      code: 2,
+      message: "Browser geolocation is unavailable.",
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3
+    });
+    return -1;
+  }
+  return geo.watchPosition(
+    (pos) => success(mapPosition(pos)),
+    error ? (err) => error(mapError(err)) : undefined,
+    options
+      ? {
+          timeout: options.timeout,
+          maximumAge: options.maximumAge,
+          enableHighAccuracy: options.enableHighAccuracy
+        }
+      : undefined
+  );
+}
+
+export function clearWatch(watchId: number): void {
+  getGeolocation()?.clearWatch(watchId);
+}
+
+export function stopObserving(): void {}
+
+const Geolocation = {
+  setRNConfiguration,
+  requestAuthorization,
+  getCurrentPosition,
+  watchPosition,
+  clearWatch,
+  stopObserving
+};
+
+export default Geolocation;


### PR DESCRIPTION
## Description

Adds web support to the `/compat` subpath of `react-native-nitro-geolocation` so projects using `react-native-web` can import `react-native-nitro-geolocation/compat` without loading native bindings.

- New `src/compat/index.web.ts` delegates all compat methods to `navigator.geolocation` via the shared `getGeolocation()` helper.
- `package.json` exports for `./compat` now expose `react-native` and `browser` conditions in addition to `default`.
- `stopObserving` tracks active watch IDs and clears them on call, matching native iOS/Android behavior (previously a no-op would leak watches).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] My code follows the project style
- [x] I've tested my changes locally
- [ ] Documentation updated (if needed)

## E2E Test Results

This change targets web, not iOS/Android. Native e2e is not applicable.
Web e2e was run locally via the new `Run Compat Suite` button in `examples/web-e2e`:

- compat-api-availability: PASS
- compat-get-current-position: PASS
- compat-watch-position + clearWatch: PASS
- compat-stop-observing: PASS

Unit tests: `yarn workspace react-native-nitro-geolocation test` — 52 passed.

**Platform tested:**
- [ ] iOS
- [ ] Android
- [x] N/A (web-only, Native is unchanged)

**Test artifacts:**
<!-- Optional: Upload screenshots or videos if there were failures -->

---

## Additional Notes

- `stopObserving` was previously a no-op on web. The fix introduces an internal `Set<number>` to track active browser watch IDs, then iterates and calls `clearWatch` on each. Behavior now matches the native compat implementations.
- Metro web compatibility confirmed by reading `metro-config` defaults (`unstable_conditionsByPlatform.web = ["browser"]`).
