### PR TITLE
docs: refresh 1.3 release docs

### DIFF
--- a/.changeset/bright-docs-roundtrip.md
+++ b/.changeset/bright-docs-roundtrip.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": patch
+"@react-native-nitro-geolocation/rozenite-plugin": patch
+---
+
+Refresh release documentation and simplify first-run guidance without changing
+package runtime behavior.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 
 **Nitro-powered geolocation for modern React Native apps**
 
-A native iOS/Android geolocation module for React Native 0.75+ and New
-Architecture apps. Start by replacing
+A native iOS/Android geolocation module for React Native 0.75+ apps using the
+New Architecture and Nitro Modules. Start by replacing
 [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation)
 with `/compat`, then move to a typed Modern API when you are ready.
+The current release line adds web support for Modern and `/compat` foreground
+geolocation plus a native Background Location API for tracking, geofencing,
+storage recovery, Headless JS, and HTTP sync.
 
 - 🎯 **Simple functional API** — Direct function calls, no complex abstractions
 - ⚡ **JSI-powered performance** — Direct native calls without Bridge overhead
@@ -31,23 +34,25 @@ Full documentation available at:
 
 | Use case | Recommendation |
 |---|---|
-| Bare React Native 0.75+ app | Use Nitro Geolocation |
+| Bare React Native 0.75+ app with New Architecture/Nitro enabled | Use Nitro Geolocation |
 | Migrating from `@react-native-community/geolocation` | Start with `/compat` |
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import |
+| Web support required | Use the Modern API root import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import. Browser builds resolve
-the package root to a web entry that uses `navigator.geolocation` and does not
-load Nitro native bindings. The `/compat` subpath remains native-only.
+Web support is available for the Modern API root import and the `/compat`
+subpath. Browser builds resolve both entries to implementations backed by
+`navigator.geolocation` and do not load Nitro native bindings. Background
+location remains native-only.
 
 ---
 
 ## 🧭 Introduction
 
-React Native Nitro Geolocation provides **two APIs** to fit your needs:
+React Native Nitro Geolocation provides **three public API surfaces** to fit
+your needs:
 
 ### 1. Modern API (Recommended)
 
@@ -57,88 +62,27 @@ React Native Nitro Geolocation provides **two APIs** to fit your needs:
 import {
   setConfiguration,
   requestPermission,
-  requestLocationSettings,
-  getLocationAvailability,
   getCurrentPosition,
-  getLastKnownPosition,
-  geocode,
-  reverseGeocode,
-  getHeading,
-  watchHeading,
-  unwatch,
-  getAccuracyAuthorization,
-  requestTemporaryFullAccuracy,
-  useWatchPosition,
 } from "react-native-nitro-geolocation";
 
-// Configure once at app startup
 setConfiguration({
   authorizationLevel: "whenInUse",
   locationProvider: "auto",
 });
 
-// Request permission
 const status = await requestPermission();
 
-// Android, v1.2+: ask the user to enable settings required for accurate location
-await requestLocationSettings({ accuracy: { android: "high" } });
-
-// v1.2+: check whether the platform can currently provide locations
-const availability = await getLocationAvailability();
-
-// Get current location
-const position = await getCurrentPosition({
-  accuracy: { android: "high", ios: "best" },
-  granularity: "permission",
-  waitForAccurateLocation: true,
-});
-
-// v1.2+: read cached location explicitly without starting a fresh request
-const cached = await getLastKnownPosition({
-  maximumAge: 60_000,
-  accuracy: { android: "balanced", ios: "hundredMeters" },
-});
-
-// v1.2+: convert between addresses and coordinates with native geocoders
-const locations = await geocode("City Hall, Seoul, South Korea");
-const addresses = await reverseGeocode({
-  latitude: 37.5665,
-  longitude: 126.978,
-});
-
-// v1.2+: inspect precise/reduced accuracy authorization
-const accuracyAuthorization = await getAccuracyAuthorization();
-if (accuracyAuthorization === "reduced") {
-  await requestTemporaryFullAccuracy("TurnByTurnNavigation");
-}
-
-// v1.2+: read and watch compass heading
-const heading = await getHeading();
-const headingToken = watchHeading((nextHeading) => {
-  console.log(nextHeading.magneticHeading);
-});
-unwatch(headingToken);
-
-// Continuous tracking with hook
-function LocationTracker() {
-  const { position, error, isWatching } = useWatchPosition({
-    enabled: true,
-    accuracy: { android: "high", ios: "bestForNavigation" },
-    distanceFilter: 10,
+if (status === "granted") {
+  const position = await getCurrentPosition({
+    accuracy: { android: "high", ios: "best" },
+    timeout: 15_000,
   });
-
-  if (error) return <Text>Error: {error.message}</Text>;
-  if (!position) return <Text>Waiting...</Text>;
-
-  return (
-    <Text>
-      {position.coords.latitude}, {position.coords.longitude}
-    </Text>
-  );
 }
 ```
 
-**Benefits**:
+See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
+for watches, geocoding, heading, cached reads, Android settings, and iOS
+accuracy authorization.
 
 ### 2. Compat API (Compatibility)
 
@@ -158,18 +102,22 @@ const watchId = Geolocation.watchPosition((position) => console.log(position));
 Geolocation.clearWatch(watchId);
 ```
 
-#### Compat API coverage
+The `/compat` subpath covers the core native community API, including
+`setRNConfiguration`, `requestAuthorization`, `getCurrentPosition`,
+`watchPosition`, `clearWatch`, and `stopObserving`. It also has a browser entry
+for callback-style foreground geolocation. See the
+[Compat API guide](https://react-native-nitro-geolocation.pages.dev/guide/compat-api)
+for the full compatibility matrix and option notes.
 
-| Community API | Nitro `/compat` | Notes |
-|---|---:|---|
-| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
-| `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
-| `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
-| `watchPosition` | Supported | Returns a numeric watch id. |
-| `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
-| `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
-| `navigator.geolocation` polyfill | Not supported | Use the Modern API root import for web. |
-| Web | Native-only for `/compat` | Modern API root import supports web through `navigator.geolocation`. |
+### 3. Background API
+
+Native background tracking, geofencing, activity events, Android Headless JS,
+HTTP sync, and stored event recovery should use the explicit background subpath.
+
+Background location is native-only. Browser builds expose unsupported stubs so
+web bundles can still import shared code safely. Start with the
+[Background Location guide](https://react-native-nitro-geolocation.pages.dev/background/overview)
+for permissions, start/stop, geofencing, storage recovery, and native sync.
 
 ---
 
@@ -204,6 +152,9 @@ Add permissions to your **Info.plist**:
 <string>This app requires access to your location at all times.</string>
 ```
 
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`.
+
 ---
 
 ### 3. Android Setup
@@ -221,219 +172,24 @@ Optional (for background):
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
----
-
-### 4. Android Reliability
-
-- `locationProvider: "auto"` and `locationProvider: "playServices"` prefer
-  Google Play Services fused location when it is available and fall back to the
-  Android platform provider.
-- Use `locationProvider: "android"` when you need to force Android's platform
-  `LocationManager` path.
-- Supports native settings resolution through `requestLocationSettings`.
-- Supports approximate/coarse location handling through permissions and
-  Android `granularity`.
-- Supports explicit cached reads through `getLastKnownPosition`.
-- Provides structured Modern API errors such as `PLAY_SERVICE_NOT_AVAILABLE`,
-  `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
+Full background tracking uses a foreground service on Android. Add the full
+permission set from the Android background setup guide when using
+`react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
 
 ---
 
-### 5. Expo Development Builds
+### 4. Continue In The Docs
 
-This package requires native Nitro bindings, so it is not an Expo Go module.
-Use Expo prebuild, a development build, or another custom native build flow,
-then apply the same iOS and Android native permission setup shown above.
+Use the docs site for the detailed flows:
 
-Managed Expo apps that cannot rebuild native code should use `expo-location`.
-See the [Expo development build guide](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build)
-for the supported setup path.
-
----
-
-### 6. Development Tools (Optional)
-
-#### DevTools Plugin (Rozenite)
-
-> **Prerequisites**: Requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be installed.
->
-> **API Compatibility**: Only works with the Modern API. Does not support the Compat API (`/compat`).
-
-Mock geolocation data during development with an interactive map interface:
-
-![DevTools Plugin](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
-
-```bash
-npm install @react-native-nitro-geolocation/rozenite-plugin
-# or
-yarn add @react-native-nitro-geolocation/rozenite-plugin
-```
-
-**Setup**:
-
-```tsx
-import {
-  useGeolocationDevTools,
-  createPosition,
-} from "@react-native-nitro-geolocation/rozenite-plugin";
-
-function App() {
-  // Enable location mocking in development
-  useGeolocationDevTools({
-    initialPosition: createPosition("Seoul, South Korea"),
-  });
-
-  return <YourApp />;
-}
-```
-
-**Features**:
-
-- 🗺️ Interactive Leaflet map interface
-- 📍 Click to set location instantly
-- ⌨️ Arrow key navigation for precise control
-- 🏙️ 20 pre-configured city presets
-- ✏️ Manual latitude/longitude input
-- 📊 Real-time heading, speed, and accuracy calculation
-- 🌓 Dark mode support
-
-[See full DevTools guide →](https://react-native-nitro-geolocation.pages.dev/guide/devtools)
-
----
-
-### 7. Usage
-
-#### Modern API (Recommended)
-
-```tsx
-// Get current location
-const position = await getCurrentPosition({
-  accuracy: { android: "high", ios: "best" },
-});
-
-// Real-time tracking with hook
-const { position, error } = useWatchPosition({
-  enabled: true,
-  accuracy: { android: "balanced", ios: "nearestTenMeters" },
-  distanceFilter: 10
-});
-```
-
-Accuracy presets are available since `v1.2`.
-
-`getLastKnownPosition(options?)`, `getLocationAvailability()`, `getHeading()`,
-`watchHeading()`, `geocode(address)`, `reverseGeocode(coords)`, selected
-Android request options (`granularity`, `waitForAccurateLocation`,
-`maxUpdateAge`, `maxUpdateDelay`, and `maxUpdates`), iOS tuning options
-(`activityType`, `pausesLocationUpdatesAutomatically`, and
-`showsBackgroundLocationIndicator`), `getAccuracyAuthorization()`, and
-`requestTemporaryFullAccuracy(purposeKey)` are available since `v1.2`.
-
-`enableHighAccuracy` is deprecated in the Modern API and remains supported only
-for v1 compatibility. Prefer `accuracy`; when `accuracy.android` or
-`accuracy.ios` is provided for the current platform, that explicit preset takes
-precedence over the boolean. `enableHighAccuracy` is expected to be removed from
-the Modern API in v2.
-
-The `/compat` API keeps `enableHighAccuracy` for drop-in compatibility with
-`@react-native-community/geolocation`.
-
-#### Compat API (Compatibility)
-
-```tsx
-import Geolocation from "react-native-nitro-geolocation/compat";
-
-Geolocation.getCurrentPosition((pos) => console.log(pos));
-const watchId = Geolocation.watchPosition((pos) => console.log(pos));
-Geolocation.clearWatch(watchId);
-```
-
----
-
----
-
-## 🔄 Migration
-
-### From `@react-native-community/geolocation`
-
-The safest migration is two-step: switch imports to `/compat` first, verify
-the app, then move call sites to the Modern API where it improves ownership,
-permission timing, cache behavior, or Android settings handling.
-
-For Modern API migration, install the Agent Skills-compatible migration
-playbook from this repository. It is migration assistance for coding agents, not
-a fully automatic migration. The skill first runs a package-manager-aware
-compat bootstrap script that installs the Nitro packages, rewrites legacy import
-sources to `/compat`, and removes `@react-native-community/geolocation`. After
-that safe mechanical step, it guides the agent to refactor compat call sites to
-Modern API best practices using explicit criteria for permission timing, React
-lifecycle ownership, watch cleanup, cache-vs-fresh location reads, accuracy, and
-Android provider/settings handling.
-
-With the Vercel Labs `skills` CLI:
-
-```bash
-npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
-```
-
-The skill source is
-[`skills/community-migration/SKILL.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
-The bundled bootstrap script is
-[`skills/community-migration/scripts/migrate-to-compat.mjs`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration/scripts/migrate-to-compat.mjs).
-
-For a drop-in compatibility migration, change the import to use `/compat`:
-
-```diff
-- import Geolocation from '@react-native-community/geolocation';
-+ import Geolocation from 'react-native-nitro-geolocation/compat';
-```
-
-Then migrate individual call sites to the Modern API:
-
-```diff
-- Geolocation.getCurrentPosition(onSuccess, onError, {
--   enableHighAccuracy: true,
--   timeout: 15000,
-- });
-+ const position = await getCurrentPosition({
-+   accuracy: { android: "high", ios: "best" },
-+   timeout: 15000,
-+ });
-```
-
-See [Community Migration](https://react-native-nitro-geolocation.pages.dev/guide/community-migration)
-for the full community import → `/compat` → Modern API path.
-
-### From `react-native-geolocation-service`
-
-Apps currently using `react-native-geolocation-service` should migrate directly
-to the Modern API. Do not route this path through `/compat`; the service package
-has Android fused-provider, settings-dialog, `mocked`/`provider`, and
-provider-related error behavior that maps more naturally to Modern APIs.
-
-Install the dedicated Agent Skills-compatible migration playbook:
-
-```bash
-npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
-```
-
-See [Service Migration](https://react-native-nitro-geolocation.pages.dev/guide/service-migration)
-for the direct service → Modern API path.
-
----
-
-## Benchmark scope
-
-The benchmark measures cached `getCurrentPosition` reads over 1000 iterations ×
-5 runs on an iPhone 14 Pro with React Native 0.81.4. It measures the
-JS-to-native path for cached locations, not cold GPS acquisition, permission
-dialogs, provider availability, or OS throttling.
-
-For cached location reads, Nitro removes Bridge overhead. This does not make GPS
-acquisition itself 22x faster; it makes cached reads and the JS-to-native call
-path cheaper.
-
----
+- [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
+- [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
+- [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
+- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+- [Migration Assistance](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance) - choose the community or service migration path.
+- [Expo Development Builds](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build) - use the package in Expo custom native builds.
+- [DevTools Plugin](https://react-native-nitro-geolocation.pages.dev/guide/devtools) - mock locations during development.
 
 ## 📖 Learn More
 

--- a/docs/docs/background/activity-recognition.md
+++ b/docs/docs/background/activity-recognition.md
@@ -22,6 +22,10 @@ Activity events are delivered through the same native event pipeline as location
 and geofence events. Android uses Activity Recognition APIs. iOS uses Core
 Motion when available.
 
+On Android 10+, request `android.permission.ACTIVITY_RECOGNITION` at runtime
+before calling `startActivityRecognition()` or using `trackingMode:
+'activityAware'`.
+
 `trackingMode: 'activityAware'` enables activity collection alongside background
 tracking. Apps can use `onActivityChange` events to pause, resume, or tune
 tracking policy for their own product rules.

--- a/docs/docs/background/overview.md
+++ b/docs/docs/background/overview.md
@@ -14,3 +14,11 @@ import {
 
 Prefer `react-native-nitro-geolocation/background` so foreground and background
 imports stay explicit and tree-shakable.
+
+## Where to go next
+
+- [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.
+- [Permissions](/background/permissions) - request foreground/background access and handle settings round-trips.
+- [Start And Stop](/background/start-stop) - start continuous tracking and subscribe to native updates.
+- [Storage Recovery](/background/storage) - drain events recorded while JavaScript was not running.
+- [Geofencing](/background/geofencing), [Activity Recognition](/background/activity-recognition), and [Native HTTP Sync](/background/http-sync) - add advanced background behavior.

--- a/docs/docs/background/permissions.md
+++ b/docs/docs/background/permissions.md
@@ -3,16 +3,33 @@
 ```ts
 import {
   checkBackgroundPermission,
-  requestBackgroundPermission,
   openAppLocationSettings,
+  requestBackgroundPermission,
 } from 'react-native-nitro-geolocation/background';
 
-const status = await checkBackgroundPermission();
-const requested = await requestBackgroundPermission();
+export async function requestBackgroundAccess() {
+  const requested = await requestBackgroundPermission();
 
-if (requested.needsSettingsRedirect) {
-  await openAppLocationSettings();
+  if (requested.needsSettingsRedirect) {
+    // Android 11+ may already have opened app settings. On iOS, show your own
+    // explanation before sending denied/restricted users to settings.
+    // await openAppLocationSettings();
+    return requested;
+  }
+
+  return requested;
+}
+
+export async function refreshBackgroundAccessAfterResume() {
+  return checkBackgroundPermission();
 }
 ```
 
-`foreground` and `background` are separate because Android and iOS gate background access differently.
+`foreground` and `background` are separate because Android and iOS gate
+background access differently. `needsSettingsRedirect` means the app still needs
+a settings or app-resume round-trip before background tracking can start. On
+Android 11+, `requestBackgroundPermission()` can open the app settings screen
+because the platform no longer allows inline background-location prompts. On
+iOS, it can also remain true until Always authorization is granted; use
+`openAppLocationSettings()` after explaining why Always access is required.
+Call `checkBackgroundPermission()` again from your app-resume path.

--- a/docs/docs/background/start-stop.md
+++ b/docs/docs/background/start-stop.md
@@ -2,33 +2,60 @@
 
 ```ts
 import {
+  checkBackgroundPermission,
   requestBackgroundPermission,
   startBackgroundLocation,
   stopBackgroundLocation,
   onBackgroundLocation,
 } from 'react-native-nitro-geolocation/background';
 
-const permission = await requestBackgroundPermission();
+let subscription;
 
-if (permission.foreground === 'granted' && permission.background === 'granted') {
-  await startBackgroundLocation({
-    trackingMode: 'activityAware',
-    interval: 10_000,
-    fastestInterval: 5_000,
-    distanceFilter: 25,
-    persist: true,
-    stopOnTerminate: false,
-    startOnBoot: true,
-    android: {
-      foregroundService: {
-        notificationTitle: 'Location tracking active',
-        notificationText: 'Your location is being recorded',
-      },
-    },
-  });
+export async function requestAndMaybeStartTracking() {
+  const permission = await requestBackgroundPermission();
+
+  if (permission.needsSettingsRedirect) {
+    // Register an AppState "active" handler and call resumeBackgroundTracking()
+    // after the user returns from settings or the authorization prompt settles.
+    return;
+  }
+
+  await startIfAllowed(permission);
 }
 
-const sub = onBackgroundLocation(console.log);
-await stopBackgroundLocation();
-sub.remove();
+export async function resumeBackgroundTracking() {
+  const permission = await checkBackgroundPermission();
+  await startIfAllowed(permission);
+}
+
+async function startIfAllowed(permission) {
+  if (permission.foreground === 'granted' && permission.background === 'granted') {
+    await startBackgroundLocation({
+      trackingMode: 'continuous',
+      interval: 10_000,
+      fastestInterval: 5_000,
+      distanceFilter: 25,
+      persist: true,
+      android: {
+        foregroundService: {
+          notificationTitle: 'Location tracking active',
+          notificationText: 'Your location is being recorded',
+        },
+      },
+    });
+
+    subscription?.remove();
+    subscription = onBackgroundLocation(console.log);
+  }
+}
+
+export async function stopTracking() {
+  await stopBackgroundLocation();
+  subscription?.remove();
+  subscription = undefined;
+}
 ```
+
+Use [Activity Recognition](/background/activity-recognition) before switching to
+`trackingMode: 'activityAware'`. Use [Android Setup](/background/setup-android)
+before enabling boot restart or changing foreground-service behavior.

--- a/docs/docs/guide/compat-api.md
+++ b/docs/docs/guide/compat-api.md
@@ -34,11 +34,14 @@ Promise/function API.
 | `watchPosition` | Supported | Returns a numeric watch id. |
 | `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
 | `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
-| `navigator.geolocation` polyfill | Not supported | Use the Modern API root import for web. |
-| Web | Native-only for `/compat` | Modern API root import supports web through `navigator.geolocation`. |
+| `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
+| Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
 
-The root Modern API supports web by delegating to the browser
-`navigator.geolocation` API. The `/compat` subpath remains native-only.
+The root Modern API and `/compat` subpath both support web by delegating to the
+browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
+shape and legacy error constants, while `setRNConfiguration()` is a no-op and
+`requestAuthorization()` calls the success callback immediately because browsers
+do not expose a standalone geolocation authorization prompt.
 
 ## Summary
 
@@ -53,7 +56,9 @@ The root Modern API supports web by delegating to the browser
 
 ### `setRNConfiguration()`
 
-Sets configuration options that will be used in all location requests.
+Preserves the legacy configuration API. Use it for iOS authorization/background
+settings. Android provider selection and request behavior should be configured
+per call or through the Modern API root import.
 
 ```ts
 Geolocation.setRNConfiguration(config: {
@@ -66,9 +71,9 @@ Geolocation.setRNConfiguration(config: {
 
 Supported options:
 
-- `skipPermissionRequests` (boolean) - Defaults to `false`. If `true`, you must request permissions before using Geolocation APIs.
+- `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
 - `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
-- `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggle wether to automatically enableBackgroundLocationUpdates. Defaults to true.
+- `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
 - `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
 
 ### `requestAuthorization()`
@@ -119,15 +124,26 @@ Geolocation.getCurrentPosition(
     timeout?: number;
     maximumAge?: number;
     enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
   }
 );
 ```
 
 Supported options:
 
-- `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to 10 minutes.
-- `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device will always return a cached position regardless of its age. Defaults to INFINITY.
+- `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Native compat defaults to 10 minutes. Web omits the field when you do not pass it, so browser defaults apply.
+- `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. Native compat defaults to INFINITY. Web omits the field when you do not pass it, so browser defaults apply.
 - `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
 
 ### `watchPosition()`
 
@@ -160,8 +176,15 @@ Geolocation.watchPosition(
     timeout?: number;
     maximumAge?: number;
     enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
     distanceFilter?: number;
     useSignificantChanges?: boolean;
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
   }
 ) => number;
 ```
@@ -169,12 +192,18 @@ Geolocation.watchPosition(
 Supported options:
 
 - `interval` (ms) -- (Android only) The rate in milliseconds at which your app prefers to receive location updates. Note that the location updates may be somewhat faster or slower than this rate to optimize for battery usage, or there may be no updates at all (if the device has no connectivity, for example).
-- `fastestInterval` (ms) -- (Android only) The fastest rate in milliseconds at which your app can handle location updates. Unless your app benefits from receiving updates more quickly than the rate specified in `interval`, you don't need to set it.
-- `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Defaults to 10 minutes.
-- `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device will always return a cached position regardless of its age. Defaults to INFINITY.
 - `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
-- `distanceFilter` (m) - The minimum distance from the previous location to exceed before returning a new location. Set to 0 to not filter locations. Defaults to 100m.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `distanceFilter` (m) - The minimum distance from the previous location to exceed before returning a new location. Set to 0 to not filter locations. Defaults to 100m on Android and no distance filter on iOS.
 - `useSignificantChanges` (bool) - Uses the battery-efficient native significant changes APIs to return locations. Locations will only be returned when the device detects a significant distance has been breached. Defaults to FALSE.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
+
+`timeout`, `maximumAge`, and `fastestInterval` are part of the legacy option
+type for compatibility, but native `/compat` watches do not use them. On web,
+`watchPosition()` forwards `timeout`, `maximumAge`, and `enableHighAccuracy` to
+`navigator.geolocation`.
 
 ### `clearWatch()`
 

--- a/docs/docs/guide/devtools.md
+++ b/docs/docs/guide/devtools.md
@@ -110,13 +110,13 @@ Enter exact coordinates via input fields:
 ### Location Presets
 Quick access to 20 major cities worldwide:
 
-**Asia-Pacific**: Seoul, Tokyo, Beijing, Singapore, Mumbai, Sydney
+**Asia-Pacific**: Seoul, Tokyo, Beijing, Shanghai, Hong Kong, Singapore, Mumbai, Bangkok, Sydney
 
-**Europe**: London, Paris, Berlin, Moscow, Istanbul
+**Europe**: London, Paris, Berlin, Moscow
 
-**Americas**: New York, Los Angeles, São Paulo, Mexico City, Toronto, Buenos Aires
+**Americas**: New York, Los Angeles, San Francisco, São Paulo, Mexico City, Toronto
 
-**Middle East & Africa**: Dubai, Cairo, Johannesburg
+**Middle East**: Dubai
 
 ### Real-time Position Data
 

--- a/docs/docs/guide/expo-development-build.md
+++ b/docs/docs/guide/expo-development-build.md
@@ -50,6 +50,9 @@ iOS `Info.plist`:
 <string>This app requires access to your location at all times.</string>
 ```
 
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
 Android `AndroidManifest.xml`:
 
 ```xml
@@ -63,6 +66,11 @@ Optional background permission:
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
+
 ## Supported Positioning
 
 Use this package when you want Nitro/New Architecture native geolocation in an
@@ -71,4 +79,3 @@ Expo development build or custom native build.
 Use `expo-location` when you need Expo Go, managed workflow setup without native
 rebuilds, Expo background tasks, Expo geofencing, or Expo config-plugin-driven
 permission setup.
-

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -10,23 +10,29 @@ React Native 0.75+ / New Architecture path for replacing the core native
 `@react-native-community/geolocation` API with `/compat`, then gradually moving
 to a typed Modern API.
 
+The current release line adds a clearer three-surface story: Modern and
+`/compat` foreground geolocation on web, plus a native Background Location API
+for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
 ## When should I use this?
 
 | Use case | Recommendation |
 | --- | --- |
-| Bare React Native 0.75+ app | Use Nitro Geolocation |
+| Bare React Native 0.75+ app with New Architecture/Nitro enabled | Use Nitro Geolocation |
 | Migrating from `@react-native-community/geolocation` | Start with `/compat` |
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import |
+| Web support required | Use the Modern API root import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import. Browser builds resolve
-the package root to a web entry that uses `navigator.geolocation` and does not
-load Nitro native bindings. The `/compat` subpath remains native-only.
+Web support is available for the Modern API root import and the `/compat`
+subpath. Browser builds resolve both entries to implementations backed by
+`navigator.geolocation` and do not load Nitro native bindings. Background
+location remains native-only.
 
-React Native Nitro Geolocation provides **two APIs** to fit your needs:
+React Native Nitro Geolocation provides **three public API surfaces** to fit
+your needs:
 
 ## 1. Modern API (Recommended)
 
@@ -50,10 +56,14 @@ setConfiguration({
 
 // Request permission
 const status = await requestPermission();
+if (status !== 'granted') {
+  throw new Error('Location permission was not granted');
+}
 
 // Get current location
 const position = await getCurrentPosition({
-  enableHighAccuracy: true
+  accuracy: { android: 'high', ios: 'best' },
+  timeout: 15000
 });
 
 // Convert between addresses and coordinates
@@ -67,7 +77,7 @@ const addresses = await reverseGeocode({
 function LocationTracker() {
   const { position, error, isWatching } = useWatchPosition({
     enabled: true,
-    enableHighAccuracy: true,
+    accuracy: { android: 'high', ios: 'bestForNavigation' },
     distanceFilter: 10
   });
 
@@ -108,6 +118,16 @@ Geolocation.getCurrentPosition(
 - Minimal migration effort
 - Callback-based API preference
 
+## 3. Background API
+
+Native background tracking, geofencing, activity events, Android Headless JS,
+HTTP sync, and stored event recovery should use the explicit background subpath
+`react-native-nitro-geolocation/background`.
+
+Background location is native-only. Browser builds expose unsupported stubs so
+web bundles can still import shared code safely. Start with the
+[Background Location guide](/background/overview) when you need full background
+tracking, geofencing, storage recovery, or native sync.
 
 ## Why Modern API?
 
@@ -201,13 +221,14 @@ Instead of complex provider patterns or class-based APIs, we provide:
 
 ## What You Get
 
-Whether you choose Modern or Compat API, you get:
+The package has three clear surfaces:
 
-- 🚀 **Lower cached-read overhead** through direct JSI bindings
-- 📱 **Improved native consistency** across Android and iOS
-- 🔁 **Seamless migration** from `@react-native-community/geolocation`
-- 🧩 **TypeScript-first** developer experience
-- 🔄 **Compat API** (via `/compat`) for the core native community geolocation surface
+- **Modern API** - typed foreground geolocation, geocoding, watching, cached reads, and Android settings helpers.
+- **Compat API** - a `/compat` path for migrating the core `@react-native-community/geolocation` surface.
+- **Background API** - native tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
+Modern and `/compat` foreground APIs also support web through the browser
+`navigator.geolocation` API.
 
 The benchmark measures cached location reads and the JS-to-native call path. It
 does not make cold GPS acquisition itself 22x faster.

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -4,7 +4,8 @@ This guide walks you through installing and setting up **React Native Nitro Geol
 
 ## 1. Installation
 
-Before installing the module, make sure you have a React Native environment (0.75+).
+Before installing the module, make sure your app uses React Native 0.75+ with
+the New Architecture and Nitro Modules enabled.
 
 ```bash
 # Install Nitro core and Geolocation module
@@ -38,6 +39,9 @@ Add the following keys to your **Info.plist**:
 <string>This app requires access to your location at all times.</string>
 ```
 
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
 
 ## 3. Android Setup
 
@@ -54,404 +58,70 @@ Optional (for background access):
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-## 4. Android Reliability
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
 
-Use the Android provider and settings APIs when your flow depends on accurate
-location or when you are migrating from packages that rely on fused location.
+## 4. Get Your First Location
+
+Configure once at app startup. Ask for permission from a user action, then read
+one position.
 
 ```tsx
 import {
   getCurrentPosition,
-  getLastKnownPosition,
-  requestLocationSettings,
+  requestPermission,
   setConfiguration
 } from 'react-native-nitro-geolocation';
 
 setConfiguration({
   authorizationLevel: 'whenInUse',
-  locationProvider: 'playServices'
+  locationProvider: 'auto'
 });
 
+async function handleUseMyLocation() {
+  const status = await requestPermission();
+
+  if (status === 'granted') {
+    const position = await getCurrentPosition({
+      accuracy: { android: 'high', ios: 'best' },
+      timeout: 15000
+    });
+  }
+}
+```
+
+## 5. Android Accuracy Helpers (Optional)
+
+If Android needs a settings prompt or an explicit cached read, configure the
+provider in your startup `setConfiguration()` call and add the settings helpers
+from the [Modern API reference](/guide/modern-api).
+
+```tsx
+import {
+  getLastKnownPosition,
+  requestLocationSettings
+} from 'react-native-nitro-geolocation';
+
 await requestLocationSettings({
-  accuracy: { android: 'high' },
-  interval: 5000,
-  fastestInterval: 1000
+  accuracy: { android: 'high' }
 });
 
 const cached = await getLastKnownPosition({
   maximumAge: 60_000,
   accuracy: { android: 'balanced', ios: 'hundredMeters' }
 });
-
-const fresh = await getCurrentPosition({
-  accuracy: { android: 'high', ios: 'best' },
-  granularity: 'permission',
-  waitForAccurateLocation: true,
-  timeout: 15000
-});
 ```
-
-- `locationProvider: 'auto'` and `locationProvider: 'playServices'` prefer
-  Google Play Services fused location when available and fall back to Android's
-  platform provider.
-- `locationProvider: 'android'` forces Android's platform `LocationManager`
-  path.
-- `requestLocationSettings()` can show Android's native settings resolution
-  dialog when settings do not satisfy the request.
-- `granularity` and Android permission state support approximate/coarse
-  location handling.
-- `getLastKnownPosition()` makes cached reads explicit instead of hiding them
-  inside a fresh request.
-- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
-  `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
-
-
-## 5. Usage with Modern API (Recommended)
-
-The Modern API provides **simple functional calls** with direct functions and a single hook for tracking.
-
-### Setup Configuration
-
-Configure once at app startup:
-
-```tsx
-import { useEffect } from 'react';
-import { setConfiguration } from 'react-native-nitro-geolocation';
-
-function App() {
-  useEffect(() => {
-    setConfiguration({
-      authorizationLevel: 'whenInUse',
-      enableBackgroundLocationUpdates: false,
-      locationProvider: 'auto'
-    });
-  }, []);
-
-  return (
-    <NavigationContainer>
-      <RootNavigator />
-    </NavigationContainer>
-  );
-}
-```
-
-### Request Permission
-
-```tsx
-import { useState } from 'react';
-import { Button, Text, View } from 'react-native';
-import { requestPermission } from 'react-native-nitro-geolocation';
-
-function PermissionButton() {
-  const [status, setStatus] = useState<string>('unknown');
-  const [loading, setLoading] = useState(false);
-
-  const handlePress = async () => {
-    setLoading(true);
-    try {
-      const result = await requestPermission();
-      setStatus(result);
-      if (result === 'granted') {
-        console.log('Permission granted!');
-      }
-    } catch (err) {
-      console.error('Permission error:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <View>
-      <Button
-        onPress={handlePress}
-        disabled={loading}
-        title={loading ? 'Requesting...' : 'Enable Location'}
-      />
-      <Text>Status: {status}</Text>
-    </View>
-  );
-}
-```
-
-### Get Current Position
-
-```tsx
-import { useState } from 'react';
-import { Button, Text, View } from 'react-native';
-import {
-  getCurrentPosition,
-  type GeolocationResponse
-} from 'react-native-nitro-geolocation';
-
-function LocationButton() {
-  const [position, setPosition] = useState<GeolocationResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handlePress = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const pos = await getCurrentPosition({
-        enableHighAccuracy: true,
-        timeout: 15000
-      });
-      setPosition(pos);
-    } catch (err: any) {
-      setError(err?.message || 'Unknown error');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <View>
-      <Button
-        onPress={handlePress}
-        disabled={loading}
-        title={loading ? 'Loading...' : 'Get Location'}
-      />
-      {error && <Text style={{ color: 'red' }}>Error: {error}</Text>}
-      {position && (
-        <View>
-          <Text>Lat: {position.coords.latitude}</Text>
-          <Text>Lng: {position.coords.longitude}</Text>
-          <Text>Accuracy: {position.coords.accuracy}m</Text>
-        </View>
-      )}
-    </View>
-  );
-}
-```
-
-### Geocode and Reverse Geocode
-
-```tsx
-import {
-  geocode,
-  reverseGeocode
-} from 'react-native-nitro-geolocation';
-
-const locations = await geocode('City Hall, Seoul, South Korea');
-const firstLocation = locations[0];
-
-const addresses = await reverseGeocode({
-  latitude: 37.5665,
-  longitude: 126.978
-});
-const firstAddress = addresses[0];
-```
-
-`geocode(address)` and `reverseGeocode(coords)` use Android `Geocoder` and iOS
-`CLGeocoder`. Result quality, language, and availability depend on the platform
-geocoder service and network state.
-
-### Watch Position (Real-time Tracking)
-
-```tsx
-import { useState } from 'react';
-import { Switch, Text, View } from 'react-native';
-import { useWatchPosition } from 'react-native-nitro-geolocation';
-
-function LiveTracker() {
-  const [enabled, setEnabled] = useState(false);
-
-  const { position, error, isWatching } = useWatchPosition({
-    enabled,
-    enableHighAccuracy: true,
-    distanceFilter: 10,  // Update every 10 meters
-    interval: 5000       // Update every 5 seconds
-  });
-
-  return (
-    <View>
-      <Switch
-        value={enabled}
-        onValueChange={setEnabled}
-        label="Track location"
-      />
-
-      <Text>Status: {isWatching ? 'Watching 🟢' : 'Stopped 🔴'}</Text>
-
-      {error && (
-        <Text style={{ color: 'red' }}>Error: {error.message}</Text>
-      )}
-
-      {position && (
-        <View>
-          <Text>Lat: {position.coords.latitude}</Text>
-          <Text>Lng: {position.coords.longitude}</Text>
-          <Text>Accuracy: {position.coords.accuracy}m</Text>
-          {position.coords.speed !== null && (
-            <Text>Speed: {position.coords.speed}m/s</Text>
-          )}
-        </View>
-      )}
-    </View>
-  );
-}
-```
-
-**Key Features**:
-- ✅ Automatic cleanup when component unmounts
-- ✅ Declarative start/stop with `enabled` prop
-- ✅ No need to manage watch IDs manually
-- ✅ Battery efficient - native subscription stops when disabled
-
-
-## 6. Usage with Compat API (Compatibility)
-
-For compatibility with `@react-native-community/geolocation`, use the `/compat` import:
-
-```tsx
-import Geolocation from 'react-native-nitro-geolocation/compat';
-
-Geolocation.getCurrentPosition(
-  (position) => {
-    console.log('Latitude:', position.coords.latitude);
-    console.log('Longitude:', position.coords.longitude);
-  },
-  (error) => console.error('Location error:', error),
-  { enableHighAccuracy: true, timeout: 15000 }
-);
-
-// Subscribe to updates
-const watchId = Geolocation.watchPosition(
-  (position) => console.log('Updated position:', position),
-  (error) => console.error(error)
-);
-
-// Don't forget to cleanup!
-Geolocation.clearWatch(watchId);
-```
-
-
-## 7. Migration Guides
-
-### From `@react-native-community/geolocation`
-
-Simply change the import path:
-
-```diff
-- import Geolocation from '@react-native-community/geolocation';
-+ import Geolocation from 'react-native-nitro-geolocation/compat';
-```
-
-or
-
-```diff
-- import { getCurrentPosition, watchPosition } from '@react-native-community/geolocation';
-+ import { getCurrentPosition, watchPosition } from 'react-native-nitro-geolocation/compat';
-```
-
-The `/compat` path is drop-in compatible with the core native community
-geolocation API. You'll get:
-- Better performance via JSI
-- Reduced bridge serialization overhead
-- Improved permission consistency
-- TypeScript definitions out of the box
-
-The root Modern API supports web through the browser `navigator.geolocation`
-API. The `/compat` subpath remains native-only. Web location requires a secure
-context and browser permission; unsupported provider/sensor APIs reject with the
-Modern API `POSITION_UNAVAILABLE` error shape.
-
-### From Compat to Modern API (Recommended)
-
-Upgrade to the simpler functional API:
-
-**Before (Compat API)**:
-```tsx
-import Geolocation from 'react-native-nitro-geolocation/compat';
-
-function LocationTracker() {
-  const [position, setPosition] = useState(null);
-  const watchIdRef = useRef(null);
-
-  useEffect(() => {
-    watchIdRef.current = Geolocation.watchPosition(
-      (pos) => setPosition(pos),
-      (err) => console.error(err),
-      { enableHighAccuracy: true }
-    );
-
-    return () => {
-      if (watchIdRef.current !== null) {
-        Geolocation.clearWatch(watchIdRef.current);
-      }
-    };
-  }, []);
-
-  return <Map position={position} />;
-}
-```
-
-**After (Modern API)**:
-```tsx
-import { useWatchPosition } from 'react-native-nitro-geolocation';
-
-function LocationTracker() {
-  const { position } = useWatchPosition({
-    enabled: true,
-    enableHighAccuracy: true
-  });
-
-  return <Map position={position} />;
-}
-```
-
-**Benefits**:
-- 70% less code
-- No watch ID management
-- Automatic cleanup
-- Declarative enable/disable
-- Better TypeScript support
-
-
-## 8. Development Tools (Optional)
-
-For an enhanced development experience, install the Rozenite DevTools plugin to mock locations:
-
-```bash
-npm install @react-native-nitro-geolocation/rozenite-plugin
-# or
-yarn add @react-native-nitro-geolocation/rozenite-plugin
-```
-
-Add to your app:
-
-```tsx
-import { useGeolocationDevTools, createPosition } from '@react-native-nitro-geolocation/rozenite-plugin';
-
-function App() {
-  // Enable location mocking in development
-  useGeolocationDevTools({
-    initialPosition: createPosition('Seoul, South Korea')
-  });
-
-  // ... rest of your app
-}
-```
-
-**Features**:
-- 🗺️ Interactive map interface
-- 📍 Click to set location
-- ⌨️ Arrow key navigation
-- 🏙️ 20 city presets
-- 📊 Real-time heading/speed calculation
-
-Learn more in the [DevTools Plugin Guide](/guide/devtools).
-
-:::warning Prerequisites
-The DevTools plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be installed in your project.
-:::
 
 
 ## Next Steps
 
-- [DevTools Plugin Guide](/guide/devtools) — Mock locations in development
 - [Modern API Reference](/guide/modern-api) — Complete documentation
 - [Compat API Reference](/guide/compat-api) — Compatibility methods
+- [Background Location](/background/overview) — Native background tracking, geofencing, and storage recovery
+- [Migration Guides](/guide/migration-assistance) — Move from community/service geolocation packages
+- [Expo Development Builds](/guide/expo-development-build) — Use the package in Expo custom native builds
+- [DevTools Plugin Guide](/guide/devtools) — Mock locations in development
 - [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
 - [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/guide/react-native-directory.md
+++ b/docs/docs/guide/react-native-directory.md
@@ -13,7 +13,7 @@ Native Directory.
 | --- | --- |
 | iOS | Supported |
 | Android | Supported |
-| Web | Modern API root import supported through `navigator.geolocation`; `/compat` remains native-only |
+| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
 | New Architecture | Required target; implemented through Nitro Modules |
 | Expo Go | Not supported |
 | Expo development builds | Supported with native setup |
@@ -24,19 +24,19 @@ Native Directory.
 Recommended short description:
 
 ```txt
-Nitro-powered native geolocation for React Native 0.75+. Use /compat to replace @react-native-community/geolocation, then migrate to a typed Modern API with Android settings checks, geocoding, heading, background tracking, and DevTools mocking.
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
 ```
 
 Recommended caveat:
 
 ```txt
-Targets bare React Native, RN CLI, Expo development/custom native builds, and Modern API web through navigator.geolocation. Expo Go and `/compat` web are not supported.
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
 ```
 
 ## Pre-Submission Checklist
 
 - README explains when to use the package and when not to use it.
-- README includes compat coverage, Modern API web behavior, and Expo limitations.
+- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
 - npm package has discoverability keywords.
 - Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
 - Docs include Expo development build guidance.

--- a/docs/docs/guide/service-migration.md
+++ b/docs/docs/guide/service-migration.md
@@ -10,8 +10,13 @@ Modern API:
 ```ts
 import {
   getCurrentPosition,
+  getLastKnownPosition,
+  hasServicesEnabled,
+  LocationErrorCode,
+  requestPermission,
   requestLocationSettings,
   setConfiguration,
+  stopObserving,
   unwatch,
   watchPosition
 } from 'react-native-nitro-geolocation';

--- a/packages/react-native-nitro-geolocation/CHANGELOG.md
+++ b/packages/react-native-nitro-geolocation/CHANGELOG.md
@@ -1,11 +1,5 @@
 # react-native-nitro-geolocation
 
-## 1.3.0
-
-### Minor Changes
-
-- Add dedicated Background Location API with Android foreground-service updates, iOS background updates, native event persistence, Android Headless JS delivery, geofencing, activity recognition events, start-on-boot support, native HTTP sync, and stored event recovery.
-
 ## 1.2.6
 
 ### Patch Changes

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -4,10 +4,13 @@
 
 **Nitro-powered geolocation for modern React Native apps**
 
-A native iOS/Android geolocation module for React Native 0.75+ and New
-Architecture apps. Start by replacing
+A native iOS/Android geolocation module for React Native 0.75+ apps using the
+New Architecture and Nitro Modules. Start by replacing
 [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation)
 with `/compat`, then move to a typed Modern API when you are ready.
+The current release line adds web support for Modern and `/compat` foreground
+geolocation plus a native Background Location API for tracking, geofencing,
+storage recovery, Headless JS, and HTTP sync.
 
 - 🎯 **Simple functional API** — Direct function calls, no complex abstractions
 - ⚡ **JSI-powered performance** — Direct native calls without Bridge overhead
@@ -31,23 +34,25 @@ Full documentation available at:
 
 | Use case | Recommendation |
 |---|---|
-| Bare React Native 0.75+ app | Use Nitro Geolocation |
+| Bare React Native 0.75+ app with New Architecture/Nitro enabled | Use Nitro Geolocation |
 | Migrating from `@react-native-community/geolocation` | Start with `/compat` |
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import |
+| Web support required | Use the Modern API root import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import. Browser builds resolve
-the package root to a web entry that uses `navigator.geolocation` and does not
-load Nitro native bindings. The `/compat` subpath remains native-only.
+Web support is available for the Modern API root import and the `/compat`
+subpath. Browser builds resolve both entries to implementations backed by
+`navigator.geolocation` and do not load Nitro native bindings. Background
+location remains native-only.
 
 ---
 
 ## 🧭 Introduction
 
-React Native Nitro Geolocation provides **two APIs** to fit your needs:
+React Native Nitro Geolocation provides **three public API surfaces** to fit
+your needs:
 
 ### 1. Modern API (Recommended)
 
@@ -57,88 +62,27 @@ React Native Nitro Geolocation provides **two APIs** to fit your needs:
 import {
   setConfiguration,
   requestPermission,
-  requestLocationSettings,
-  getLocationAvailability,
   getCurrentPosition,
-  getLastKnownPosition,
-  geocode,
-  reverseGeocode,
-  getHeading,
-  watchHeading,
-  unwatch,
-  getAccuracyAuthorization,
-  requestTemporaryFullAccuracy,
-  useWatchPosition,
 } from "react-native-nitro-geolocation";
 
-// Configure once at app startup
 setConfiguration({
   authorizationLevel: "whenInUse",
   locationProvider: "auto",
 });
 
-// Request permission
 const status = await requestPermission();
 
-// Android, v1.2+: ask the user to enable settings required for accurate location
-await requestLocationSettings({ accuracy: { android: "high" } });
-
-// v1.2+: check whether the platform can currently provide locations
-const availability = await getLocationAvailability();
-
-// Get current location
-const position = await getCurrentPosition({
-  accuracy: { android: "high", ios: "best" },
-  granularity: "permission",
-  waitForAccurateLocation: true,
-});
-
-// v1.2+: read cached location explicitly without starting a fresh request
-const cached = await getLastKnownPosition({
-  maximumAge: 60_000,
-  accuracy: { android: "balanced", ios: "hundredMeters" },
-});
-
-// v1.2+: convert between addresses and coordinates with native geocoders
-const locations = await geocode("City Hall, Seoul, South Korea");
-const addresses = await reverseGeocode({
-  latitude: 37.5665,
-  longitude: 126.978,
-});
-
-// v1.2+: inspect precise/reduced accuracy authorization
-const accuracyAuthorization = await getAccuracyAuthorization();
-if (accuracyAuthorization === "reduced") {
-  await requestTemporaryFullAccuracy("TurnByTurnNavigation");
-}
-
-// v1.2+: read and watch compass heading
-const heading = await getHeading();
-const headingToken = watchHeading((nextHeading) => {
-  console.log(nextHeading.magneticHeading);
-});
-unwatch(headingToken);
-
-// Continuous tracking with hook
-function LocationTracker() {
-  const { position, error, isWatching } = useWatchPosition({
-    enabled: true,
-    accuracy: { android: "high", ios: "bestForNavigation" },
-    distanceFilter: 10,
+if (status === "granted") {
+  const position = await getCurrentPosition({
+    accuracy: { android: "high", ios: "best" },
+    timeout: 15_000,
   });
-
-  if (error) return <Text>Error: {error.message}</Text>;
-  if (!position) return <Text>Waiting...</Text>;
-
-  return (
-    <Text>
-      {position.coords.latitude}, {position.coords.longitude}
-    </Text>
-  );
 }
 ```
 
-**Benefits**:
+See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
+for watches, geocoding, heading, cached reads, Android settings, and iOS
+accuracy authorization.
 
 ### 2. Compat API (Compatibility)
 
@@ -158,18 +102,22 @@ const watchId = Geolocation.watchPosition((position) => console.log(position));
 Geolocation.clearWatch(watchId);
 ```
 
-#### Compat API coverage
+The `/compat` subpath covers the core native community API, including
+`setRNConfiguration`, `requestAuthorization`, `getCurrentPosition`,
+`watchPosition`, `clearWatch`, and `stopObserving`. It also has a browser entry
+for callback-style foreground geolocation. See the
+[Compat API guide](https://react-native-nitro-geolocation.pages.dev/guide/compat-api)
+for the full compatibility matrix and option notes.
 
-| Community API | Nitro `/compat` | Notes |
-|---|---:|---|
-| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
-| `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
-| `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
-| `watchPosition` | Supported | Returns a numeric watch id. |
-| `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
-| `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
-| `navigator.geolocation` polyfill | Not supported | Use the Modern API root import for web. |
-| Web | Native-only for `/compat` | Modern API root import supports web through `navigator.geolocation`. |
+### 3. Background API
+
+Native background tracking, geofencing, activity events, Android Headless JS,
+HTTP sync, and stored event recovery should use the explicit background subpath.
+
+Background location is native-only. Browser builds expose unsupported stubs so
+web bundles can still import shared code safely. Start with the
+[Background Location guide](https://react-native-nitro-geolocation.pages.dev/background/overview)
+for permissions, start/stop, geofencing, storage recovery, and native sync.
 
 ---
 
@@ -204,6 +152,9 @@ Add permissions to your **Info.plist**:
 <string>This app requires access to your location at all times.</string>
 ```
 
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`.
+
 ---
 
 ### 3. Android Setup
@@ -221,219 +172,24 @@ Optional (for background):
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
----
-
-### 4. Android Reliability
-
-- `locationProvider: "auto"` and `locationProvider: "playServices"` prefer
-  Google Play Services fused location when available and fall back to Android's
-  platform provider.
-- Use `locationProvider: "android"` when you need to force Android's platform
-  `LocationManager` path.
-- Supports native settings resolution through `requestLocationSettings`.
-- Supports approximate/coarse location handling through permissions and
-  Android `granularity`.
-- Supports explicit cached reads through `getLastKnownPosition`.
-- Provides structured Modern API errors such as `PLAY_SERVICE_NOT_AVAILABLE`,
-  `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
+Full background tracking uses a foreground service on Android. Add the full
+permission set from the Android background setup guide when using
+`react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
 
 ---
 
-### 5. Expo Development Builds
+### 4. Continue In The Docs
 
-This package requires native Nitro bindings, so it is not an Expo Go module.
-Use Expo prebuild, a development build, or another custom native build flow,
-then apply the same iOS and Android native permission setup shown above.
+Use the docs site for the detailed flows:
 
-Managed Expo apps that cannot rebuild native code should use `expo-location`.
-See the [Expo development build guide](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build)
-for the supported setup path.
-
----
-
-### 6. Development Tools (Optional)
-
-#### DevTools Plugin (Rozenite)
-
-> **Prerequisites**: Requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be installed.
->
-> **API Compatibility**: Only works with the Modern API. Does not support the Compat API (`/compat`).
-
-Mock geolocation data during development with an interactive map interface:
-
-![DevTools Plugin](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
-
-```bash
-npm install @react-native-nitro-geolocation/rozenite-plugin
-# or
-yarn add @react-native-nitro-geolocation/rozenite-plugin
-```
-
-**Setup**:
-
-```tsx
-import {
-  useGeolocationDevTools,
-  createPosition,
-} from "@react-native-nitro-geolocation/rozenite-plugin";
-
-function App() {
-  // Enable location mocking in development
-  useGeolocationDevTools({
-    initialPosition: createPosition("Seoul, South Korea"),
-  });
-
-  return <YourApp />;
-}
-```
-
-**Features**:
-
-- 🗺️ Interactive Leaflet map interface
-- 📍 Click to set location instantly
-- ⌨️ Arrow key navigation for precise control
-- 🏙️ 20 pre-configured city presets
-- ✏️ Manual latitude/longitude input
-- 📊 Real-time heading, speed, and accuracy calculation
-- 🌓 Dark mode support
-
-[See full DevTools guide →](https://react-native-nitro-geolocation.pages.dev/guide/devtools)
-
----
-
-### 7. Usage
-
-#### Modern API (Recommended)
-
-```tsx
-// Get current location
-const position = await getCurrentPosition({
-  accuracy: { android: "high", ios: "best" },
-});
-
-// Real-time tracking with hook
-const { position, error } = useWatchPosition({
-  enabled: true,
-  accuracy: { android: "balanced", ios: "nearestTenMeters" },
-  distanceFilter: 10
-});
-```
-
-Accuracy presets are available since `v1.2`.
-
-`getLastKnownPosition(options?)`, `getLocationAvailability()`, `getHeading()`,
-`watchHeading()`, `geocode(address)`, `reverseGeocode(coords)`, selected
-Android request options (`granularity`, `waitForAccurateLocation`,
-`maxUpdateAge`, `maxUpdateDelay`, and `maxUpdates`), iOS tuning options
-(`activityType`, `pausesLocationUpdatesAutomatically`, and
-`showsBackgroundLocationIndicator`), `getAccuracyAuthorization()`, and
-`requestTemporaryFullAccuracy(purposeKey)` are available since `v1.2`.
-
-`enableHighAccuracy` is deprecated in the Modern API and remains supported only
-for v1 compatibility. Prefer `accuracy`; when `accuracy.android` or
-`accuracy.ios` is provided for the current platform, that explicit preset takes
-precedence over the boolean. `enableHighAccuracy` is expected to be removed from
-the Modern API in v2.
-
-The `/compat` API keeps `enableHighAccuracy` for drop-in compatibility with
-`@react-native-community/geolocation`.
-
-#### Compat API (Compatibility)
-
-```tsx
-import Geolocation from "react-native-nitro-geolocation/compat";
-
-Geolocation.getCurrentPosition((pos) => console.log(pos));
-const watchId = Geolocation.watchPosition((pos) => console.log(pos));
-Geolocation.clearWatch(watchId);
-```
-
----
-
----
-
-## 🔄 Migration
-
-### From `@react-native-community/geolocation`
-
-The safest migration is two-step: switch imports to `/compat` first, verify
-the app, then move call sites to the Modern API where it improves ownership,
-permission timing, cache behavior, or Android settings handling.
-
-For Modern API migration, install the Agent Skills-compatible migration
-playbook from this repository. It is migration assistance for coding agents, not
-a fully automatic migration. The skill first runs a package-manager-aware
-compat bootstrap script that installs the Nitro packages, rewrites legacy import
-sources to `/compat`, and removes `@react-native-community/geolocation`. After
-that safe mechanical step, it guides the agent to refactor compat call sites to
-Modern API best practices using explicit criteria for permission timing, React
-lifecycle ownership, watch cleanup, cache-vs-fresh location reads, accuracy, and
-Android provider/settings handling.
-
-With the Vercel Labs `skills` CLI:
-
-```bash
-npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
-```
-
-The skill source is
-[`skills/community-migration/SKILL.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
-The bundled bootstrap script is
-[`skills/community-migration/scripts/migrate-to-compat.mjs`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration/scripts/migrate-to-compat.mjs).
-
-For a drop-in compatibility migration, change the import to use `/compat`:
-
-```diff
-- import Geolocation from '@react-native-community/geolocation';
-+ import Geolocation from 'react-native-nitro-geolocation/compat';
-```
-
-Then migrate individual call sites to the Modern API:
-
-```diff
-- Geolocation.getCurrentPosition(onSuccess, onError, {
--   enableHighAccuracy: true,
--   timeout: 15000,
-- });
-+ const position = await getCurrentPosition({
-+   accuracy: { android: "high", ios: "best" },
-+   timeout: 15000,
-+ });
-```
-
-See [Community Migration](https://react-native-nitro-geolocation.pages.dev/guide/community-migration)
-for the full community import → `/compat` → Modern API path.
-
-### From `react-native-geolocation-service`
-
-Apps currently using `react-native-geolocation-service` should migrate directly
-to the Modern API. Do not route this path through `/compat`; the service package
-has Android fused-provider, settings-dialog, `mocked`/`provider`, and
-provider-related error behavior that maps more naturally to Modern APIs.
-
-Install the dedicated Agent Skills-compatible migration playbook:
-
-```bash
-npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
-```
-
-See [Service Migration](https://react-native-nitro-geolocation.pages.dev/guide/service-migration)
-for the direct service → Modern API path.
-
----
-
-## Benchmark scope
-
-The benchmark measures cached `getCurrentPosition` reads over 1000 iterations ×
-5 runs on an iPhone 14 Pro with React Native 0.81.4. It measures the
-JS-to-native path for cached locations, not cold GPS acquisition, permission
-dialogs, provider availability, or OS throttling.
-
-For cached location reads, Nitro removes Bridge overhead. This does not make GPS
-acquisition itself 22x faster; it makes cached reads and the JS-to-native call
-path cheaper.
-
----
+- [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
+- [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
+- [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
+- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+- [Migration Assistance](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance) - choose the community or service migration path.
+- [Expo Development Builds](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build) - use the package in Expo custom native builds.
+- [DevTools Plugin](https://react-native-nitro-geolocation.pages.dev/guide/devtools) - mock locations during development.
 
 ## 📖 Learn More
 

--- a/packages/rozenite-devtools-plugin/README.md
+++ b/packages/rozenite-devtools-plugin/README.md
@@ -93,7 +93,7 @@ function App() {
 
 ### Available city presets
 
-Seoul, Tokyo, Beijing, Singapore, Mumbai, London, Paris, Berlin, Moscow, Istanbul, New York, Los Angeles, São Paulo, Mexico City, Toronto, Sydney, Dubai, Cairo, Johannesburg, Buenos Aires
+Seoul, Tokyo, New York, Los Angeles, San Francisco, London, Paris, Berlin, Sydney, Singapore, Hong Kong, Shanghai, Beijing, Dubai, Mumbai, Bangkok, Toronto, São Paulo, Mexico City, Moscow
 
 ## Opening DevTools
 


### PR DESCRIPTION
## Summary
- refresh 1.3 release-facing docs for Modern/Compat web support and the Background API surface
- align background permission/setup docs with Android 11+ settings round-trips, iOS Always/background-mode requirements, and Android activity-recognition/runtime notification permissions
- sync migration, compat, and Rozenite DevTools docs with current public types, exports, and preset data
- add a changeset so package-doc changes satisfy release CI without manually versioning changelogs

## Review
- Ran four-agent doc review loops until final pass returned no P1/P2 findings across API/export docs, release/changelog state, native background setup, and migration/compat/devtools docs.

## Validation
- `yarn format:check`
- `yarn workspace react-native-nitro-geolocation test`
- `CI=1 yarn changeset status --since=HEAD`
