### PR TITLE
docs: add README DevTools section

### DIFF
--- a/.changeset/lucky-devtools-readme.md
+++ b/.changeset/lucky-devtools-readme.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Add README guidance for the Rozenite DevTools plugin.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,39 @@ permission set from the Android background setup guide when using
 
 ---
 
-### 4. Continue In The Docs
+### 4. DevTools Plugin
+
+Use the Rozenite DevTools plugin to mock locations during development with an
+interactive map. It works with the Modern API root import.
+
+![DevTools Plugin Demo](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
+
+```bash
+yarn add @react-native-nitro-geolocation/rozenite-plugin
+```
+
+```tsx
+import {
+  createPosition,
+  useGeolocationDevTools,
+} from "@react-native-nitro-geolocation/rozenite-plugin";
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: createPosition("Seoul, South Korea"),
+  });
+
+  return <RootNavigator />;
+}
+```
+
+The plugin requires Rozenite DevTools in your app. See the
+[DevTools Plugin guide](https://react-native-nitro-geolocation.pages.dev/guide/devtools)
+for setup, presets, troubleshooting, and the demo.
+
+---
+
+### 5. Continue In The Docs
 
 Use the docs site for the detailed flows:
 

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -179,7 +179,39 @@ permission set from the Android background setup guide when using
 
 ---
 
-### 4. Continue In The Docs
+### 4. DevTools Plugin
+
+Use the Rozenite DevTools plugin to mock locations during development with an
+interactive map. It works with the Modern API root import.
+
+![DevTools Plugin Demo](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
+
+```bash
+yarn add @react-native-nitro-geolocation/rozenite-plugin
+```
+
+```tsx
+import {
+  createPosition,
+  useGeolocationDevTools,
+} from "@react-native-nitro-geolocation/rozenite-plugin";
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: createPosition("Seoul, South Korea"),
+  });
+
+  return <RootNavigator />;
+}
+```
+
+The plugin requires Rozenite DevTools in your app. See the
+[DevTools Plugin guide](https://react-native-nitro-geolocation.pages.dev/guide/devtools)
+for setup, presets, troubleshooting, and the demo.
+
+---
+
+### 5. Continue In The Docs
 
 Use the docs site for the detailed flows:
 


### PR DESCRIPTION
## Summary
- Restored a Rozenite DevTools Plugin section in the root README and package README.
- Added the install command, a Modern API hook example, and a link to the full DevTools guide.
- Added a patch changeset for the package README update.

## Checks
- yarn format:check
- yarn workspace react-native-nitro-geolocation test
- CI=1 yarn changeset status --since=origin/main