### PR TITLE
fix: allow Android foreground service location without background permission

### DIFF
--- a/.changeset/fix-android-foreground-service-permission.md
+++ b/.changeset/fix-android-foreground-service-permission.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix Android foreground service background location startup requiring background location permission.

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -5,6 +5,38 @@ appId: nitrogeolocation.example
 # Android provider-selection proof is gated because it needs a connected
 # physical Android device with live, non-mocked providers.
 
+- runFlow:
+    when:
+      platform: Android
+    file: issue-119-android.yaml
+- runFlow:
+    when:
+      platform: Android
+    file: issue-120-android.yaml
+- runFlow:
+    when:
+      platform: Android
+    file: issue-121-android.yaml
+- runFlow:
+    when:
+      platform: Android
+    file: issue-122-android.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: issue-119-ios.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: issue-120-ios.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: issue-121-ios.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: issue-122-ios.yaml
 - runFlow: permission-check.yaml
 - runFlow:
     when:

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -1,0 +1,33 @@
+appId: nitrogeolocation.example
+---
+# Repro for #119 on Android. Regression contract fails on main while bug exists.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-119
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 119"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-119-run-button"
+- tapOn:
+    text: ".*(While using the app|앱 사용 중에만 허용|Allow).*"
+    optional: true
+- extendedWaitUntil:
+    visible: "Issue 119: passed"
+    timeout: 15000
+- assertVisible:
+    id: "issue-119-permission-prompt-result"

--- a/examples/v0.81.1/.maestro/issue-119-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-ios.yaml
@@ -1,0 +1,30 @@
+appId: nitrogeolocation.example
+---
+# Repro for #119 on iOS. Android-only issue is skipped on this platform.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-119
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 119"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-119-run-button"
+- extendedWaitUntil:
+    visible: "Issue 119: passed"
+    timeout: 15000
+- assertVisible:
+    id: "issue-119-permission-prompt-result"

--- a/examples/v0.81.1/.maestro/issue-120-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-android.yaml
@@ -1,0 +1,30 @@
+appId: nitrogeolocation.example
+---
+# Repro for #120 on Android. iOS-only issue is skipped on this platform.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-120
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 120"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-120-run-button"
+- extendedWaitUntil:
+    visible: "Issue 120: passed"
+    timeout: 15000
+- assertVisible:
+    id: "issue-120-stop-without-motion-result"

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -1,0 +1,33 @@
+appId: nitrogeolocation.example
+---
+# Repro for #120 on iOS. Regression contract fails if Motion & Fitness prompt appears.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-120
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 120"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-120-run-button"
+- extendedWaitUntil:
+    visible: "Issue 120: passed"
+    timeout: 30000
+- assertNotVisible: ".*Motion.*Fitness.*"
+- assertVisible:
+    id: "issue-120-stop-without-motion-result"

--- a/examples/v0.81.1/.maestro/issue-121-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-android.yaml
@@ -1,0 +1,34 @@
+appId: nitrogeolocation.example
+---
+# Repro for #121 on Android. Regression contract fails on main while bug exists.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: deny
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-121
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 121"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-121-run-button"
+- extendedWaitUntil:
+    visible: "Issue 121: passed"
+    timeout: 30000
+- assertVisible:
+    id: "issue-121-foreground-service-result"

--- a/examples/v0.81.1/.maestro/issue-121-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-ios.yaml
@@ -1,0 +1,30 @@
+appId: nitrogeolocation.example
+---
+# Repro for #121 on iOS. Android-only issue is skipped on this platform.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-121
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 121"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-121-run-button"
+- extendedWaitUntil:
+    visible: "Issue 121: passed"
+    timeout: 15000
+- assertVisible:
+    id: "issue-121-foreground-service-result"

--- a/examples/v0.81.1/.maestro/issue-122-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-android.yaml
@@ -1,0 +1,30 @@
+appId: nitrogeolocation.example
+---
+# Repro for #122 on Android. iOS-only issue is skipped on this platform.
+
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-122
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 122"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-122-run-button"
+- extendedWaitUntil:
+    visible: "Issue 122: passed"
+    timeout: 15000
+- assertVisible:
+    id: "issue-122-persist-false-result"

--- a/examples/v0.81.1/.maestro/issue-122-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-ios.yaml
@@ -1,0 +1,49 @@
+appId: nitrogeolocation.example
+---
+# Repro for #122 on iOS. Regression contract fails on main while bug exists.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-122
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 122"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-122-run-button"
+- extendedWaitUntil:
+    visible: "persist=false tracking started"
+    timeout: 30000
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+- setLocation:
+    latitude: 37.567
+    longitude: 126.9785
+- setLocation:
+    latitude: 37.5675
+    longitude: 126.979
+- setLocation:
+    latitude: 37.568
+    longitude: 126.9795
+- tapOn:
+    id: "issue-122-validate-button"
+- extendedWaitUntil:
+    visible: "Issue 122: passed"
+    timeout: 30000
+- assertVisible:
+    id: "issue-122-persist-false-result"

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -18,6 +18,10 @@ import IOSAccuracyAuthorizationScreen from "./screens/IOSAccuracyAuthorizationSc
 import IOSLocationTuningScreen from "./screens/IOSLocationTuningScreen";
 import IOSReleaseOptionsBridgeScreen from "./screens/IOSReleaseOptionsBridgeScreen";
 import Issue67Screen from "./screens/Issue67Screen";
+import Issue119Screen from "./screens/Issue119Screen";
+import Issue120Screen from "./screens/Issue120Screen";
+import Issue121Screen from "./screens/Issue121Screen";
+import Issue122Screen from "./screens/Issue122Screen";
 import LastKnownPositionScreen from "./screens/LastKnownPositionScreen";
 import LocationAvailabilityScreen from "./screens/LocationAvailabilityScreen";
 import LocationSimulationScreen from "./screens/LocationSimulationScreen";
@@ -53,6 +57,10 @@ const linking = {
       IOSLocationTuning: "ios-location-tuning",
       IOSAccuracyAuthorization: "ios-accuracy-authorization",
       IOSReleaseOptionsBridge: "ios-release-options-bridge",
+      Issue119: "issue-119",
+      Issue120: "issue-120",
+      Issue121: "issue-121",
+      Issue122: "issue-122",
       WebE2E: "web-e2e",
       Issue67: "issue-67"
     }
@@ -180,6 +188,26 @@ export default function App() {
         <Tab.Screen
           name="IOSReleaseOptionsBridge"
           component={IOSReleaseOptionsBridgeScreen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="Issue119"
+          component={Issue119Screen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="Issue120"
+          component={Issue120Screen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="Issue121"
+          component={Issue121Screen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="Issue122"
+          component={Issue122Screen}
           options={hiddenTabOptions}
         />
         <Tab.Screen

--- a/examples/v0.81.1/src/screens/Issue119Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue119Screen.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Platform } from "react-native";
+import { requestPermission } from "react-native-nitro-geolocation";
+import {
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  createScenarioResult,
+  createScenarioResults,
+  useScenarioResults
+} from "./scenario";
+
+const initialResults = createScenarioResults(["permissionPrompt"] as const);
+
+const shortError = (error: unknown) =>
+  String((error as { message?: unknown })?.message ?? error)
+    .split("\n")[0]
+    .slice(0, 160);
+
+export default function Issue119Screen() {
+  const { results, setResult } = useScenarioResults(initialResults);
+
+  const run = async () => {
+    setResult(
+      "permissionPrompt",
+      createScenarioResult("running", "Calling requestPermission()")
+    );
+    if (Platform.OS !== "android") {
+      setResult(
+        "permissionPrompt",
+        createScenarioResult("passed", "Android-only repro skipped on iOS")
+      );
+      return;
+    }
+
+    try {
+      const status = await requestPermission();
+      setResult(
+        "permissionPrompt",
+        createScenarioResult(
+          status === "granted" ? "passed" : "failed",
+          `requestPermission resolved ${status}; expected granted after native prompt`
+        )
+      );
+    } catch (error) {
+      setResult(
+        "permissionPrompt",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix="issue-119"
+      title="Issue 119"
+      subtitle="Android requestPermission should show native prompt"
+    >
+      <ScenarioSection
+        index={1}
+        title="Android Permission Prompt"
+        description="requestPermission should resolve granted after native allow"
+      >
+        <ScenarioButton
+          title="Run Issue 119"
+          onPress={run}
+          testID="issue-119-run-button"
+        />
+      </ScenarioSection>
+      <ResultList
+        prefix="issue-119"
+        results={results}
+        items={[
+          {
+            id: "permission-prompt",
+            resultKey: "permissionPrompt",
+            label: "Issue 119"
+          }
+        ]}
+      />
+    </ScenarioScreen>
+  );
+}

--- a/examples/v0.81.1/src/screens/Issue120Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue120Screen.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Platform } from "react-native";
+import {
+  startBackgroundLocation,
+  stopBackgroundLocation
+} from "react-native-nitro-geolocation/background";
+import type { BackgroundLocationOptions } from "react-native-nitro-geolocation/background";
+import {
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  createScenarioResult,
+  createScenarioResults,
+  useScenarioResults
+} from "./scenario";
+
+const initialResults = createScenarioResults(["stopWithoutMotion"] as const);
+
+const shortError = (error: unknown) =>
+  String((error as { message?: unknown })?.message ?? error)
+    .split("\n")[0]
+    .slice(0, 160);
+
+const options: BackgroundLocationOptions = {
+  accuracy: { ios: "bestForNavigation" },
+  trackingMode: "continuous",
+  startOnBoot: false,
+  stopOnTerminate: true,
+  ios: {
+    pausesLocationUpdatesAutomatically: false,
+    showsBackgroundLocationIndicator: false
+  }
+};
+
+export default function Issue120Screen() {
+  const { results, setResult } = useScenarioResults(initialResults);
+
+  const run = async () => {
+    setResult(
+      "stopWithoutMotion",
+      createScenarioResult("running", "Starting and stopping location")
+    );
+    if (Platform.OS !== "ios") {
+      setResult(
+        "stopWithoutMotion",
+        createScenarioResult("passed", "iOS-only repro skipped on Android")
+      );
+      return;
+    }
+
+    try {
+      await stopBackgroundLocation().catch(() => undefined);
+      await startBackgroundLocation(options);
+      await stopBackgroundLocation();
+      setResult(
+        "stopWithoutMotion",
+        createScenarioResult(
+          "passed",
+          "Stopped without requesting activity recognition"
+        )
+      );
+    } catch (error) {
+      setResult(
+        "stopWithoutMotion",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix="issue-120"
+      title="Issue 120"
+      subtitle="iOS stopBackgroundLocation must not request extra permission"
+    >
+      <ScenarioSection
+        index={1}
+        title="Stop Without Motion"
+        description="Continuous tracking has no activityRecognition options"
+      >
+        <ScenarioButton
+          title="Run Issue 120"
+          onPress={run}
+          testID="issue-120-run-button"
+        />
+      </ScenarioSection>
+      <ResultList
+        prefix="issue-120"
+        results={results}
+        items={[
+          {
+            id: "stop-without-motion",
+            resultKey: "stopWithoutMotion",
+            label: "Issue 120"
+          }
+        ]}
+      />
+    </ScenarioScreen>
+  );
+}

--- a/examples/v0.81.1/src/screens/Issue121Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue121Screen.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { Platform } from "react-native";
+import {
+  startBackgroundLocation,
+  stopBackgroundLocation
+} from "react-native-nitro-geolocation/background";
+import type { BackgroundLocationOptions } from "react-native-nitro-geolocation/background";
+import {
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  createScenarioResult,
+  createScenarioResults,
+  useScenarioResults
+} from "./scenario";
+
+const initialResults = createScenarioResults(["foregroundService"] as const);
+
+const shortError = (error: unknown) =>
+  String((error as { message?: unknown })?.message ?? error)
+    .split("\n")[0]
+    .slice(0, 160);
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const options: BackgroundLocationOptions = {
+  accuracy: { android: "high" },
+  trackingMode: "continuous",
+  android: {
+    foregroundService: {
+      notificationTitle: "Issue 121",
+      notificationText: "Foreground service location repro",
+      notificationChannelId: "nitro-issue-121",
+      notificationChannelName: "Nitro Issue 121"
+    }
+  },
+  startOnBoot: false,
+  stopOnTerminate: true
+};
+
+export default function Issue121Screen() {
+  const { results, setResult } = useScenarioResults(initialResults);
+
+  const run = async () => {
+    setResult(
+      "foregroundService",
+      createScenarioResult(
+        "running",
+        "Starting foreground service without background grant"
+      )
+    );
+    if (Platform.OS !== "android") {
+      setResult(
+        "foregroundService",
+        createScenarioResult("passed", "Android-only repro skipped on iOS")
+      );
+      return;
+    }
+
+    try {
+      await stopBackgroundLocation().catch(() => undefined);
+      await startBackgroundLocation(options);
+      await sleep(1500);
+      await stopBackgroundLocation();
+      setResult(
+        "foregroundService",
+        createScenarioResult(
+          "passed",
+          "Foreground service started without background grant"
+        )
+      );
+    } catch (error) {
+      setResult(
+        "foregroundService",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix="issue-121"
+      title="Issue 121"
+      subtitle="Android foreground service should not require background grant"
+    >
+      <ScenarioSection
+        index={1}
+        title="Foreground Service"
+        description="Foreground service path should start with foreground permission"
+      >
+        <ScenarioButton
+          title="Run Issue 121"
+          onPress={run}
+          testID="issue-121-run-button"
+        />
+      </ScenarioSection>
+      <ResultList
+        prefix="issue-121"
+        results={results}
+        items={[
+          {
+            id: "foreground-service",
+            resultKey: "foregroundService",
+            label: "Issue 121"
+          }
+        ]}
+      />
+    </ScenarioScreen>
+  );
+}

--- a/examples/v0.81.1/src/screens/Issue122Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue122Screen.tsx
@@ -1,0 +1,145 @@
+import React, { useRef } from "react";
+import { Platform } from "react-native";
+import {
+  clearStoredBackgroundEvents,
+  clearStoredBackgroundLocations,
+  getBackgroundLocationStatus,
+  startBackgroundLocation,
+  stopBackgroundLocation
+} from "react-native-nitro-geolocation/background";
+import type { BackgroundLocationOptions } from "react-native-nitro-geolocation/background";
+import {
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  createScenarioResult,
+  createScenarioResults,
+  useScenarioResults
+} from "./scenario";
+
+const initialResults = createScenarioResults(["persistFalse"] as const);
+
+const shortError = (error: unknown) =>
+  String((error as { message?: unknown })?.message ?? error)
+    .split("\n")[0]
+    .slice(0, 160);
+
+const options: BackgroundLocationOptions = {
+  accuracy: { ios: "bestForNavigation" },
+  persist: false,
+  trackingMode: "continuous",
+  startOnBoot: false,
+  stopOnTerminate: true,
+  ios: {
+    activityType: "automotiveNavigation",
+    pausesLocationUpdatesAutomatically: false,
+    showsBackgroundLocationIndicator: false
+  }
+};
+
+export default function Issue122Screen() {
+  const { results, setResult } = useScenarioResults(initialResults);
+  const startedAtRef = useRef<number | undefined>(undefined);
+
+  const start = async () => {
+    setResult(
+      "persistFalse",
+      createScenarioResult("running", "Starting persist=false tracking")
+    );
+    if (Platform.OS !== "ios") {
+      setResult(
+        "persistFalse",
+        createScenarioResult("passed", "iOS-only repro skipped on Android")
+      );
+      return;
+    }
+
+    try {
+      await stopBackgroundLocation().catch(() => undefined);
+      await clearStoredBackgroundEvents().catch(() => undefined);
+      await clearStoredBackgroundLocations().catch(() => undefined);
+      startedAtRef.current = Date.now();
+      await startBackgroundLocation(options);
+      setResult(
+        "persistFalse",
+        createScenarioResult("running", "persist=false tracking started")
+      );
+    } catch (error) {
+      setResult(
+        "persistFalse",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  const validate = async () => {
+    setResult(
+      "persistFalse",
+      createScenarioResult("running", "Validating UI responsiveness")
+    );
+    if (Platform.OS !== "ios") {
+      setResult(
+        "persistFalse",
+        createScenarioResult("passed", "iOS-only repro skipped on Android")
+      );
+      return;
+    }
+
+    try {
+      await stopBackgroundLocation();
+      const status = await getBackgroundLocationStatus();
+      const elapsed = Date.now() - (startedAtRef.current ?? Date.now());
+      const storedCount = status.storedEventCount + status.storedLocationCount;
+
+      setResult(
+        "persistFalse",
+        createScenarioResult(
+          storedCount === 0 && elapsed < 5000 ? "passed" : "failed",
+          `persist=false stored=${storedCount}, elapsed=${elapsed}ms`
+        )
+      );
+    } catch (error) {
+      setResult(
+        "persistFalse",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix="issue-122"
+      title="Issue 122"
+      subtitle="iOS persist=false should not degrade UI responsiveness"
+    >
+      <ScenarioSection
+        index={1}
+        title="Persist False"
+        description="No background events or locations should persist"
+      >
+        <ScenarioButton
+          title="Start Issue 122"
+          onPress={start}
+          testID="issue-122-run-button"
+        />
+        <ScenarioButton
+          title="Validate Issue 122"
+          onPress={validate}
+          testID="issue-122-validate-button"
+        />
+      </ScenarioSection>
+      <ResultList
+        prefix="issue-122"
+        results={results}
+        items={[
+          {
+            id: "persist-false",
+            resultKey: "persistFalse",
+            label: "Issue 122"
+          }
+        ]}
+      />
+    </ScenarioScreen>
+  );
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -100,7 +100,8 @@ class NitroBackgroundLocationController private constructor(
         if (permissions.foregroundPermission() != PermissionStatus.GRANTED) {
             throw SecurityException("Foreground location permission is required")
         }
-        if (permissions.backgroundPermission() != BackgroundPermissionStatus.GRANTED) {
+        if (current.android?.foregroundService == null &&
+            permissions.backgroundPermission() != BackgroundPermissionStatus.GRANTED) {
             throw SecurityException("Background location permission is required")
         }
         state = BackgroundLocationState.STARTING


### PR DESCRIPTION
## Summary
- Fix Android foreground-service background location startup so it no longer requires the runtime background location grant.
- Keep background permission checks for paths that still need true background access, such as geofencing.
- Keep the issue-specific E2E screens and Maestro flows for #119-#122 in place.

## Changes
- Skip the `ACCESS_BACKGROUND_LOCATION` gate in `NitroBackgroundLocationController.start()` when `android.foregroundService` is configured.
- Add hidden example screens and Maestro flows for the four reported issues, including the #121 regression path.

## SSoT / Cleanup
- Permission logic remains centralized in the Android background controller.
- No public API or type changes.

## Changeset
- Added a patch changeset for `react-native-nitro-geolocation`.

## Docs
- No docs update needed because public API behavior and signatures are unchanged.

## Verification
- `yarn workspace react-native-nitro-geolocation-example typecheck`
- `yarn format:check`
- `./gradlew app:installDebug -x lint -PreactNativeDevServerPort=8081 -PreactNativeArchitectures=arm64-v8a --no-daemon --console=plain`
- Android real device SM-S921N / Android 14 / API 34: `maestro test --platform android --udid R3CX80LJ1EM examples/v0.81.1/.maestro/issue-121-android.yaml`

Fixes #121
