### PR TITLE
fix: handle permission prompt and motion stop regressions

### DIFF
--- a/.changeset/fair-timers-fix.md
+++ b/.changeset/fair-timers-fix.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix Android requestPermission prompting from a denied initial state and avoid requesting iOS Motion & Fitness permission when background motion tracking was not started.

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -4,6 +4,10 @@ appId: nitrogeolocation.example
 
 - launchApp:
     clearState: true
+    permissions:
+      all: deny
+      android.permission.ACCESS_COARSE_LOCATION: deny
+      android.permission.ACCESS_FINE_LOCATION: deny
 
 - extendedWaitUntil:
     visible: "Geolocation API"

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -5,7 +5,9 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
     permissions:
-      all: allow
+      all: deny
+      location: always
+      motion: unset
 
 - extendedWaitUntil:
     visible: "Geolocation API"

--- a/examples/v0.81.1/ios/Podfile.lock
+++ b/examples/v0.81.1/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroGeolocation (1.2.6):
+  - NitroGeolocation (1.3.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2767,7 +2767,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroGeolocation: 923a4c6a8e42a102c4ee9c0fa2fc484985666016
+  NitroGeolocation: 911c6655cd0ef8455f13dc51508e2ce8d6068e2f
   NitroModules: 1dc73273d6e3aee937eec41ef3ed9470804b9884
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -116,9 +116,10 @@ class NitroGeolocation(
         success: (PermissionStatus) -> Unit,
         error: ((LocationError) -> Unit)?
     ): Unit {
-        // Check if already determined
+        // Android reports missing location permission as DENIED even before a
+        // runtime prompt has been shown, so denied must still request.
         val currentStatus = getCurrentPermissionStatus()
-        if (currentStatus != PermissionStatus.UNDETERMINED) {
+        if (currentStatus == PermissionStatus.GRANTED) {
             success(currentStatus)
             return
         }

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -23,6 +23,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     private var delegate: NitroBackgroundLocationDelegate?
     private let motionManager = CMMotionActivityManager()
     private let motionQueue = OperationQueue()
+    private var isMotionUpdatesRunning = false
     private let syncQueue = DispatchQueue(label: "nitro.background.sync")
     private let httpSync = IOSBackgroundHttpSync()
     private var permissionSemaphore: DispatchSemaphore?
@@ -114,7 +115,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 self.manager?.stopUpdatingLocation()
                 self.manager?.stopMonitoringSignificantLocationChanges()
             }
-            self.motionManager.stopActivityUpdates()
+            self.stopMotionUpdatesIfRunning()
             self.isRunning = false
             self.state = .stopped
         }
@@ -128,7 +129,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 self.manager?.stopMonitoringSignificantLocationChanges()
                 self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
             }
-            self.motionManager.stopActivityUpdates()
+            self.stopMotionUpdatesIfRunning()
             self.options = nil
             self.defaults.removeObject(forKey: self.optionsKey)
             self.isRunning = false
@@ -376,7 +377,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func stopActivityRecognition() throws -> Promise<Void> {
         return Promise.async {
-            self.motionManager.stopActivityUpdates()
+            self.stopMotionUpdatesIfRunning()
         }
     }
 
@@ -496,6 +497,13 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             guard let self, let activity else { return }
             self.handleMotionActivity(activity)
         }
+        isMotionUpdatesRunning = true
+    }
+
+    private func stopMotionUpdatesIfRunning() {
+        guard isMotionUpdatesRunning else { return }
+        motionManager.stopActivityUpdates()
+        isMotionUpdatesRunning = false
     }
 
     private func handleMotionActivity(_ activity: CMMotionActivity) {


### PR DESCRIPTION
## Summary

Fix two regressions covered by the issue E2E flows:

- Android `requestPermission()` now still opens the native runtime prompt when the initial permission state is denied because no prompt has been shown yet.
- iOS background location stop/reset now avoids touching CoreMotion when motion updates were never started, preventing the unexpected Motion & Fitness permission prompt.


## Linked Issues

Fixes #119
Fixes #120

## Changes

- Update Android permission request early-return logic to return immediately only when permission is already granted.
- Track whether iOS motion updates have started before calling `stopActivityUpdates()`.
- Tighten the #119 Android Maestro repro to start from denied location permissions.
- Tighten the #120 iOS Maestro repro to grant location while leaving motion permission unset.
- Update the example iOS `Podfile.lock` to match the current `NitroGeolocation` pod version required by the build.

## SSoT / Cleanup

- No public API or type changes.
- No duplicated permission or motion state logic added.
- E2E pages remain issue-specific and separate.

## Changeset

- Added a patch Changeset for `react-native-nitro-geolocation`.

## Docs

- No docs changes needed; this is native behavior and regression coverage only.

## Screenshots

### Before
<img width="1080" height="2340" alt="before-issue-119-android" src="https://github.com/user-attachments/assets/0d94579d-c48f-4131-8cf4-2fb9916976bc" />
<img width="1206" height="2622" alt="before-issue-120-ios" src="https://github.com/user-attachments/assets/b847d7b8-db04-432b-9231-76e5662f5872" />

### After
<img width="1080" height="2340" alt="after-issue-119-android" src="https://github.com/user-attachments/assets/b9a89666-d3ca-4183-b402-b95ea9ceac5e" />
<img width="1206" height="2622" alt="after-issue-120-ios" src="https://github.com/user-attachments/assets/f22475f0-6a2f-4d28-9b8b-66fc8d6171ed" />
