### PR TITLE
docs: document background diagnosis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,15 @@ for the full compatibility matrix and option notes.
 ### 3. Background API
 
 Native background tracking, geofencing, activity events, Android Headless JS,
-HTTP sync, and stored event recovery should use the explicit background subpath.
+HTTP sync, stored event recovery, and silent-delivery diagnosis should use the
+explicit background subpath.
 
 Background location is native-only. Browser builds expose unsupported stubs so
 web bundles can still import shared code safely. Start with the
 [Background Location guide](https://react-native-nitro-geolocation.pages.dev/background/overview)
 for permissions, start/stop, geofencing, storage recovery, and native sync.
+Use `diagnoseBackgroundLocation()` from the same subpath to turn the raw
+background status into actionable issues when delivery is silent.
 
 ---
 
@@ -218,7 +221,7 @@ Use the docs site for the detailed flows:
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
 - [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
-- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, HTTP sync, and delivery diagnosis.
 - [Migration Assistance](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance) - choose the community or service migration path.
 - [Expo Development Builds](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build) - use the package in Expo custom native builds.
 - [DevTools Plugin](https://react-native-nitro-geolocation.pages.dev/guide/devtools) - mock locations during development.

--- a/docs/docs/background/overview.md
+++ b/docs/docs/background/overview.md
@@ -7,6 +7,7 @@ Background tracking is separate from `watchPosition`. `watchPosition` is for act
 ```ts
 import {
   startBackgroundLocation,
+  diagnoseBackgroundLocation,
   addGeofences,
   registerBackgroundTask,
 } from 'react-native-nitro-geolocation/background';
@@ -20,5 +21,30 @@ imports stay explicit and tree-shakable.
 - [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.
 - [Permissions](/background/permissions) - request foreground/background access and handle settings round-trips.
 - [Start And Stop](/background/start-stop) - start continuous tracking and subscribe to native updates.
+- [Troubleshooting](/background/troubleshooting) - use `diagnoseBackgroundLocation()` to interpret the native background status when delivery is silent.
 - [Storage Recovery](/background/storage) - drain events recorded while JavaScript was not running.
 - [Geofencing](/background/geofencing), [Activity Recognition](/background/activity-recognition), and [Native HTTP Sync](/background/http-sync) - add advanced background behavior.
+
+## Diagnose Silent Background Delivery
+
+Use `diagnoseBackgroundLocation()` when background tracking is configured but
+the app is not receiving locations. It reads `getBackgroundLocationStatus()`
+and returns actionable issues instead of forcing app code to interpret every
+status field.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const diagnosis = await diagnoseBackgroundLocation();
+
+if (!diagnosis.healthy) {
+  console.warn(diagnosis.issues.join('\n'));
+}
+```
+
+The result is `{ healthy, status, issues }`. `healthy` is `true` when no issues
+were found, `status` is the raw background status, and `issues` contains
+human-readable reasons delivery may be blocked, such as a native `lastError`,
+missing foreground or background permission, disabled device location services,
+tracking configured but not started, or Android foreground-service and
+notification-permission problems.

--- a/docs/docs/background/troubleshooting.md
+++ b/docs/docs/background/troubleshooting.md
@@ -1,8 +1,32 @@
 # Troubleshooting
 
+## Diagnose background delivery
+
+Call `diagnoseBackgroundLocation()` when the background pipeline is silent. It
+returns `{ healthy, status, issues }`, where `issues` lists the common blockers
+derived from the native background status.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const { healthy, issues } = await diagnoseBackgroundLocation();
+
+if (!healthy) {
+  console.warn(issues.join('\n'));
+}
+```
+
+The helper checks the last native error, foreground and background permission,
+device location services, configured/running state, stored location count, and
+Android foreground-service or notification-permission state.
+
 ## Android tracking does not start
 
 Check foreground location, background location, Android 13+ notification permission, and device location services. Continuous background tracking requires `android.foregroundService`.
+
+If those values look correct but no locations arrive, inspect
+`status.lastError` from `diagnoseBackgroundLocation()` or
+`getBackgroundLocationStatus()`.
 
 ## Android starts but stops after swipe-away
 

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -112,12 +112,15 @@ for the full compatibility matrix and option notes.
 ### 3. Background API
 
 Native background tracking, geofencing, activity events, Android Headless JS,
-HTTP sync, and stored event recovery should use the explicit background subpath.
+HTTP sync, stored event recovery, and silent-delivery diagnosis should use the
+explicit background subpath.
 
 Background location is native-only. Browser builds expose unsupported stubs so
 web bundles can still import shared code safely. Start with the
 [Background Location guide](https://react-native-nitro-geolocation.pages.dev/background/overview)
 for permissions, start/stop, geofencing, storage recovery, and native sync.
+Use `diagnoseBackgroundLocation()` from the same subpath to turn the raw
+background status into actionable issues when delivery is silent.
 
 ---
 
@@ -218,7 +221,7 @@ Use the docs site for the detailed flows:
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
 - [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
-- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+- [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, HTTP sync, and delivery diagnosis.
 - [Migration Assistance](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance) - choose the community or service migration path.
 - [Expo Development Builds](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build) - use the package in Expo custom native builds.
 - [DevTools Plugin](https://react-native-nitro-geolocation.pages.dev/guide/devtools) - mock locations during development.


### PR DESCRIPTION
## Description

Documents the `diagnoseBackgroundLocation()` background API added in #129.

**Summary**
- Adds a Background Location overview section showing how to import and call `diagnoseBackgroundLocation()`.
- Expands troubleshooting docs with the `{ healthy, status, issues }` result shape and the native status checks behind the diagnosis.
- Updates the root README and package README so the background subpath mentions silent-delivery diagnosis alongside tracking, geofencing, storage recovery, Headless JS, and HTTP sync.

**SSoT / Cleanup**
- Kept the docs aligned with the current public export in `packages/react-native-nitro-geolocation/src/background/index.ts`.
- No duplicated API contract or separate behavior description added outside the background docs/README surface.

**Changeset**
- No new Changeset. `main` already has the pending minor Changeset for `diagnoseBackgroundLocation()` from #129, so these docs can ship with that unreleased API surface.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] My code follows the project style
- [x] I've tested my changes locally
- [x] Documentation updated (if needed)

## E2E Test Results

N/A for docs-only changes.

**Platform tested:**
- [ ] iOS
- [ ] Android
- [x] N/A (docs only)

**Test artifacts:**
N/A

---

## Additional Notes

Validation:
- `yarn format:check`
- `yarn workspace docs typecheck`
- `yarn workspace docs build`
