### PR TITLE
fix: Android background headless warning

### DIFF
--- a/.changeset/quiet-android-headless-warning.md
+++ b/.changeset/quiet-android-headless-warning.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Skip Android Headless JS dispatch when a live background listener already received the foreground-service event.
+
+This prevents React Native from warning `No task registered for key NitroBackgroundLocationTask` on every Android background location update when apps use foreground-service tracking without registering a Headless JS task.

--- a/examples/v0.81.1/.maestro/issue-132-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-132-android.yaml
@@ -1,0 +1,45 @@
+appId: nitrogeolocation.example
+---
+# Repro for #132 on Android.
+# This flow must run against the no-headless bundle built from index.no-headless.js.
+# The companion shell script asserts logcat has no
+# "No task registered for key NitroBackgroundLocationTask" warning.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/issue-132
+- tapOn:
+    text: "열기|Open"
+    optional: true
+
+- extendedWaitUntil:
+    visible: "Issue 132"
+    timeout: 15000
+
+- tapOn:
+    id: "issue-132-start-button"
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+- runScript: scripts/wait-15s.js
+- setLocation:
+    latitude: 37.567
+    longitude: 126.979
+
+- extendedWaitUntil:
+    visible: "Foreground listener: passed"
+    timeout: 30000
+
+- tapOn:
+    id: "issue-132-cleanup-button"

--- a/examples/v0.81.1/index.no-headless.js
+++ b/examples/v0.81.1/index.no-headless.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -20,6 +20,7 @@
     "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh",
     "test:e2e:background-long-run:android": "bash ./scripts/test-background-long-run-android.sh",
     "test:e2e:background-long-run:ios": "bash ./scripts/test-background-long-run-ios.sh",
+    "test:e2e:issue-132:android": "bash ./scripts/test-issue-132-android.sh",
     "test:e2e:web:android": "bash ./scripts/test-e2e-web-android.sh",
     "test:e2e:web:ios": "bash ./scripts/test-e2e-web-ios.sh"
   },

--- a/examples/v0.81.1/scripts/test-issue-132-android.sh
+++ b/examples/v0.81.1/scripts/test-issue-132-android.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANDROID_DIR="$EXAMPLE_DIR/android"
+
+ADB_BIN="${ADB:-adb}"
+AGENT_DEVICE_BIN="${AGENT_DEVICE:-agent-device}"
+ADB_DEVICE_ARGS=()
+AGENT_DEVICE_ARGS=(--platform android)
+if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+  ADB_DEVICE_ARGS=(-s "$ANDROID_SERIAL")
+  AGENT_DEVICE_ARGS+=(--serial "$ANDROID_SERIAL")
+fi
+
+EXPECT_WARNING="${EXPECT_WARNING:-0}"
+LOG_FILE="${LOG_FILE:-$ANDROID_DIR/build/reports/issue-132-logcat.txt}"
+WARNING_PATTERN="No task registered for key NitroBackgroundLocationTask"
+APK_PATH="$ANDROID_DIR/app/build/outputs/apk/release/app-release.apk"
+SESSION_NAME="${AGENT_DEVICE_SESSION:-issue132}"
+
+cleanup() {
+  "$AGENT_DEVICE_BIN" --session "$SESSION_NAME" close >/dev/null 2>&1 || true
+  "$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell am force-stop nitrogeolocation.example >/dev/null 2>&1 || true
+  "$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell cmd location set-location-enabled true >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+cd "$ANDROID_DIR"
+ENTRY_FILE=index.no-headless.js ./gradlew :app:assembleRelease \
+  --no-daemon \
+  --console=plain \
+  -PreactNativeArchitectures="${REACT_NATIVE_ARCHITECTURES:-arm64-v8a}"
+
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" install -r "$APK_PATH" >/dev/null
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell cmd location set-location-enabled true >/dev/null
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell pm grant nitrogeolocation.example android.permission.ACCESS_FINE_LOCATION >/dev/null 2>&1 || true
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell pm grant nitrogeolocation.example android.permission.ACCESS_COARSE_LOCATION >/dev/null 2>&1 || true
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell pm grant nitrogeolocation.example android.permission.ACCESS_BACKGROUND_LOCATION >/dev/null 2>&1 || true
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell pm grant nitrogeolocation.example android.permission.POST_NOTIFICATIONS >/dev/null 2>&1 || true
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" logcat -c
+mkdir -p "$(dirname "$LOG_FILE")"
+
+if [[ "$("$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" shell getprop ro.kernel.qemu | tr -d '\r')" != "1" ]]; then
+  echo "Issue 132 E2E requires an Android emulator because it injects locations with adb emu geo fix." >&2
+  exit 1
+fi
+
+"$AGENT_DEVICE_BIN" --session "$SESSION_NAME" --session-lock strip open nitrogeolocation://app/issue-132 \
+  "${AGENT_DEVICE_ARGS[@]}" >/dev/null
+"$AGENT_DEVICE_BIN" --session "$SESSION_NAME" press 'id="issue-132-start-button"' >/dev/null
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" emu geo fix 126.978 37.5665 >/dev/null
+sleep 15
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" emu geo fix 126.979 37.567 >/dev/null
+
+ui_passed=0
+for _ in $(seq 1 30); do
+  if "$AGENT_DEVICE_BIN" --session "$SESSION_NAME" snapshot 2>/dev/null | grep -Fq "Foreground listener: passed"; then
+    ui_passed=1
+    break
+  fi
+  sleep 1
+done
+
+"$AGENT_DEVICE_BIN" --session "$SESSION_NAME" press 'id="issue-132-cleanup-button"' >/dev/null 2>&1 || true
+
+if [[ "$ui_passed" != "1" ]]; then
+  echo "Issue 132 E2E failed: foreground listener did not receive a location update." >&2
+  "$AGENT_DEVICE_BIN" --session "$SESSION_NAME" snapshot >&2 || true
+  exit 1
+fi
+
+"$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" logcat -d -v time > "$LOG_FILE"
+
+if grep -Fq "$WARNING_PATTERN" "$LOG_FILE"; then
+  if [[ "$EXPECT_WARNING" == "1" ]]; then
+    echo "Issue 132 warning reproduced: $WARNING_PATTERN"
+    exit 0
+  fi
+  echo "Issue 132 regression: unexpected warning found in $LOG_FILE" >&2
+  exit 1
+fi
+
+if [[ "$EXPECT_WARNING" == "1" ]]; then
+  echo "Issue 132 warning was expected but not found in $LOG_FILE" >&2
+  exit 1
+fi
+
+echo "Issue 132 green: no Headless JS task warning found."

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -22,6 +22,7 @@ import Issue119Screen from "./screens/Issue119Screen";
 import Issue120Screen from "./screens/Issue120Screen";
 import Issue121Screen from "./screens/Issue121Screen";
 import Issue122Screen from "./screens/Issue122Screen";
+import Issue132Screen from "./screens/Issue132Screen";
 import LastKnownPositionScreen from "./screens/LastKnownPositionScreen";
 import LocationAvailabilityScreen from "./screens/LocationAvailabilityScreen";
 import LocationSimulationScreen from "./screens/LocationSimulationScreen";
@@ -61,6 +62,7 @@ const linking = {
       Issue120: "issue-120",
       Issue121: "issue-121",
       Issue122: "issue-122",
+      Issue132: "issue-132",
       WebE2E: "web-e2e",
       Issue67: "issue-67"
     }
@@ -208,6 +210,11 @@ export default function App() {
         <Tab.Screen
           name="Issue122"
           component={Issue122Screen}
+          options={hiddenTabOptions}
+        />
+        <Tab.Screen
+          name="Issue132"
+          component={Issue132Screen}
           options={hiddenTabOptions}
         />
         <Tab.Screen

--- a/examples/v0.81.1/src/screens/Issue132Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue132Screen.tsx
@@ -1,0 +1,218 @@
+import React, { useRef, useState } from "react";
+import { Platform } from "react-native";
+import {
+  type BackgroundLocationOptions,
+  type BackgroundSubscription,
+  clearStoredBackgroundEvents,
+  clearStoredBackgroundLocations,
+  getBackgroundLocationStatus,
+  onBackgroundLocation,
+  resetBackgroundLocation,
+  startBackgroundLocation,
+  stopBackgroundLocation
+} from "react-native-nitro-geolocation/background";
+import {
+  ButtonRow,
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  StatusBlock,
+  createScenarioResult,
+  createScenarioResults,
+  sharedStyles,
+  useScenarioResults
+} from "./scenario";
+
+const PREFIX = "issue-132";
+
+const initialResults = createScenarioResults(["foregroundListener"] as const);
+
+const options: BackgroundLocationOptions = {
+  trackingMode: "continuous",
+  interval: 1_000,
+  fastestInterval: 500,
+  distanceFilter: 0,
+  persist: false,
+  stopOnTerminate: true,
+  startOnBoot: false,
+  android: {
+    locationProvider: "android_platform",
+    requestNotificationPermission: false,
+    foregroundService: {
+      notificationTitle: "Issue 132 foreground listener",
+      notificationText: "Waiting for foreground-service location updates",
+      notificationChannelId: "nitro-issue-132",
+      notificationChannelName: "Nitro Issue 132"
+    }
+  }
+};
+
+const shortError = (error: unknown) =>
+  String(error instanceof Error ? error.message : error)
+    .split("\n")[0]
+    .slice(0, 160);
+
+export default function Issue132Screen() {
+  const { results, setResult, resetResults } =
+    useScenarioResults(initialResults);
+  const subscriptionRef = useRef<BackgroundSubscription | undefined>(undefined);
+  const updateCountRef = useRef(0);
+  const [status, setStatus] = useState("not checked");
+  const [liveUpdates, setLiveUpdates] = useState(0);
+
+  const refreshStatus = async () => {
+    const current = await getBackgroundLocationStatus();
+    setStatus(
+      `${current.state} / running=${String(current.isRunning)} / fgService=${String(
+        current.android?.isForegroundServiceRunning ?? false
+      )}`
+    );
+  };
+
+  const removeListener = () => {
+    subscriptionRef.current?.remove();
+    subscriptionRef.current = undefined;
+  };
+
+  const cleanup = async () => {
+    removeListener();
+    await stopBackgroundLocation().catch(() => undefined);
+    await resetBackgroundLocation().catch(() => undefined);
+    await refreshStatus().catch(() => undefined);
+  };
+
+  const runForegroundListener = async () => {
+    setResult(
+      "foregroundListener",
+      createScenarioResult(
+        "running",
+        "Starting foreground-service tracking with only a live JS listener"
+      )
+    );
+
+    if (Platform.OS !== "android") {
+      setResult(
+        "foregroundListener",
+        createScenarioResult("passed", "Android-only warning repro skipped")
+      );
+      return;
+    }
+
+    try {
+      await cleanup();
+      await Promise.all([
+        clearStoredBackgroundLocations(),
+        clearStoredBackgroundEvents()
+      ]);
+
+      updateCountRef.current = 0;
+      setLiveUpdates(0);
+      subscriptionRef.current = onBackgroundLocation((location) => {
+        updateCountRef.current += 1;
+        setLiveUpdates(updateCountRef.current);
+        setResult(
+          "foregroundListener",
+          createScenarioResult(
+            "passed",
+            `Live update ${updateCountRef.current} delivered at ${location.coords.latitude.toFixed(
+              5
+            )}, ${location.coords.longitude.toFixed(5)}`
+          )
+        );
+      });
+
+      await startBackgroundLocation(options);
+      await refreshStatus();
+    } catch (error) {
+      removeListener();
+      setResult(
+        "foregroundListener",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  const runCleanup = async () => {
+    try {
+      await cleanup();
+      resetResults();
+      setLiveUpdates(0);
+      updateCountRef.current = 0;
+    } catch (error) {
+      setResult(
+        "foregroundListener",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix={PREFIX}
+      title="Issue 132"
+      subtitle="Foreground-service listener must not start Headless JS when no task is registered"
+    >
+      <ScenarioSection
+        index={1}
+        title="Observed State"
+        description="The E2E script checks logcat for missing Headless JS task warnings"
+      >
+        <StatusBlock
+          testID={`${PREFIX}-status-card`}
+          rows={[
+            {
+              label: "Status:",
+              value: status,
+              testID: `${PREFIX}-status`
+            },
+            {
+              label: "Live updates:",
+              value: liveUpdates,
+              testID: `${PREFIX}-live-updates`
+            }
+          ]}
+        />
+        <ButtonRow>
+          <ScenarioButton
+            title="Refresh"
+            onPress={refreshStatus}
+            testID={`${PREFIX}-refresh-button`}
+            containerStyle={sharedStyles.button}
+          />
+          <ScenarioButton
+            title="Cleanup"
+            onPress={runCleanup}
+            color="#6B7280"
+            testID={`${PREFIX}-cleanup-button`}
+            containerStyle={sharedStyles.button}
+          />
+        </ButtonRow>
+      </ScenarioSection>
+
+      <ScenarioSection
+        index={2}
+        title="Foreground Listener Repro"
+        description="Runs without registerBackgroundTask in the no-headless bundle"
+        divided
+      >
+        <ScenarioButton
+          title="Start Foreground Listener"
+          onPress={runForegroundListener}
+          testID={`${PREFIX}-start-button`}
+        />
+        <ResultList
+          prefix={PREFIX}
+          results={results}
+          items={[
+            {
+              id: "foreground-listener",
+              resultKey: "foregroundListener",
+              label: "Foreground listener"
+            }
+          ]}
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
@@ -50,3 +50,12 @@ internal fun resolveMaxStored(configured: Int?, default: Int): Int {
         else -> configured
     }
 }
+
+/**
+ * Headless JS is the fallback path when no in-process JS listener received the native event. If a
+ * live listener already handled the event, starting Headless JS duplicates delivery and React
+ * Native warns when the app did not register NitroBackgroundLocationTask.
+ */
+internal fun shouldDispatchHeadlessTask(deliveredToInProcessListener: Boolean): Boolean {
+    return !deliveredToInProcessListener
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHub.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHub.kt
@@ -45,22 +45,27 @@ class NitroBackgroundEventHub {
         errorListeners.remove(token)
     }
 
-    fun emit(event: BackgroundEventEnvelope) {
+    fun emit(event: BackgroundEventEnvelope): Boolean {
+        var delivered = eventListeners.isNotEmpty()
         eventListeners.values.forEach { listener -> dispatch { listener(event) } }
 
         when (event.type) {
             BackgroundEventType.LOCATION -> {
                 event.location?.let { location ->
+                    delivered = delivered || locationListeners.isNotEmpty()
                     locationListeners.values.forEach { listener -> dispatch { listener(location) } }
                 }
             }
             BackgroundEventType.ERROR -> {
                 event.error?.let { error ->
+                    delivered = delivered || errorListeners.isNotEmpty()
                     errorListeners.values.forEach { listener -> dispatch { listener(error) } }
                 }
             }
             else -> Unit
         }
+
+        return delivered
     }
 
     // Listeners run inline on the caller's thread (often the broadcast receiver thread). Isolate

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -604,7 +604,8 @@ class NitroBackgroundLocationController private constructor(
     }
 
     private fun dispatchEvent(event: BackgroundEventEnvelope) {
-        eventHub.emit(event)
+        val deliveredToInProcessListener = eventHub.emit(event)
+        if (!shouldDispatchHeadlessTask(deliveredToInProcessListener)) return
         // The in-process eventHub already delivered to any live JS listeners; the headless task is
         // the fallback for when JS is dead. Guard its start: startService from the background can be
         // rejected (ForegroundServiceStartNotAllowed / IllegalState), which must not crash the

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
@@ -64,4 +64,14 @@ class BackgroundDecisionsTest {
         assertEquals(0, resolveMaxStored(0, 10_000))
         assertEquals(0, resolveMaxStored(-5, 10_000))
     }
+
+    @Test
+    fun headlessTaskIsSkippedWhenInProcessListenerReceivedEvent() {
+        assertFalse(shouldDispatchHeadlessTask(true))
+    }
+
+    @Test
+    fun headlessTaskRunsWhenNoInProcessListenerReceivedEvent() {
+        assertTrue(shouldDispatchHeadlessTask(false))
+    }
 }


### PR DESCRIPTION
## Summary
- fix Android background event dispatch so Headless JS only runs when no in-process JS listener received the event
- add an Issue 132 E2E screen and no-headless example entry to reproduce foreground-service usage without registerBackgroundTask
- add an Android E2E runner that builds the no-headless release APK, injects emulator locations, and asserts logcat has no `No task registered for key NitroBackgroundLocationTask` warning
- add a patch Changeset for `react-native-nitro-geolocation`

## Root Cause
`dispatchEvent()` always started `NitroBackgroundHeadlessTaskService` after emitting to live JS listeners. Apps using `onBackgroundLocation()` with foreground-service tracking but no registered Headless JS task therefore received duplicate Headless JS dispatch attempts and React Native warned on every update.

## Verification
- Red check: temporarily reverted the native dispatch fix, ran `ANDROID_SERIAL=emulator-5554 EXPECT_WARNING=1 REACT_NATIVE_ARCHITECTURES=arm64-v8a yarn workspace react-native-nitro-geolocation-example test:e2e:issue-132:android`, confirmed `No task registered for key NitroBackgroundLocationTask` in logcat
- Green check: restored fix, ran `ANDROID_SERIAL=emulator-5554 REACT_NATIVE_ARCHITECTURES=arm64-v8a yarn workspace react-native-nitro-geolocation-example test:e2e:issue-132:android`, confirmed no Headless JS task warning
- `yarn workspace react-native-nitro-geolocation-example typecheck`
- `./gradlew :react-native-nitro-geolocation:testDebugUnitTest`
- `bash -n examples/v0.81.1/scripts/test-issue-132-android.sh`
- `git diff --check`

Fixes #132
