### PR TITLE
chore: run E2E CI from PR title [E2E]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,9 @@
 
 <!--
 If your PR includes code changes, please run E2E tests locally.
+To run optional CI E2E checks, add the `E2E` label to the PR. The iOS and
+Android E2E workflow runs with read-only permissions and reports through GitHub
+Checks.
 For documentation-only changes, you can skip this section.
 
 Run the following command in the example app:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,10 +165,9 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: |
-            adb kill-server
-            adb start-server
-            adb wait-for-device
-            timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do sleep 5; done'
+            adb devices
+            timeout 180 bash -c 'until [[ "$(adb get-state 2>/dev/null)" == "device" ]]; do adb reconnect offline || true; adb devices; sleep 5; done'
+            timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do adb devices; sleep 5; done'
             adb shell input keyevent 82 || true
             yarn workspace react-native-nitro-geolocation-example android:release
             yarn test:e2e:android

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,7 +165,7 @@ jobs:
   android-e2e:
     name: Android E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.title, '[E2E]')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,14 +81,10 @@ jobs:
           xcrun simctl boot "$SIMULATOR_UDID" || true
           xcrun simctl bootstatus "$SIMULATOR_UDID" -b
 
-      - name: Start Metro
-        run: |
-          yarn workspace react-native-nitro-geolocation-example start > /tmp/metro-ios.log 2>&1 &
-
-      - name: Build and install iOS app
+      - name: Build and install iOS release app
         working-directory: examples/v0.81.1
         run: |
-          yarn react-native run-ios --udid "$SIMULATOR_UDID"
+          yarn react-native run-ios --mode Release --udid "$SIMULATOR_UDID"
 
       - name: Run iOS E2E
         run: |
@@ -101,7 +97,6 @@ jobs:
           name: ios-e2e-artifacts
           if-no-files-found: ignore
           path: |
-            /tmp/metro-ios.log
             ~/.maestro/tests
 
   android-e2e:
@@ -153,8 +148,7 @@ jobs:
           target: google_apis
           profile: pixel_6
           script: |
-            yarn workspace react-native-nitro-geolocation-example start > /tmp/metro-android.log 2>&1 &
-            yarn workspace react-native-nitro-geolocation-example android
+            yarn workspace react-native-nitro-geolocation-example android:release
             yarn test:e2e:android
 
       - name: Upload Android E2E artifacts
@@ -164,5 +158,4 @@ jobs:
           name: android-e2e-artifacts
           if-no-files-found: ignore
           path: |
-            /tmp/metro-android.log
             ~/.maestro/tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3"
           bundler-cache: true
           working-directory: examples/v0.81.1
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,10 +149,11 @@ jobs:
       - name: Run Android E2E
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 35
+          api-level: 34
           arch: x86_64
           target: google_apis
           profile: pixel_6
+          emulator-boot-timeout: 600
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -177,10 +177,8 @@ jobs:
             timeout 180 bash -c 'until [[ "$(adb get-state 2>/dev/null)" == "device" ]]; do adb reconnect offline || true; adb devices; sleep 5; done'
             timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do adb devices; sleep 5; done'
             adb shell input keyevent 82 || true
-            cd examples/v0.81.1/android
-            ./gradlew --no-daemon --console=plain assembleRelease
-            adb install -r app/build/outputs/apk/release/app-release.apk
-            cd ../../..
+            ./examples/v0.81.1/android/gradlew -p examples/v0.81.1/android --no-daemon --console=plain assembleRelease
+            adb install -r examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
             yarn test:e2e:android
 
       - name: Upload Android E2E artifacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,8 @@ name: E2E
 on:
   pull_request:
     types:
-      - labeled
+      - opened
+      - edited
       - reopened
       - ready_for_review
       - synchronize
@@ -23,10 +24,7 @@ jobs:
     timeout-minutes: 60
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (
-        contains(github.event.pull_request.labels.*.name, 'E2E') &&
-        (github.event.action != 'labeled' || github.event.label.name == 'E2E')
-      )
+      contains(github.event.pull_request.title, '[E2E]')
 
     steps:
       - name: Checkout
@@ -110,10 +108,7 @@ jobs:
     timeout-minutes: 60
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (
-        contains(github.event.pull_request.labels.*.name, 'E2E') &&
-        (github.event.action != 'labeled' || github.event.label.name == 'E2E')
-      )
+      contains(github.event.pull_request.title, '[E2E]')
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -140,6 +140,12 @@ jobs:
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run Android E2E
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -147,7 +153,14 @@ jobs:
           arch: x86_64
           target: google_apis
           profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           script: |
+            adb kill-server
+            adb start-server
+            adb wait-for-device
+            timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do sleep 5; done'
+            adb shell input keyevent 82 || true
             yarn workspace react-native-nitro-geolocation-example android:release
             yarn test:e2e:android
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
   ios-e2e:
     name: iOS E2E
     runs-on: macos-15
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.title, '[E2E]')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,43 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Compute iOS app fingerprint
+        id: ios-app-fingerprint
+        shell: bash
+        run: |
+          fingerprint="$(
+            {
+              printf 'ios-e2e-app-v1\n'
+              xcodebuild -version
+              git ls-files -z -- \
+                mise.toml \
+                package.json \
+                yarn.lock \
+                packages/react-native-nitro-geolocation \
+                packages/rozenite-devtools-plugin \
+                examples/v0.81.1/package.json \
+                examples/v0.81.1/app.json \
+                examples/v0.81.1/babel.config.js \
+                examples/v0.81.1/index.js \
+                examples/v0.81.1/index.no-headless.js \
+                examples/v0.81.1/metro.config.js \
+                examples/v0.81.1/react-native.config.js \
+                examples/v0.81.1/src \
+                examples/v0.81.1/ios \
+                | xargs -0 shasum -a 256
+            } | shasum -a 256 | awk '{ print $1 }'
+          )"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "key=ios-e2e-app-$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "iOS app fingerprint: $fingerprint"
+
+      - name: Restore iOS release app cache
+        id: ios-app-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: examples/v0.81.1/ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
+          key: ${{ steps.ios-app-fingerprint.outputs.key }}
+
       - name: Setup mise
         uses: jdx/mise-action@v3
         with:
@@ -56,11 +93,13 @@ jobs:
           yarn build:all
 
       - name: Install iOS gems
+        if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
         run: |
           bundle install
 
       - name: Install iOS pods
+        if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
         run: |
           bundle exec pod install --project-directory=ios
@@ -76,7 +115,8 @@ jobs:
           xcrun simctl boot "$SIMULATOR_UDID" || true
           xcrun simctl bootstatus "$SIMULATOR_UDID" -b
 
-      - name: Build and install iOS release app
+      - name: Build iOS release app
+        if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
         run: |
           xcodebuild \
@@ -87,6 +127,18 @@ jobs:
             -destination "id=$SIMULATOR_UDID" \
             -derivedDataPath ios/build \
             build
+
+      - name: Save iOS release app cache
+        if: steps.ios-app-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: examples/v0.81.1/ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
+          key: ${{ steps.ios-app-fingerprint.outputs.key }}
+
+      - name: Install iOS release app
+        working-directory: examples/v0.81.1
+        run: |
           xcrun simctl install "$SIMULATOR_UDID" ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
 
       - name: Run iOS E2E
@@ -116,6 +168,43 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Compute Android app fingerprint
+        id: android-app-fingerprint
+        shell: bash
+        run: |
+          fingerprint="$(
+            {
+              printf 'android-e2e-app-v1\n'
+              printf 'api-level=34\n'
+              git ls-files -z -- \
+                mise.toml \
+                package.json \
+                yarn.lock \
+                packages/react-native-nitro-geolocation \
+                packages/rozenite-devtools-plugin \
+                examples/v0.81.1/package.json \
+                examples/v0.81.1/app.json \
+                examples/v0.81.1/babel.config.js \
+                examples/v0.81.1/index.js \
+                examples/v0.81.1/index.no-headless.js \
+                examples/v0.81.1/metro.config.js \
+                examples/v0.81.1/react-native.config.js \
+                examples/v0.81.1/src \
+                examples/v0.81.1/android \
+                | xargs -0 sha256sum
+            } | sha256sum | awk '{ print $1 }'
+          )"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "key=android-e2e-app-$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "Android app fingerprint: $fingerprint"
+
+      - name: Restore Android release app cache
+        id: android-app-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
+          key: ${{ steps.android-app-fingerprint.outputs.key }}
+
       - name: Setup mise
         uses: jdx/mise-action@v3
         with:
@@ -139,6 +228,19 @@ jobs:
         run: |
           yarn build:all
 
+      - name: Build Android release app
+        if: steps.android-app-cache.outputs.cache-hit != 'true'
+        run: |
+          ./examples/v0.81.1/android/gradlew -p examples/v0.81.1/android --no-daemon --console=plain assembleRelease
+
+      - name: Save Android release app cache
+        if: steps.android-app-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
+          key: ${{ steps.android-app-fingerprint.outputs.key }}
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -160,7 +262,6 @@ jobs:
             timeout 180 bash -c 'until [[ "$(adb get-state 2>/dev/null)" == "device" ]]; do adb reconnect offline || true; adb devices; sleep 5; done'
             timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do adb devices; sleep 5; done'
             adb shell input keyevent 82 || true
-            ./examples/v0.81.1/android/gradlew -p examples/v0.81.1/android --no-daemon --console=plain assembleRelease
             adb install -r examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
             yarn test:e2e:android
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,10 +74,18 @@ jobs:
         with:
           install: false
 
-      - name: Trust and install tools via mise
+      - name: Trust mise config
         run: |
           mise trust --yes
-          mise install java maestro node ruby
+
+      - name: Install iOS E2E tools via mise
+        run: |
+          mise install java maestro node
+
+      - name: Install iOS native build tools via mise
+        if: steps.ios-app-cache.outputs.cache-hit != 'true'
+        run: |
+          mise install ruby
 
       - name: Enable Corepack
         run: |
@@ -210,9 +218,12 @@ jobs:
         with:
           install: false
 
-      - name: Trust and install tools via mise
+      - name: Trust mise config
         run: |
           mise trust --yes
+
+      - name: Install Android E2E tools via mise
+        run: |
           mise install java maestro node
 
       - name: Enable Corepack

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,167 @@
+name: E2E
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - reopened
+      - ready_for_review
+      - synchronize
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios-e2e:
+    name: iOS E2E
+    runs-on: macos-15
+    timeout-minutes: 60
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'E2E') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'E2E')
+      )
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+
+      - name: Install dependencies
+        run: |
+          yarn install
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: examples/v0.81.1
+
+      - name: Install iOS pods
+        working-directory: examples/v0.81.1
+        run: |
+          bundle exec pod install --project-directory=ios
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Boot iOS simulator
+        run: |
+          SIMULATOR_UDID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
+          if [ -z "$SIMULATOR_UDID" ]; then
+            echo "No available iPhone simulator found." >&2
+            exit 1
+          fi
+          echo "SIMULATOR_UDID=$SIMULATOR_UDID" >> "$GITHUB_ENV"
+          xcrun simctl boot "$SIMULATOR_UDID" || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+
+      - name: Start Metro
+        run: |
+          yarn workspace react-native-nitro-geolocation-example start > /tmp/metro-ios.log 2>&1 &
+
+      - name: Build and install iOS app
+        working-directory: examples/v0.81.1
+        run: |
+          yarn react-native run-ios --udid "$SIMULATOR_UDID"
+
+      - name: Run iOS E2E
+        run: |
+          yarn test:e2e:ios
+
+      - name: Upload iOS E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-e2e-artifacts
+          if-no-files-found: ignore
+          path: |
+            /tmp/metro-ios.log
+            ~/.maestro/tests
+
+  android-e2e:
+    name: Android E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.pull_request.labels.*.name, 'E2E') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'E2E')
+      )
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+
+      - name: Install dependencies
+        run: |
+          yarn install
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Run Android E2E
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          script: |
+            yarn workspace react-native-nitro-geolocation-example start > /tmp/metro-android.log 2>&1 &
+            yarn workspace react-native-nitro-geolocation-example android
+            yarn test:e2e:android
+
+      - name: Upload Android E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-artifacts
+          if-no-files-found: ignore
+          path: |
+            /tmp/metro-android.log
+            ~/.maestro/tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,6 +53,10 @@ jobs:
         run: |
           yarn install
 
+      - name: Build packages
+        run: |
+          yarn build:all
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -134,6 +138,10 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install
+
+      - name: Build packages
+        run: |
+          yarn build:all
 
       - name: Install Maestro
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,20 +34,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install java maestro node ruby
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |
@@ -57,22 +57,15 @@ jobs:
         run: |
           yarn build:all
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          working-directory: examples/v0.81.1
+      - name: Install iOS gems
+        working-directory: examples/v0.81.1
+        run: |
+          bundle install
 
       - name: Install iOS pods
         working-directory: examples/v0.81.1
         run: |
           bundle exec pod install --project-directory=ios
-
-      - name: Install Maestro
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: Boot iOS simulator
         run: |
@@ -128,20 +121,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install java maestro node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |
@@ -150,11 +143,6 @@ jobs:
       - name: Build packages
         run: |
           yarn build:all
-
-      - name: Install Maestro
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,15 @@ jobs:
       - name: Build and install iOS release app
         working-directory: examples/v0.81.1
         run: |
-          yarn react-native run-ios --mode Release --udid "$SIMULATOR_UDID"
+          xcodebuild \
+            -workspace ios/NitroGeolocationExample.xcworkspace \
+            -scheme NitroGeolocationExample \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "id=$SIMULATOR_UDID" \
+            -derivedDataPath ios/build \
+            build
+          xcrun simctl install "$SIMULATOR_UDID" ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
 
       - name: Run iOS E2E
         run: |
@@ -169,7 +177,10 @@ jobs:
             timeout 180 bash -c 'until [[ "$(adb get-state 2>/dev/null)" == "device" ]]; do adb reconnect offline || true; adb devices; sleep 5; done'
             timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do adb devices; sleep 5; done'
             adb shell input keyevent 82 || true
-            yarn workspace react-native-nitro-geolocation-example android:release
+            cd examples/v0.81.1/android
+            ./gradlew --no-daemon --console=plain assembleRelease
+            adb install -r app/build/outputs/apk/release/app-release.apk
+            cd ../../..
             yarn test:e2e:android
 
       - name: Upload Android E2E artifacts

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -57,7 +57,7 @@ appId: nitrogeolocation.example
 
 - extendedWaitUntil:
     visible: "Positive presets: passed"
-    timeout: 60000
+    timeout: 120000
 
 - assertVisible:
     id: "accuracy-presets-positive-result"

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/accuracy-presets
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -89,10 +95,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/accuracy-presets
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -55,9 +55,20 @@ appId: nitrogeolocation.example
 - tapOn:
     id: "e2e-action-accuracy-presets-run-positive-button"
 
-- extendedWaitUntil:
-    visible: "Positive presets: passed"
-    timeout: 120000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: "Positive presets: passed"
+          timeout: 60000
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible: "Positive presets: passed"
+          timeout: 120000
 
 - assertVisible:
     id: "accuracy-presets-positive-result"

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -95,7 +95,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/accuracy-presets
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -79,6 +86,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/accuracy-presets
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/accuracy-presets
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -84,6 +98,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -92,6 +113,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/accuracy-presets
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/android-provider-selection.yaml
+++ b/examples/v0.81.1/.maestro/android-provider-selection.yaml
@@ -21,10 +21,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/android-request-options/providers
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-provider-selection.yaml
+++ b/examples/v0.81.1/.maestro/android-provider-selection.yaml
@@ -18,6 +18,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/providers
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-provider-selection.yaml
+++ b/examples/v0.81.1/.maestro/android-provider-selection.yaml
@@ -12,12 +12,26 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/providers
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/android-provider-selection.yaml
+++ b/examples/v0.81.1/.maestro/android-provider-selection.yaml
@@ -21,7 +21,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/android-request-options-errors.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-errors.yaml
@@ -17,7 +17,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -65,7 +65,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/android-request-options-errors.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-errors.yaml
@@ -8,12 +8,26 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/errors
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -54,6 +68,13 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -62,6 +83,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/errors
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/android-request-options-errors.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-errors.yaml
@@ -17,10 +17,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/android-request-options/errors
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -59,10 +65,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/android-request-options/errors
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options-errors.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-errors.yaml
@@ -14,6 +14,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/errors
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -49,6 +56,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/errors
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options-watch.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-watch.yaml
@@ -17,7 +17,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/android-request-options-watch.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-watch.yaml
@@ -17,10 +17,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/android-request-options/watches
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options-watch.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-watch.yaml
@@ -8,12 +8,26 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/watches
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/android-request-options-watch.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options-watch.yaml
@@ -14,6 +14,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options/watches
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options.yaml
@@ -8,12 +8,26 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
 
 - openLink:
     link: nitrogeolocation://app/android-request-options
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/android-request-options.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options.yaml
@@ -17,10 +17,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/android-request-options
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options.yaml
@@ -14,6 +14,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/android-request-options
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/android-request-options.yaml
+++ b/examples/v0.81.1/.maestro/android-request-options.yaml
@@ -17,7 +17,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/api-errors.yaml
+++ b/examples/v0.81.1/.maestro/api-errors.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/api-errors
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -55,10 +61,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/api-errors
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/api-errors.yaml
+++ b/examples/v0.81.1/.maestro/api-errors.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -61,7 +61,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/api-errors.yaml
+++ b/examples/v0.81.1/.maestro/api-errors.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/api-errors
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -45,6 +52,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/api-errors
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/api-errors.yaml
+++ b/examples/v0.81.1/.maestro/api-errors.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/api-errors
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -50,6 +64,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -58,6 +79,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/api-errors
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/background-e2e.yaml
+++ b/examples/v0.81.1/.maestro/background-e2e.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-e2e
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/background-e2e.yaml
+++ b/examples/v0.81.1/.maestro/background-e2e.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-e2e
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-e2e.yaml
+++ b/examples/v0.81.1/.maestro/background-e2e.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-e2e
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-e2e.yaml
+++ b/examples/v0.81.1/.maestro/background-e2e.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
@@ -6,6 +6,13 @@ appId: nitrogeolocation.example
     link: nitrogeolocation://app/background-long-run
 - runFlow:
     when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
       platform: iOS
       visible: "Cancel|취소"
     commands:

--- a/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
@@ -4,6 +4,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
@@ -7,7 +7,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-arm-reboot.yaml
@@ -7,10 +7,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
@@ -8,10 +8,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     link: nitrogeolocation://app/background-long-run
 - runFlow:
     when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
       platform: iOS
       visible: "Cancel|취소"
     commands:

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
@@ -5,6 +5,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
@@ -8,7 +8,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -17,6 +17,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -44,6 +51,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -20,7 +20,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -60,7 +60,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -20,10 +20,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -54,10 +60,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -9,6 +9,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -17,6 +24,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -57,6 +71,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -43,6 +50,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -53,10 +59,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -59,7 +59,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -56,6 +70,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/compat-api.yaml
+++ b/examples/v0.81.1/.maestro/compat-api.yaml
@@ -6,6 +6,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -14,6 +21,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/compat
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/compat-api.yaml
+++ b/examples/v0.81.1/.maestro/compat-api.yaml
@@ -14,6 +14,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/compat
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 - tapOn:
     text: "Compat API, tab, 8 of 8|Compat API"

--- a/examples/v0.81.1/.maestro/compat-api.yaml
+++ b/examples/v0.81.1/.maestro/compat-api.yaml
@@ -17,10 +17,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/compat
 - waitForAnimationToEnd
 - tapOn:
     text: "Compat API, tab, 8 of 8|Compat API"

--- a/examples/v0.81.1/.maestro/compat-api.yaml
+++ b/examples/v0.81.1/.maestro/compat-api.yaml
@@ -17,7 +17,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/current-position.yaml
+++ b/examples/v0.81.1/.maestro/current-position.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/current-position
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 # First ensure we have permission
@@ -66,6 +73,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/current-position
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/current-position.yaml
+++ b/examples/v0.81.1/.maestro/current-position.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -82,7 +82,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/current-position.yaml
+++ b/examples/v0.81.1/.maestro/current-position.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/current-position
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -71,6 +85,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -79,6 +100,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/current-position
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/current-position.yaml
+++ b/examples/v0.81.1/.maestro/current-position.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/current-position
 - waitForAnimationToEnd
 
 # First ensure we have permission
@@ -76,10 +82,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/current-position
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/dismiss-ios-open-alert.yaml
+++ b/examples/v0.81.1/.maestro/dismiss-ios-open-alert.yaml
@@ -1,0 +1,5 @@
+appId: nitrogeolocation.example
+---
+- tapOn:
+    text: "Open|열기"
+    optional: true

--- a/examples/v0.81.1/.maestro/geocoding.yaml
+++ b/examples/v0.81.1/.maestro/geocoding.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/geocoding
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/geocoding.yaml
+++ b/examples/v0.81.1/.maestro/geocoding.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/geocoding
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 - tapOn:
     id: "com.google.android.googlequicksearchbox:id/assistant_robin_fast_track_banner_dismiss_button"

--- a/examples/v0.81.1/.maestro/geocoding.yaml
+++ b/examples/v0.81.1/.maestro/geocoding.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/geocoding.yaml
+++ b/examples/v0.81.1/.maestro/geocoding.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/geocoding
 - waitForAnimationToEnd
 - tapOn:
     id: "com.google.android.googlequicksearchbox:id/assistant_robin_fast_track_banner_dismiss_button"

--- a/examples/v0.81.1/.maestro/heading-android.yaml
+++ b/examples/v0.81.1/.maestro/heading-android.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -81,7 +81,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/heading-android.yaml
+++ b/examples/v0.81.1/.maestro/heading-android.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -70,6 +84,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -78,6 +99,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/heading-android.yaml
+++ b/examples/v0.81.1/.maestro/heading-android.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/heading
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -75,10 +81,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/heading
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/heading-android.yaml
+++ b/examples/v0.81.1/.maestro/heading-android.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -65,6 +72,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/heading-ios.yaml
+++ b/examples/v0.81.1/.maestro/heading-ios.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -56,6 +63,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/heading-ios.yaml
+++ b/examples/v0.81.1/.maestro/heading-ios.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/heading
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -66,10 +72,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/heading
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/heading-ios.yaml
+++ b/examples/v0.81.1/.maestro/heading-ios.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -72,7 +72,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/heading-ios.yaml
+++ b/examples/v0.81.1/.maestro/heading-ios.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -61,6 +75,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -69,6 +90,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/heading
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
+++ b/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/ios-accuracy-authorization
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -81,10 +87,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/ios-accuracy-authorization
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
+++ b/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-accuracy-authorization
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -71,6 +78,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-accuracy-authorization
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
+++ b/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-accuracy-authorization
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -76,6 +90,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -84,6 +105,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-accuracy-authorization
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
+++ b/examples/v0.81.1/.maestro/ios-accuracy-authorization.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -87,7 +87,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/ios-location-tuning.yaml
+++ b/examples/v0.81.1/.maestro/ios-location-tuning.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-location-tuning
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -70,6 +84,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -78,6 +99,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-location-tuning
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/ios-location-tuning.yaml
+++ b/examples/v0.81.1/.maestro/ios-location-tuning.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-location-tuning
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -65,6 +72,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-location-tuning
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-location-tuning.yaml
+++ b/examples/v0.81.1/.maestro/ios-location-tuning.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/ios-location-tuning
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -75,10 +81,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/ios-location-tuning
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-location-tuning.yaml
+++ b/examples/v0.81.1/.maestro/ios-location-tuning.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -81,7 +81,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
+++ b/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/ios-release-options-bridge
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
+++ b/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-release-options-bridge
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
+++ b/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/ios-release-options-bridge
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
+++ b/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -23,10 +23,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-119
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -8,6 +8,9 @@ appId: nitrogeolocation.example
       all: deny
       android.permission.ACCESS_COARSE_LOCATION: deny
       android.permission.ACCESS_FINE_LOCATION: deny
+- tapOn:
+    text: "Wait|대기"
+    optional: true
 
 - extendedWaitUntil:
     visible: "Geolocation API"

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
       all: deny
       android.permission.ACCESS_COARSE_LOCATION: deny
       android.permission.ACCESS_FINE_LOCATION: deny
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - tapOn:
     text: "Wait|대기"
     optional: true
@@ -20,6 +27,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-119
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -20,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-119
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-119-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-android.yaml
@@ -23,7 +23,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-119-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-ios.yaml
@@ -5,6 +5,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -13,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-119
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-119-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-ios.yaml
@@ -16,7 +16,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-119-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-ios.yaml
@@ -16,10 +16,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-119
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-119-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-119-ios.yaml
@@ -13,6 +13,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-119
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-120-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-android.yaml
@@ -16,10 +16,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-120
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-120-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-android.yaml
@@ -16,7 +16,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-120-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-android.yaml
@@ -5,6 +5,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -13,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-120
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-120-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-android.yaml
@@ -13,6 +13,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-120
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -17,6 +17,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-120
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -9,6 +9,13 @@ appId: nitrogeolocation.example
       location: always
       motion: unset
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -17,6 +24,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-120
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -20,7 +20,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-120-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-120-ios.yaml
@@ -20,10 +20,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-120
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-121-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-android.yaml
@@ -9,6 +9,13 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -17,6 +24,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-121
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-121-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-android.yaml
@@ -20,10 +20,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-121
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-121-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-android.yaml
@@ -20,7 +20,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-121-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-android.yaml
@@ -17,6 +17,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-121
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-121-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-ios.yaml
@@ -5,6 +5,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -13,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-121
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-121-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-ios.yaml
@@ -13,6 +13,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-121
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-121-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-ios.yaml
@@ -16,7 +16,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-121-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-121-ios.yaml
@@ -16,10 +16,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-121
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-122-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-android.yaml
@@ -5,6 +5,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -13,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-122
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-122-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-android.yaml
@@ -16,7 +16,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-122-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-android.yaml
@@ -13,6 +13,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-122
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-122-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-android.yaml
@@ -16,10 +16,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-122
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-122-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-ios.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-122
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-122-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-ios.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-122
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-122-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-ios.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-122-ios.yaml
+++ b/examples/v0.81.1/.maestro/issue-122-ios.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-122
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-132-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-132-android.yaml
@@ -21,10 +21,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-132
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-132-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-132-android.yaml
@@ -10,6 +10,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
@@ -18,6 +25,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-132
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-132-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-132-android.yaml
@@ -18,6 +18,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-132
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-132-android.yaml
+++ b/examples/v0.81.1/.maestro/issue-132-android.yaml
@@ -21,7 +21,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
+++ b/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/issue-67
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
+++ b/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
+++ b/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
@@ -10,12 +10,26 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
 
 - openLink:
     link: nitrogeolocation://app/issue-67
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
+++ b/examples/v0.81.1/.maestro/issue-67-android-coarse-location.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/issue-67
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -15,6 +15,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/last-known-position?case=allowed
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -73,6 +80,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/last-known-position?case=denied
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -18,10 +18,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/last-known-position?case=allowed
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -83,10 +89,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/last-known-position?case=denied
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -18,7 +18,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -89,7 +89,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -7,6 +7,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -15,6 +22,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/last-known-position?case=allowed
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -78,6 +92,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -86,6 +107,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/last-known-position?case=denied
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/location-availability.yaml
+++ b/examples/v0.81.1/.maestro/location-availability.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-availability
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -59,6 +73,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -67,6 +88,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-availability
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/location-availability.yaml
+++ b/examples/v0.81.1/.maestro/location-availability.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/location-availability
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -64,10 +70,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/location-availability
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/location-availability.yaml
+++ b/examples/v0.81.1/.maestro/location-availability.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-availability
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -54,6 +61,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-availability
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/location-availability.yaml
+++ b/examples/v0.81.1/.maestro/location-availability.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -70,7 +70,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/location-simulation.yaml
+++ b/examples/v0.81.1/.maestro/location-simulation.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/location-simulation
 - waitForAnimationToEnd
 
 # Request permission

--- a/examples/v0.81.1/.maestro/location-simulation.yaml
+++ b/examples/v0.81.1/.maestro/location-simulation.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/location-simulation.yaml
+++ b/examples/v0.81.1/.maestro/location-simulation.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-simulation
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/location-simulation.yaml
+++ b/examples/v0.81.1/.maestro/location-simulation.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/location-simulation
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 # Request permission

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
@@ -20,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
@@ -16,10 +16,24 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - stopApp
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
@@ -23,7 +23,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
@@ -23,10 +23,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/mocked-metadata
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -17,6 +17,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -20,10 +20,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/mocked-metadata
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -13,10 +13,24 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - stopApp
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -20,7 +20,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
@@ -17,6 +17,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
@@ -20,10 +20,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/mocked-metadata
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
@@ -13,10 +13,24 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - stopApp
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
@@ -20,7 +20,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
@@ -10,6 +10,13 @@ appId: nitrogeolocation.example
 - launchApp:
     clearState: true
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -18,6 +25,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
@@ -18,6 +18,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/mocked-metadata
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
@@ -21,10 +21,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/mocked-metadata
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
@@ -21,7 +21,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/permission-check.yaml
+++ b/examples/v0.81.1/.maestro/permission-check.yaml
@@ -14,7 +14,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/permission-check.yaml
+++ b/examples/v0.81.1/.maestro/permission-check.yaml
@@ -11,6 +11,13 @@ appId: nitrogeolocation.example
 - stopApp
 - openLink:
     link: nitrogeolocation://app/permission-check
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 # Navigate directly to the permission contract page.

--- a/examples/v0.81.1/.maestro/permission-check.yaml
+++ b/examples/v0.81.1/.maestro/permission-check.yaml
@@ -5,12 +5,26 @@ appId: nitrogeolocation.example
     clearState: true
     permissions:
       all: allow
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 30000
 - stopApp
 - openLink:
     link: nitrogeolocation://app/permission-check
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/permission-check.yaml
+++ b/examples/v0.81.1/.maestro/permission-check.yaml
@@ -14,10 +14,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/permission-check
 - waitForAnimationToEnd
 
 # Navigate directly to the permission contract page.

--- a/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
@@ -13,6 +13,13 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -21,6 +28,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/provider-settings
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
@@ -24,7 +24,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
@@ -21,6 +21,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/provider-settings
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
@@ -47,5 +54,8 @@ appId: nitrogeolocation.example
     visible: "Settings: blocked"
     timeout: 10000
 
-- assertVisible: "Name: SETTINGS_NOT_SATISFIED"
+- extendedWaitUntil:
+    visible:
+      id: "provider-settings-error-name"
+    timeout: 10000
 - assertVisible: "Provider readiness: not ready"

--- a/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings-not-ready.yaml
@@ -24,10 +24,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/provider-settings
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/provider-settings.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings.yaml
@@ -14,6 +14,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/provider-settings
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/provider-settings.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings.yaml
@@ -17,7 +17,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/provider-settings.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings.yaml
@@ -10,10 +10,24 @@ appId: nitrogeolocation.example
       android.permission.ACCESS_COARSE_LOCATION: allow
       android.permission.ACCESS_FINE_LOCATION: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - stopApp
 
 - openLink:
     link: nitrogeolocation://app/provider-settings
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/provider-settings.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings.yaml
@@ -17,10 +17,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/provider-settings
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/watch-position.yaml
+++ b/examples/v0.81.1/.maestro/watch-position.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -92,7 +92,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/watch-position.yaml
+++ b/examples/v0.81.1/.maestro/watch-position.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/watch-position
 - waitForAnimationToEnd
 
 # Ensure permission is granted
@@ -86,10 +92,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/watch-position
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/watch-position.yaml
+++ b/examples/v0.81.1/.maestro/watch-position.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/watch-position
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 # Ensure permission is granted
@@ -76,6 +83,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/watch-position
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/watch-position.yaml
+++ b/examples/v0.81.1/.maestro/watch-position.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/watch-position
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -81,6 +95,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 10000
@@ -89,6 +110,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/watch-position
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -16,6 +16,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=unavailable
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -19,7 +19,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 20000
@@ -16,6 +23,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=unavailable
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -19,10 +19,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/web-e2e?autorun=unavailable
 - waitForAnimationToEnd
 
 - extendedWaitUntil:

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -23,7 +23,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"
@@ -151,7 +151,7 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: "Open in.*NitroGeolocationExample.*"
+      visible: "Cancel|취소"
     commands:
       - tapOn:
           text: "Open|열기"

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -23,10 +23,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/web-e2e?autorun=success
 - waitForAnimationToEnd
 
 - tapOn:
@@ -145,10 +151,16 @@ appId: nitrogeolocation.example
 - runFlow:
     when:
       platform: iOS
-      visible: ".*NitroGeolocationExample.*"
+      visible: "Open in.*NitroGeolocationExample.*"
     commands:
       - tapOn:
           text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/web-e2e?autorun=denied
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -20,6 +20,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=success
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - tapOn:
@@ -135,6 +142,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=denied
+- runFlow:
+    when:
+      platform: iOS
+      visible: ".*NitroGeolocationExample.*"
+    commands:
+      - tapOn:
+          text: "Open|열기"
 - waitForAnimationToEnd
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -8,6 +8,13 @@ appId: nitrogeolocation.example
     permissions:
       all: allow
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - setLocation:
     latitude: 37.5665
     longitude: 126.9780
@@ -20,6 +27,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=success
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS
@@ -140,6 +154,13 @@ appId: nitrogeolocation.example
     permissions:
       all: deny
 
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
     timeout: 20000
@@ -148,6 +169,13 @@ appId: nitrogeolocation.example
 
 - openLink:
     link: nitrogeolocation://app/web-e2e?autorun=denied
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
 - runFlow:
     when:
       platform: iOS

--- a/examples/v0.81.1/scripts/maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/maestro-retry-flows.sh
@@ -10,6 +10,9 @@ Options:
   --maestro <path>      Maestro executable. Default: maestro.
   --maestro-arg <arg>   Extra Maestro arg. Can be repeated.
   --env <key=value>     Extra Maestro env var. Can be repeated.
+  --suite-name <name>   Label used in log messages. Default: suite.
+  --failure-log-lines <n|all>
+                      Lines of each final failed flow log to print. Default: all.
 USAGE
 }
 
@@ -17,6 +20,8 @@ PLATFORM=""
 FLOW_DIR=""
 ATTEMPTS="${MAESTRO_RETRY_ATTEMPTS:-3}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
+SUITE_NAME="suite"
+FAILURE_LOG_LINES="${MAESTRO_RETRY_FAILURE_LOG_LINES:-all}"
 MAESTRO_ARGS=()
 MAESTRO_ENV_ARGS=()
 
@@ -46,6 +51,14 @@ while [[ $# -gt 0 ]]; do
       MAESTRO_ENV_ARGS+=("-e" "$2")
       shift 2
       ;;
+    --suite-name)
+      SUITE_NAME="$2"
+      shift 2
+      ;;
+    --failure-log-lines)
+      FAILURE_LOG_LINES="$2"
+      shift 2
+      ;;
     --)
       shift
       break
@@ -68,6 +81,10 @@ if [[ -z "$PLATFORM" || -z "$FLOW_DIR" ]]; then
 fi
 if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   echo "--attempts must be a positive integer." >&2
+  exit 2
+fi
+if [[ "$FAILURE_LOG_LINES" != "all" ]] && ! [[ "$FAILURE_LOG_LINES" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--failure-log-lines must be a positive integer or 'all'." >&2
   exit 2
 fi
 
@@ -100,7 +117,7 @@ run_flow() {
     return 1
   fi
 
-  echo "::group::Maestro attempt $attempt/$ATTEMPTS: $flow"
+  echo "::group::Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: $flow"
   set +e
   CMD=("$MAESTRO_BIN" test --platform "$PLATFORM")
   if [[ "${#MAESTRO_ARGS[@]}" -gt 0 ]]; then
@@ -118,11 +135,30 @@ run_flow() {
   return "$status"
 }
 
+print_final_failure_log() {
+  local flow="$1"
+  local log_path
+  log_path="$(flow_log_path "$ATTEMPTS" "$flow")"
+
+  echo "::group::Maestro final failure log: $flow"
+  if [[ -f "$log_path" ]]; then
+    echo "Last attempt log: $log_path"
+    if [[ "$FAILURE_LOG_LINES" == "all" ]]; then
+      cat "$log_path"
+    else
+      tail -n "$FAILURE_LOG_LINES" "$log_path"
+    fi
+  else
+    echo "Missing final attempt log: $log_path"
+  fi
+  echo "::endgroup::"
+}
+
 for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
   if [[ "$attempt" -eq 1 ]]; then
-    echo "Maestro attempt $attempt/$ATTEMPTS: initial full sweep (${#PENDING[@]} flow(s))"
+    echo "Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: initial full sweep (${#PENDING[@]} flow(s))"
   else
-    echo "Maestro attempt $attempt/$ATTEMPTS: retry failed flows only (${#PENDING[@]} flow(s))"
+    echo "Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: retry failed flows only (${#PENDING[@]} flow(s))"
   fi
   NEXT=()
 
@@ -137,18 +173,22 @@ for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
 
   if [[ "${#NEXT[@]}" -eq 0 ]]; then
     PENDING=()
-    echo "All Maestro flows passed after attempt $attempt/$ATTEMPTS."
+    echo "All Maestro $SUITE_NAME flows passed after attempt $attempt/$ATTEMPTS."
     exit 0
   fi
   PENDING=("${NEXT[@]}")
 done
 
 echo "::group::Maestro final failures"
-echo "Final failed Maestro flow(s): ${#PENDING[@]}"
+echo "Final failed Maestro $SUITE_NAME flow(s): ${#PENDING[@]}"
 for flow in "${PENDING[@]}"; do
   echo "- $flow"
 done
 echo "Retry logs: $RUN_DIR"
 echo "::endgroup::"
+
+for flow in "${PENDING[@]}"; do
+  print_final_failure_log "$flow"
+done
 
 exit 1

--- a/examples/v0.81.1/scripts/maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/maestro-retry-flows.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: maestro-retry-flows.sh --platform <android|ios> --flow-dir <dir> [options] -- <flow.yaml>...
+
+Options:
+  --attempts <n>        Total attempts per flow. Default: 3.
+  --maestro <path>      Maestro executable. Default: maestro.
+  --maestro-arg <arg>   Extra Maestro arg. Can be repeated.
+  --env <key=value>     Extra Maestro env var. Can be repeated.
+USAGE
+}
+
+PLATFORM=""
+FLOW_DIR=""
+ATTEMPTS="${MAESTRO_RETRY_ATTEMPTS:-3}"
+MAESTRO_BIN="${MAESTRO:-maestro}"
+MAESTRO_ARGS=()
+MAESTRO_ENV_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)
+      PLATFORM="$2"
+      shift 2
+      ;;
+    --flow-dir)
+      FLOW_DIR="$2"
+      shift 2
+      ;;
+    --attempts)
+      ATTEMPTS="$2"
+      shift 2
+      ;;
+    --maestro)
+      MAESTRO_BIN="$2"
+      shift 2
+      ;;
+    --maestro-arg)
+      MAESTRO_ARGS+=("$2")
+      shift 2
+      ;;
+    --env)
+      MAESTRO_ENV_ARGS+=("-e" "$2")
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$PLATFORM" || -z "$FLOW_DIR" ]]; then
+  usage
+  exit 2
+fi
+if ! [[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--attempts must be a positive integer." >&2
+  exit 2
+fi
+
+PENDING=("$@")
+if [[ "${#PENDING[@]}" -eq 0 ]]; then
+  echo "No Maestro flows to run."
+  exit 0
+fi
+
+RUN_DIR="${MAESTRO_RETRY_RUN_DIR:-$HOME/.maestro/tests/retry-$(date +%Y-%m-%d_%H%M%S)}"
+mkdir -p "$RUN_DIR"
+
+flow_log_path() {
+  local attempt="$1"
+  local flow="$2"
+  local name
+  name="$(basename "$flow" .yaml)"
+  printf '%s/attempt-%s-%s.log' "$RUN_DIR" "$attempt" "$name"
+}
+
+run_flow() {
+  local attempt="$1"
+  local flow="$2"
+  local path="$FLOW_DIR/$flow"
+  local log_path
+  log_path="$(flow_log_path "$attempt" "$flow")"
+
+  if [[ ! -f "$path" ]]; then
+    echo "Missing Maestro flow: $path" | tee "$log_path" >&2
+    return 1
+  fi
+
+  echo "::group::Maestro attempt $attempt/$ATTEMPTS: $flow"
+  set +e
+  CMD=("$MAESTRO_BIN" test --platform "$PLATFORM")
+  if [[ "${#MAESTRO_ARGS[@]}" -gt 0 ]]; then
+    CMD+=("${MAESTRO_ARGS[@]}")
+  fi
+  if [[ "${#MAESTRO_ENV_ARGS[@]}" -gt 0 ]]; then
+    CMD+=("${MAESTRO_ENV_ARGS[@]}")
+  fi
+  CMD+=("$path")
+  "${CMD[@]}" 2>&1 | tee "$log_path"
+  local status="${PIPESTATUS[0]}"
+  set -e
+  echo "::endgroup::"
+
+  return "$status"
+}
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+  if [[ "$attempt" -eq 1 ]]; then
+    echo "Maestro attempt $attempt/$ATTEMPTS: initial full sweep (${#PENDING[@]} flow(s))"
+  else
+    echo "Maestro attempt $attempt/$ATTEMPTS: retry failed flows only (${#PENDING[@]} flow(s))"
+  fi
+  NEXT=()
+
+  for flow in "${PENDING[@]}"; do
+    if run_flow "$attempt" "$flow"; then
+      echo "PASS: $flow"
+    else
+      echo "FAIL: $flow"
+      NEXT+=("$flow")
+    fi
+  done
+
+  if [[ "${#NEXT[@]}" -eq 0 ]]; then
+    PENDING=()
+    echo "All Maestro flows passed after attempt $attempt/$ATTEMPTS."
+    exit 0
+  fi
+  PENDING=("${NEXT[@]}")
+done
+
+echo "::group::Maestro final failures"
+echo "Final failed Maestro flow(s): ${#PENDING[@]}"
+for flow in "${PENDING[@]}"; do
+  echo "- $flow"
+done
+echo "Retry logs: $RUN_DIR"
+echo "::endgroup::"
+
+exit 1

--- a/examples/v0.81.1/scripts/maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/maestro-retry-flows.sh
@@ -22,6 +22,7 @@ ATTEMPTS="${MAESTRO_RETRY_ATTEMPTS:-3}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 SUITE_NAME="suite"
 FAILURE_LOG_LINES="${MAESTRO_RETRY_FAILURE_LOG_LINES:-all}"
+INFRA_RETRIES="${MAESTRO_INFRA_RETRIES:-2}"
 MAESTRO_ARGS=()
 MAESTRO_ENV_ARGS=()
 
@@ -87,6 +88,10 @@ if [[ "$FAILURE_LOG_LINES" != "all" ]] && ! [[ "$FAILURE_LOG_LINES" =~ ^[1-9][0-
   echo "--failure-log-lines must be a positive integer or 'all'." >&2
   exit 2
 fi
+if ! [[ "$INFRA_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "MAESTRO_INFRA_RETRIES must be a non-negative integer." >&2
+  exit 2
+fi
 
 PENDING=("$@")
 if [[ "${#PENDING[@]}" -eq 0 ]]; then
@@ -105,32 +110,76 @@ flow_log_path() {
   printf '%s/attempt-%s-%s.log' "$RUN_DIR" "$attempt" "$name"
 }
 
+is_android_driver_infra_failure() {
+  local log_path="$1"
+  [[ "$PLATFORM" == "android" ]] || return 1
+  grep -Eq \
+    'Maestro Android driver did not start up in time|io\.grpc\.StatusRuntimeException: UNAVAILABLE|Command failed \(tcp:[0-9]+\): closed' \
+    "$log_path"
+}
+
+recover_android_driver() {
+  [[ "$PLATFORM" == "android" ]] || return
+
+  local adb_bin="${ADB:-adb}"
+  local adb_device_args=()
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    adb_device_args=(-s "$ANDROID_SERIAL")
+  fi
+
+  if command -v "$adb_bin" >/dev/null 2>&1; then
+    "$adb_bin" kill-server >/dev/null 2>&1 || true
+    "$adb_bin" start-server >/dev/null 2>&1 || true
+    "$adb_bin" "${adb_device_args[@]}" wait-for-device >/dev/null 2>&1 || true
+    sleep 3
+  fi
+}
+
 run_flow() {
   local attempt="$1"
   local flow="$2"
   local path="$FLOW_DIR/$flow"
   local log_path
   log_path="$(flow_log_path "$attempt" "$flow")"
+  local infra_try status
 
   if [[ ! -f "$path" ]]; then
     echo "Missing Maestro flow: $path" | tee "$log_path" >&2
     return 1
   fi
 
-  echo "::group::Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: $flow"
-  set +e
-  CMD=("$MAESTRO_BIN" test --platform "$PLATFORM")
-  if [[ "${#MAESTRO_ARGS[@]}" -gt 0 ]]; then
-    CMD+=("${MAESTRO_ARGS[@]}")
-  fi
-  if [[ "${#MAESTRO_ENV_ARGS[@]}" -gt 0 ]]; then
-    CMD+=("${MAESTRO_ENV_ARGS[@]}")
-  fi
-  CMD+=("$path")
-  "${CMD[@]}" 2>&1 | tee "$log_path"
-  local status="${PIPESTATUS[0]}"
-  set -e
-  echo "::endgroup::"
+  for ((infra_try = 0; infra_try <= INFRA_RETRIES; infra_try++)); do
+    if [[ "$infra_try" -eq 0 ]]; then
+      echo "::group::Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: $flow"
+    else
+      echo "::group::Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: $flow (driver recovery $infra_try/$INFRA_RETRIES)"
+      recover_android_driver
+    fi
+
+    set +e
+    CMD=("$MAESTRO_BIN" test --platform "$PLATFORM")
+    if [[ "${#MAESTRO_ARGS[@]}" -gt 0 ]]; then
+      CMD+=("${MAESTRO_ARGS[@]}")
+    fi
+    if [[ "${#MAESTRO_ENV_ARGS[@]}" -gt 0 ]]; then
+      CMD+=("${MAESTRO_ENV_ARGS[@]}")
+    fi
+    CMD+=("$path")
+    "${CMD[@]}" 2>&1 | tee "$log_path"
+    status="${PIPESTATUS[0]}"
+    set -e
+    echo "::endgroup::"
+
+    if [[ "$status" -eq 0 ]]; then
+      return 0
+    fi
+    if ! is_android_driver_infra_failure "$log_path"; then
+      return "$status"
+    fi
+    if [[ "$infra_try" -lt "$INFRA_RETRIES" ]]; then
+      echo "Maestro Android driver infra failure detected. Recovering ADB and retrying $flow without consuming a flow attempt."
+    fi
+  done
 
   return "$status"
 }

--- a/examples/v0.81.1/scripts/maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/maestro-retry-flows.sh
@@ -135,6 +135,29 @@ recover_android_driver() {
   fi
 }
 
+dismiss_ios_open_alert() {
+  local attempt="$1"
+  local flow="$2"
+
+  [[ "$PLATFORM" == "ios" ]] || return
+
+  local alert_flow="$FLOW_DIR/dismiss-ios-open-alert.yaml"
+  [[ -f "$alert_flow" ]] || return
+
+  local cleanup_log
+  cleanup_log="$RUN_DIR/ios-open-alert-cleanup-${attempt}-$(basename "$flow" .yaml).log"
+
+  local cleanup_cmd=("$MAESTRO_BIN" test --platform "$PLATFORM")
+  if [[ "${#MAESTRO_ARGS[@]}" -gt 0 ]]; then
+    cleanup_cmd+=("${MAESTRO_ARGS[@]}")
+  fi
+  cleanup_cmd+=("$alert_flow")
+
+  if ! "${cleanup_cmd[@]}" >"$cleanup_log" 2>&1; then
+    echo "iOS open-alert cleanup failed before $flow. Continuing; log: $cleanup_log"
+  fi
+}
+
 run_flow() {
   local attempt="$1"
   local flow="$2"
@@ -155,6 +178,8 @@ run_flow() {
       echo "::group::Maestro $SUITE_NAME attempt $attempt/$ATTEMPTS: $flow (driver recovery $infra_try/$INFRA_RETRIES)"
       recover_android_driver
     fi
+
+    dismiss_ios_open_alert "$attempt" "$flow"
 
     set +e
     CMD=("$MAESTRO_BIN" test --platform "$PLATFORM")

--- a/examples/v0.81.1/scripts/maestro-suite-flows.mjs
+++ b/examples/v0.81.1/scripts/maestro-suite-flows.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const [suitePath, platformArg] = process.argv.slice(2);
+
+if (!suitePath || !platformArg) {
+  console.error('Usage: maestro-suite-flows.mjs <suite.yaml> <android|ios>');
+  process.exit(2);
+}
+
+const targetPlatform = platformArg.toLowerCase();
+const lines = readFileSync(suitePath, 'utf8').split(/\r?\n/);
+
+function parseEnvGuard(expression) {
+  const trimmed = expression.trim();
+  if (trimmed === 'true') {
+    return true;
+  }
+  if (trimmed === 'false') {
+    return false;
+  }
+
+  const match = trimmed.match(/^\$\{\s*([A-Z0-9_]+)\s*==\s*['"]([^'"]+)['"]\s*\}$/);
+  if (!match) {
+    throw new Error(`Unsupported Maestro runFlow guard: ${expression}`);
+  }
+
+  const [, name, expected] = match;
+  return (process.env[name] ?? '') === expected;
+}
+
+function shouldInclude(entry) {
+  if (entry.platform && entry.platform.toLowerCase() !== targetPlatform) {
+    return false;
+  }
+  if (entry.trueExpression && !parseEnvGuard(entry.trueExpression)) {
+    return false;
+  }
+  return true;
+}
+
+const entries = [];
+let current = null;
+
+function flush() {
+  if (current?.file) {
+    entries.push(current);
+  }
+  current = null;
+}
+
+for (const line of lines) {
+  const direct = line.match(/^- runFlow:\s*(\S+\.ya?ml)\s*$/);
+  if (direct) {
+    flush();
+    entries.push({ file: direct[1] });
+    continue;
+  }
+
+  if (/^- runFlow:\s*$/.test(line)) {
+    flush();
+    current = {};
+    continue;
+  }
+
+  if (!current) {
+    continue;
+  }
+
+  const file = line.match(/^\s+file:\s*(\S+\.ya?ml)\s*$/);
+  if (file) {
+    current.file = file[1];
+    continue;
+  }
+
+  const platform = line.match(/^\s+platform:\s*(\S+)\s*$/);
+  if (platform) {
+    current.platform = platform[1];
+    continue;
+  }
+
+  const trueExpression = line.match(/^\s+true:\s*(.+?)\s*$/);
+  if (trueExpression) {
+    current.trueExpression = trueExpression[1];
+  }
+}
+
+flush();
+
+for (const entry of entries) {
+  if (shouldInclude(entry)) {
+    console.log(entry.file);
+  }
+}

--- a/examples/v0.81.1/scripts/maestro-suite-flows.mjs
+++ b/examples/v0.81.1/scripts/maestro-suite-flows.mjs
@@ -1,32 +1,34 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
+import { readFileSync } from "node:fs";
 
 const [suitePath, platformArg] = process.argv.slice(2);
 
 if (!suitePath || !platformArg) {
-  console.error('Usage: maestro-suite-flows.mjs <suite.yaml> <android|ios>');
+  console.error("Usage: maestro-suite-flows.mjs <suite.yaml> <android|ios>");
   process.exit(2);
 }
 
 const targetPlatform = platformArg.toLowerCase();
-const lines = readFileSync(suitePath, 'utf8').split(/\r?\n/);
+const lines = readFileSync(suitePath, "utf8").split(/\r?\n/);
 
 function parseEnvGuard(expression) {
   const trimmed = expression.trim();
-  if (trimmed === 'true') {
+  if (trimmed === "true") {
     return true;
   }
-  if (trimmed === 'false') {
+  if (trimmed === "false") {
     return false;
   }
 
-  const match = trimmed.match(/^\$\{\s*([A-Z0-9_]+)\s*==\s*['"]([^'"]+)['"]\s*\}$/);
+  const match = trimmed.match(
+    /^\$\{\s*([A-Z0-9_]+)\s*==\s*['"]([^'"]+)['"]\s*\}$/
+  );
   if (!match) {
     throw new Error(`Unsupported Maestro runFlow guard: ${expression}`);
   }
 
   const [, name, expected] = match;
-  return (process.env[name] ?? '') === expected;
+  return (process.env[name] ?? "") === expected;
 }
 
 function shouldInclude(entry) {

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -50,15 +50,65 @@ if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
   PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="1"
 fi
 
+COMMON_FLOWS=(
+  current-position.yaml
+  watch-position.yaml
+  location-simulation.yaml
+  accuracy-presets.yaml
+  last-known-position.yaml
+  geocoding.yaml
+  location-availability.yaml
+  heading.yaml
+)
+
+ANDROID_FLOWS=(
+  issue-119-android.yaml
+  issue-120-android.yaml
+  issue-121-android.yaml
+  issue-122-android.yaml
+  permission-check.yaml
+  android-request-options.yaml
+  "${COMMON_FLOWS[@]}"
+  issue-67-android-coarse-location.yaml
+  provider-settings.yaml
+  background-e2e.yaml
+  mocked-metadata-android-true.yaml
+  api-errors.yaml
+  compat-api.yaml
+)
+
+if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
+  ANDROID_FLOWS=(
+    "${ANDROID_FLOWS[@]:0:5}"
+    android-provider-selection.yaml
+    "${ANDROID_FLOWS[@]:5}"
+  )
+fi
+
+run_maestro_flows() {
+  local maestro_extra_args=()
+  local arg
+  for arg in "${MAESTRO_DEVICE_ARGS[@]}"; do
+    maestro_extra_args+=(--maestro-arg "$arg")
+  done
+
+  "$SCRIPT_DIR/maestro-retry-flows.sh" \
+    --platform android \
+    --flow-dir "$FLOW_DIR" \
+    --maestro "$MAESTRO_BIN" \
+    "${maestro_extra_args[@]}" \
+    --env "RUN_ANDROID_PROVIDER_SELECTION=$RUN_ANDROID_PROVIDER_SELECTION_VALUE" \
+    --env "PROVIDER_SELECTION_PHYSICAL_DEVICE=$PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE" \
+    -- "$@"
+}
+
 "$ADB_BIN" "${ADB_DEVICE_ARGS[@]}" reverse tcp:8081 tcp:8081 >/dev/null
+status=0
+
 set_location_enabled true
-"$MAESTRO_BIN" test --platform android \
-  "${MAESTRO_DEVICE_ARGS[@]}" \
-  -e RUN_ANDROID_PROVIDER_SELECTION="$RUN_ANDROID_PROVIDER_SELECTION_VALUE" \
-  -e PROVIDER_SELECTION_PHYSICAL_DEVICE="$PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE" \
-  "$FLOW_DIR/all-tests.yaml"
+run_maestro_flows "${ANDROID_FLOWS[@]}" || status=1
 
 set_location_enabled false
-"$MAESTRO_BIN" test --platform android \
-  "${MAESTRO_DEVICE_ARGS[@]}" \
-  "$FLOW_DIR/provider-settings-not-ready.yaml"
+run_maestro_flows provider-settings-not-ready.yaml || status=1
+
+exit "$status"

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -7,6 +7,7 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
+NODE_BIN="${NODE:-node}"
 ADB_DEVICE_ARGS=()
 if [[ -n "${ANDROID_SERIAL:-}" ]]; then
   ADB_DEVICE_ARGS=(-s "$ANDROID_SERIAL")
@@ -50,40 +51,10 @@ if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
   PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="1"
 fi
 
-COMMON_FLOWS=(
-  current-position.yaml
-  watch-position.yaml
-  location-simulation.yaml
-  accuracy-presets.yaml
-  last-known-position.yaml
-  geocoding.yaml
-  location-availability.yaml
-  heading.yaml
-)
-
-ANDROID_FLOWS=(
-  issue-119-android.yaml
-  issue-120-android.yaml
-  issue-121-android.yaml
-  issue-122-android.yaml
-  permission-check.yaml
-  android-request-options.yaml
-  "${COMMON_FLOWS[@]}"
-  issue-67-android-coarse-location.yaml
-  provider-settings.yaml
-  background-e2e.yaml
-  mocked-metadata-android-true.yaml
-  api-errors.yaml
-  compat-api.yaml
-)
-
-if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
-  ANDROID_FLOWS=(
-    "${ANDROID_FLOWS[@]:0:5}"
-    android-provider-selection.yaml
-    "${ANDROID_FLOWS[@]:5}"
-  )
-fi
+ANDROID_FLOWS=()
+while IFS= read -r flow; do
+  ANDROID_FLOWS+=("$flow")
+done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" android)
 
 run_maestro_flows() {
   local maestro_extra_args=()

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -57,6 +57,9 @@ while IFS= read -r flow; do
 done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" android)
 
 run_maestro_flows() {
+  local suite_name="$1"
+  shift
+
   local maestro_extra_args=()
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
     maestro_extra_args+=(--maestro-arg --udid --maestro-arg "$ANDROID_SERIAL")
@@ -66,6 +69,7 @@ run_maestro_flows() {
     --platform android \
     --flow-dir "$FLOW_DIR" \
     --maestro "$MAESTRO_BIN" \
+    --suite-name "$suite_name" \
     "${maestro_extra_args[@]}" \
     --env "RUN_ANDROID_PROVIDER_SELECTION=$RUN_ANDROID_PROVIDER_SELECTION_VALUE" \
     --env "PROVIDER_SELECTION_PHYSICAL_DEVICE=$PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE" \
@@ -76,9 +80,9 @@ adb_cmd reverse tcp:8081 tcp:8081 >/dev/null
 status=0
 
 set_location_enabled true
-run_maestro_flows "${ANDROID_FLOWS[@]}" || status=1
+run_maestro_flows "android location-enabled" "${ANDROID_FLOWS[@]}" || status=1
 
 set_location_enabled false
-run_maestro_flows provider-settings-not-ready.yaml || status=1
+run_maestro_flows "android location-disabled" provider-settings-not-ready.yaml || status=1
 
 exit "$status"

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -8,6 +8,7 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
+ANR_DISMISSER_PID=""
 
 adb_cmd() {
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
@@ -21,7 +22,61 @@ set_location_enabled() {
   adb_cmd shell cmd location set-location-enabled "$1" >/dev/null
 }
 
+dismiss_android_anr_once() {
+  local dump coords
+  dump="$(adb_cmd exec-out uiautomator dump /dev/tty 2>/dev/null || true)"
+  coords="$(
+    printf '%s' "$dump" | "$NODE_BIN" -e '
+      let input = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => {
+        input += chunk;
+      });
+      process.stdin.on("end", () => {
+        const match = input.match(
+          /text="(?:Wait|대기)"[^>]*bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/
+        );
+        if (!match) {
+          return;
+        }
+
+        const [, left, top, right, bottom] = match.map(Number);
+        console.log(
+          `${Math.round((left + right) / 2)} ${Math.round((top + bottom) / 2)}`
+        );
+      });
+    '
+  )"
+
+  if [[ -z "$coords" ]]; then
+    return 1
+  fi
+
+  read -r x y <<<"$coords"
+  adb_cmd shell input tap "$x" "$y" >/dev/null
+  echo "Dismissed Android ANR dialog via Wait."
+}
+
+start_android_anr_dismissal_loop() {
+  (
+    while true; do
+      dismiss_android_anr_once || true
+      sleep 1
+    done
+  ) &
+  ANR_DISMISSER_PID="$!"
+}
+
+stop_android_anr_dismissal_loop() {
+  if [[ -n "$ANR_DISMISSER_PID" ]]; then
+    kill "$ANR_DISMISSER_PID" >/dev/null 2>&1 || true
+    wait "$ANR_DISMISSER_PID" 2>/dev/null || true
+    ANR_DISMISSER_PID=""
+  fi
+}
+
 restore_location() {
+  stop_android_anr_dismissal_loop
   set_location_enabled true || true
   adb_cmd reverse --remove tcp:8081 >/dev/null 2>&1 || true
 }
@@ -77,6 +132,7 @@ run_maestro_flows() {
 }
 
 adb_cmd reverse tcp:8081 tcp:8081 >/dev/null
+start_android_anr_dismissal_loop
 status=0
 
 set_location_enabled true

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -9,6 +9,7 @@ ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
 ANR_DISMISSER_PID=""
+DISABLED_LAUNCHER_PACKAGE=""
 
 adb_cmd() {
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
@@ -75,8 +76,40 @@ stop_android_anr_dismissal_loop() {
   fi
 }
 
+disable_emulator_launcher() {
+  if ! is_emulator; then
+    return
+  fi
+
+  local launcher_package
+  launcher_package="$(
+    adb_cmd shell cmd package resolve-activity --brief \
+      -a android.intent.action.MAIN \
+      -c android.intent.category.HOME 2>/dev/null |
+      tr -d '\r' |
+      awk -F/ 'NF > 1 { package = $1 } END { print package }'
+  )"
+
+  if [[ -z "$launcher_package" || "$launcher_package" == "android" ]]; then
+    return
+  fi
+
+  if adb_cmd shell pm disable-user --user 0 "$launcher_package" >/dev/null 2>&1; then
+    DISABLED_LAUNCHER_PACKAGE="$launcher_package"
+    echo "Disabled emulator launcher package to avoid launcher ANR dialogs: $launcher_package"
+  fi
+}
+
+restore_emulator_launcher() {
+  if [[ -n "$DISABLED_LAUNCHER_PACKAGE" ]]; then
+    adb_cmd shell pm enable "$DISABLED_LAUNCHER_PACKAGE" >/dev/null 2>&1 || true
+    DISABLED_LAUNCHER_PACKAGE=""
+  fi
+}
+
 restore_location() {
   stop_android_anr_dismissal_loop
+  restore_emulator_launcher
   set_location_enabled true || true
   adb_cmd reverse --remove tcp:8081 >/dev/null 2>&1 || true
 }
@@ -132,6 +165,7 @@ run_maestro_flows() {
 }
 
 adb_cmd reverse tcp:8081 tcp:8081 >/dev/null
+disable_emulator_launcher
 start_android_anr_dismissal_loop
 status=0
 

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -8,7 +8,6 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
-ANR_DISMISSER_PID=""
 DISABLED_LAUNCHER_PACKAGE=""
 
 adb_cmd() {
@@ -21,59 +20,6 @@ adb_cmd() {
 
 set_location_enabled() {
   adb_cmd shell cmd location set-location-enabled "$1" >/dev/null
-}
-
-dismiss_android_anr_once() {
-  local dump coords
-  dump="$(adb_cmd exec-out uiautomator dump /dev/tty 2>/dev/null || true)"
-  coords="$(
-    printf '%s' "$dump" | "$NODE_BIN" -e '
-      let input = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => {
-        input += chunk;
-      });
-      process.stdin.on("end", () => {
-        const match = input.match(
-          /text="(?:Wait|대기)"[^>]*bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/
-        );
-        if (!match) {
-          return;
-        }
-
-        const [, left, top, right, bottom] = match.map(Number);
-        console.log(
-          `${Math.round((left + right) / 2)} ${Math.round((top + bottom) / 2)}`
-        );
-      });
-    '
-  )"
-
-  if [[ -z "$coords" ]]; then
-    return 1
-  fi
-
-  read -r x y <<<"$coords"
-  adb_cmd shell input tap "$x" "$y" >/dev/null
-  echo "Dismissed Android ANR dialog via Wait."
-}
-
-start_android_anr_dismissal_loop() {
-  (
-    while true; do
-      dismiss_android_anr_once || true
-      sleep 1
-    done
-  ) &
-  ANR_DISMISSER_PID="$!"
-}
-
-stop_android_anr_dismissal_loop() {
-  if [[ -n "$ANR_DISMISSER_PID" ]]; then
-    kill "$ANR_DISMISSER_PID" >/dev/null 2>&1 || true
-    wait "$ANR_DISMISSER_PID" 2>/dev/null || true
-    ANR_DISMISSER_PID=""
-  fi
 }
 
 disable_emulator_launcher() {
@@ -108,7 +54,6 @@ restore_emulator_launcher() {
 }
 
 restore_location() {
-  stop_android_anr_dismissal_loop
   restore_emulator_launcher
   set_location_enabled true || true
   adb_cmd reverse --remove tcp:8081 >/dev/null 2>&1 || true
@@ -166,7 +111,6 @@ run_maestro_flows() {
 
 adb_cmd reverse tcp:8081 tcp:8081 >/dev/null
 disable_emulator_launcher
-start_android_anr_dismissal_loop
 status=0
 
 set_location_enabled true

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -7,4 +7,35 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 MAESTRO_BIN="${MAESTRO:-maestro}"
 
-"$MAESTRO_BIN" test --platform ios "$FLOW_DIR/all-tests.yaml"
+COMMON_FLOWS=(
+  permission-check.yaml
+  current-position.yaml
+  watch-position.yaml
+  location-simulation.yaml
+  accuracy-presets.yaml
+  last-known-position.yaml
+  geocoding.yaml
+  location-availability.yaml
+  heading.yaml
+)
+
+IOS_FLOWS=(
+  issue-119-ios.yaml
+  issue-120-ios.yaml
+  issue-121-ios.yaml
+  issue-122-ios.yaml
+  "${COMMON_FLOWS[@]}"
+  ios-location-tuning.yaml
+  ios-accuracy-authorization.yaml
+  ios-release-options-bridge.yaml
+  background-e2e.yaml
+  mocked-metadata-ios-true.yaml
+  api-errors.yaml
+  compat-api.yaml
+)
+
+"$SCRIPT_DIR/maestro-retry-flows.sh" \
+  --platform ios \
+  --flow-dir "$FLOW_DIR" \
+  --maestro "$MAESTRO_BIN" \
+  -- "${IOS_FLOWS[@]}"

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -6,33 +6,12 @@ EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 MAESTRO_BIN="${MAESTRO:-maestro}"
+NODE_BIN="${NODE:-node}"
 
-COMMON_FLOWS=(
-  permission-check.yaml
-  current-position.yaml
-  watch-position.yaml
-  location-simulation.yaml
-  accuracy-presets.yaml
-  last-known-position.yaml
-  geocoding.yaml
-  location-availability.yaml
-  heading.yaml
-)
-
-IOS_FLOWS=(
-  issue-119-ios.yaml
-  issue-120-ios.yaml
-  issue-121-ios.yaml
-  issue-122-ios.yaml
-  "${COMMON_FLOWS[@]}"
-  ios-location-tuning.yaml
-  ios-accuracy-authorization.yaml
-  ios-release-options-bridge.yaml
-  background-e2e.yaml
-  mocked-metadata-ios-true.yaml
-  api-errors.yaml
-  compat-api.yaml
-)
+IOS_FLOWS=()
+while IFS= read -r flow; do
+  IOS_FLOWS+=("$flow")
+done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" ios)
 
 "$SCRIPT_DIR/maestro-retry-flows.sh" \
   --platform ios \

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -17,4 +17,5 @@ done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.
   --platform ios \
   --flow-dir "$FLOW_DIR" \
   --maestro "$MAESTRO_BIN" \
+  --suite-name "ios" \
   -- "${IOS_FLOWS[@]}"

--- a/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
+++ b/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
@@ -17,6 +17,7 @@ import {
   ScenarioScreen,
   ScenarioSection,
   assertFixtureCoordinates,
+  captureLocationError,
   createScenarioResults,
   getDisplayErrorMessage,
   runWithNativeGeolocation,
@@ -37,8 +38,9 @@ type PositiveScenarioMessage = {
   message: string;
 };
 
-const FIXTURE_RETRY_TIMEOUT_MS = 25000;
+const FIXTURE_RETRY_TIMEOUT_MS = Platform.OS === "ios" ? 90000 : 25000;
 const FIXTURE_RETRY_INTERVAL_MS = 1000;
+const IOS_REQUEST_TIMEOUT_MS = 30000;
 
 const initialResults = createScenarioResults([
   "positive",
@@ -52,6 +54,14 @@ const isFixtureMismatchError = (
   return error instanceof Error && error.name === "FixtureMismatchError";
 };
 
+const isRetryableLocationError = (error: unknown) => {
+  if (isFixtureMismatchError(error)) {
+    return true;
+  }
+
+  return captureLocationError(error).code === LocationErrorCode.TIMEOUT;
+};
+
 const sleep = (durationMs: number) =>
   new Promise<void>((resolve) => {
     setTimeout(() => resolve(), durationMs);
@@ -61,33 +71,33 @@ const runScenarioWithSettledFixture = async (
   scenario: AccuracyScenario
 ): Promise<string> => {
   const deadline = Date.now() + FIXTURE_RETRY_TIMEOUT_MS;
-  let lastFixtureMismatch: FixtureMismatchError | null = null;
+  let lastRetryableError: Error | null = null;
   let attempt = 0;
 
   while (Date.now() <= deadline) {
     attempt += 1;
-    const position = await runWithNativeGeolocation(() =>
-      getCurrentPosition(scenario.options)
-    );
 
     try {
+      const position = await runWithNativeGeolocation(() =>
+        getCurrentPosition(scenario.options)
+      );
+
       return scenario.assertPosition
         ? scenario.assertPosition(position)
         : assertFixtureCoordinates(position);
     } catch (error) {
-      if (!isFixtureMismatchError(error)) {
+      if (!isRetryableLocationError(error)) {
         throw error;
       }
 
-      lastFixtureMismatch = new FixtureMismatchError(
-        `${error.message} Attempt ${attempt}.`
-      );
+      const message = getDisplayErrorMessage(error);
+      lastRetryableError = new Error(`${message} Attempt ${attempt}.`);
       await sleep(FIXTURE_RETRY_INTERVAL_MS);
     }
   }
 
   throw (
-    lastFixtureMismatch ??
+    lastRetryableError ??
     new FixtureMismatchError("Injected fixture location was not observed.")
   );
 };
@@ -143,8 +153,10 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
         accuracy: {
           ios: "bestForNavigation"
         },
+        activityType: "otherNavigation",
         maximumAge: 0,
-        timeout: 15000
+        pausesLocationUpdatesAutomatically: false,
+        timeout: IOS_REQUEST_TIMEOUT_MS
       }
     },
     {
@@ -154,8 +166,10 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
         accuracy: {
           ios: "nearestTenMeters"
         },
+        activityType: "otherNavigation",
         maximumAge: 0,
-        timeout: 15000
+        pausesLocationUpdatesAutomatically: false,
+        timeout: IOS_REQUEST_TIMEOUT_MS
       }
     },
     {
@@ -166,8 +180,10 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
         accuracy: {
           ios: "reduced"
         },
+        activityType: "otherNavigation",
         maximumAge: 0,
-        timeout: 15000
+        pausesLocationUpdatesAutomatically: false,
+        timeout: IOS_REQUEST_TIMEOUT_MS
       }
     }
   ];

--- a/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
@@ -239,9 +239,21 @@ export default function ProviderSettingsScreen() {
           <KeyValueBlock
             testID="provider-settings-error"
             rows={[
-              { label: "Code", value: error.code },
-              { label: "Name", value: error.name },
-              { label: "Message", value: error.message }
+              {
+                label: "Code",
+                value: error.code,
+                testID: "provider-settings-error-code"
+              },
+              {
+                label: "Name",
+                value: error.name,
+                testID: "provider-settings-error-name"
+              },
+              {
+                label: "Message",
+                value: error.message,
+                testID: "provider-settings-error-message"
+              }
             ]}
           />
         </ScenarioSection>


### PR DESCRIPTION
## Summary

- Add an opt-in E2E workflow that runs when a pull request title contains `[E2E]` or when manually dispatched.
- Run Android and iOS E2E jobs against installed release app artifacts, without starting Metro during Maestro execution.
- Cache release app artifacts by native app fingerprint and reuse them when native inputs have not changed.
- Retry Maestro by running the full suite first, then retrying only failed flows for two more attempts before reporting final failures.
- Stabilize CI devices by handling Android ANR/driver recovery and dismissing stale iOS deep-link confirmation alerts.

## Notes

- The workflow does not post PR comments. Results stay in GitHub Checks, so fork PRs do not need write permissions.
- Final failed Maestro flow logs are printed directly in CI stdout, and Maestro artifacts are uploaded for deeper inspection.

## Validation

- Latest head: `70af8a6`
- `CI`: passed
- `Changeset CI`: passed
- `E2E`: passed
- Android E2E: passed (`2026-06-28T13:04:24Z` -> `2026-06-28T13:26:27Z`)
- iOS E2E: passed (`2026-06-28T13:04:24Z` -> `2026-06-28T14:04:50Z`)
- E2E run: https://github.com/jingjing2222/react-native-nitro-geolocation/actions/runs/28323153282
