### PR TITLE
feat: add prebuilt native binary release flow

### DIFF
--- a/.changeset/prebuilt-native-assets.md
+++ b/.changeset/prebuilt-native-assets.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Publish Android AAR and iOS XCFramework prebuilt assets to GitHub Releases and use matching prebuilts during native installs when available.

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1,0 +1,126 @@
+name: Prebuilt Binaries
+
+on:
+  push:
+    tags:
+      - "react-native-nitro-geolocation@*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Package tag to build, for example react-native-nitro-geolocation@1.4.2"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  android:
+    name: Build Android AAR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: ref
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build AAR
+        run: scripts/build-prebuilt-android.sh build/prebuilt
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-prebuilt
+          path: |
+            build/prebuilt/*-android.aar
+            build/prebuilt/*-android.aar.sha256
+          if-no-files-found: error
+
+  ios:
+    name: Build iOS XCFramework
+    runs-on: macos-latest
+    steps:
+      - name: Resolve tag
+        id: ref
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install JS dependencies
+        run: yarn install
+
+      - name: Install Ruby dependencies
+        working-directory: examples/v0.81.1
+        run: bundle install
+
+      - name: Build XCFramework
+        run: scripts/build-prebuilt-ios.sh build/prebuilt
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-prebuilt
+          path: |
+            build/prebuilt/*-ios.xcframework.zip
+            build/prebuilt/*-ios.xcframework.zip.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Upload release assets
+    runs-on: ubuntu-latest
+    needs:
+      - android
+      - ios
+    steps:
+      - name: Resolve tag
+        id: ref
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build/prebuilt
+          merge-multiple: true
+
+      - name: Create release if missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ref.outputs.tag }}
+        run: |
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --title "$TAG" --generate-notes
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ref.outputs.tag }}
+        run: gh release upload "$TAG" build/prebuilt/* --clobber

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ Rebuild your native app:
 cd ios && pod install
 ```
 
+Released npm builds try to use the matching GitHub Release prebuilts first:
+Android downloads the release AAR and reuses its native `.so` files, while iOS
+downloads the release XCFramework. If the prebuilt asset is unavailable, the
+native source build is used automatically. Android prebuilts are used only when
+the app's React Native and Nitro Modules major/minor versions match the release
+asset build. To force source builds, set `NITRO_GEOLOCATION_USE_PREBUILT=0`.
+
 ---
 
 ### 2. iOS Setup

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -21,6 +21,17 @@ After installation, rebuild your native app to ensure the new module is linked.
 cd ios && pod install
 ```
 
+Released npm builds try to use the matching GitHub Release prebuilts first:
+Android downloads the release AAR and reuses its native `.so` files, while iOS
+downloads the release XCFramework. If the prebuilt asset is unavailable, the
+native source build is used automatically. Android prebuilts are used only when
+the app's React Native and Nitro Modules major/minor versions match the release
+asset build. To force source builds, set:
+
+```bash
+NITRO_GEOLOCATION_USE_PREBUILT=0
+```
+
 This package requires native Nitro bindings. Expo Go is not supported. For Expo
 apps, use prebuild, a development build, or another custom native build flow;
 see the [Expo development build guide](/guide/expo-development-build).

--- a/packages/react-native-nitro-geolocation/NitroGeolocation.podspec
+++ b/packages/react-native-nitro-geolocation/NitroGeolocation.podspec
@@ -1,6 +1,9 @@
 require "json"
+require_relative "scripts/prebuilt_ios"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+use_prebuilt = NitroGeolocationPrebuiltIOS.use_prebuilt?(__dir__)
+prebuilt_available = use_prebuilt && NitroGeolocationPrebuiltIOS.ensure_framework(__dir__, package)
 
 Pod::Spec.new do |s|
   s.name         = "NitroGeolocation"
@@ -13,18 +16,24 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => ".git", :tag => "#{s.version}" }
 
-
-  s.source_files = [
-    "ios/**/*.{swift}",
-    "ios/**/*.{m,mm}",
-    "cpp/**/*.{hpp,cpp}",
-  ]
-
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
 
-  load 'nitrogen/generated/ios/NitroGeolocation+autolinking.rb'
-  add_nitrogen_files(s)
+  if prebuilt_available
+    s.vendored_frameworks = "prebuilds/ios/NitroGeolocation.xcframework"
+    s.preserve_paths = "prebuilds/ios/NitroGeolocation.xcframework"
+    s.dependency "NitroModules"
+  else
+    s.source_files = [
+      "ios/**/*.{swift}",
+      "ios/**/*.{m,mm}",
+      "cpp/**/*.{hpp,cpp}",
+    ]
 
-  install_modules_dependencies(s)
+    load 'nitrogen/generated/ios/NitroGeolocation+autolinking.rb'
+    add_nitrogen_files(s)
+
+    install_modules_dependencies(s)
+  end
+
 end

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -142,6 +142,13 @@ Rebuild your native app:
 cd ios && pod install
 ```
 
+Released npm builds try to use the matching GitHub Release prebuilts first:
+Android downloads the release AAR and reuses its native `.so` files, while iOS
+downloads the release XCFramework. If the prebuilt asset is unavailable, the
+native source build is used automatically. Android prebuilts are used only when
+the app's React Native and Nitro Modules major/minor versions match the release
+asset build. To force source builds, set `NITRO_GEOLOCATION_USE_PREBUILT=0`.
+
 ---
 
 ### 2. iOS Setup

--- a/packages/react-native-nitro-geolocation/android/build.gradle
+++ b/packages/react-native-nitro-geolocation/android/build.gradle
@@ -34,6 +34,157 @@ def getExtOrDefaultValue(name, defaultValue) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["NitroGeolocation_" + name] ?: defaultValue)
 }
 
+def getNitroGeolocationBooleanProperty(name, defaultValue) {
+  def envName = "NITRO_GEOLOCATION_${name.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+  def propertyName = "NitroGeolocation_${name}"
+  def value = rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties[propertyName] ?: System.getenv(envName))
+  return value == null ? defaultValue : !["0", "false", "no", "off"].contains(value.toString().toLowerCase())
+}
+
+def getNitroGeolocationStringProperty(name, defaultValue) {
+  def envName = "NITRO_GEOLOCATION_${name.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+  def propertyName = "NitroGeolocation_${name}"
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties[propertyName] ?: System.getenv(envName) ?: defaultValue)
+}
+
+def parseMajorMinor(version) {
+  def matcher = (version ?: "") =~ /(\d+)\.(\d+)/
+  return matcher.find() ? "${matcher.group(1)}.${matcher.group(2)}" : null
+}
+
+def readPackageJsonVersion(packageJsonFile) {
+  if (!packageJsonFile.exists()) {
+    return null
+  }
+
+  try {
+    return new groovy.json.JsonSlurper().parse(packageJsonFile).version
+  } catch (Throwable ignored) {
+    return null
+  }
+}
+
+def readNodeModuleVersion(moduleName) {
+  def candidates = [
+    rootProject.file("../node_modules/${moduleName}/package.json"),
+    file("../node_modules/${moduleName}/package.json"),
+    new File(file("..").canonicalFile, "node_modules/${moduleName}/package.json")
+  ]
+
+  for (def candidate : candidates) {
+    def version = readPackageJsonVersion(candidate)
+    if (version != null) {
+      return version
+    }
+  }
+
+  return null
+}
+
+def isNitroGeolocationSourceCheckout() {
+  def packageDir = file("..").canonicalFile
+  def workspacePackageJson = new File(packageDir, "../../package.json")
+  if (!workspacePackageJson.exists()) {
+    return false
+  }
+
+  try {
+    def workspacePackage = new groovy.json.JsonSlurper().parse(workspacePackageJson)
+    return workspacePackage.name == "react-native-nitro-geolocation-monorepo"
+  } catch (Throwable ignored) {
+    return false
+  }
+}
+
+def packageJson = new groovy.json.JsonSlurper().parse(file("../package.json"))
+def packageVersion = packageJson.version
+def prebuiltTag = "react-native-nitro-geolocation@${packageVersion}"
+def encodedPrebuiltTag = java.net.URLEncoder.encode(prebuiltTag, "UTF-8").replace("+", "%20")
+def prebuiltAssetName = "react-native-nitro-geolocation-${packageVersion}-android.aar"
+def prebuiltUrlBase = getNitroGeolocationStringProperty(
+  "prebuiltUrlBase",
+  "https://github.com/jingjing2222/react-native-nitro-geolocation/releases/download/${encodedPrebuiltTag}"
+)
+def prebuiltUrl = "${prebuiltUrlBase}/${prebuiltAssetName}"
+def prebuiltCacheDir = new File(gradle.gradleUserHomeDir, "caches/react-native-nitro-geolocation/${packageVersion}")
+def prebuiltAarFile = new File(prebuiltCacheDir, prebuiltAssetName)
+def prebuiltJniDir = file("${buildDir}/generated/prebuilt-jni")
+
+def bundledReactNativeVersion = packageJson.devDependencies["react-native"]
+def bundledNitroModulesVersion = packageJson.devDependencies["react-native-nitro-modules"]
+def consumerReactNativeVersion = readNodeModuleVersion("react-native")
+def consumerNitroModulesVersion = readNodeModuleVersion("react-native-nitro-modules")
+def isAndroidPrebuiltAbiCompatible = {
+  return parseMajorMinor(consumerReactNativeVersion) == parseMajorMinor(bundledReactNativeVersion) &&
+    parseMajorMinor(consumerNitroModulesVersion) == parseMajorMinor(bundledNitroModulesVersion)
+}
+
+def downloadNitroGeolocationPrebuiltIfAvailable = {
+  try {
+    if (!prebuiltAarFile.exists()) {
+      prebuiltCacheDir.mkdirs()
+      logger.lifecycle("[NitroGeolocation] Downloading Android prebuilt AAR: ${prebuiltUrl}")
+      new URL(prebuiltUrl).withInputStream { input ->
+        prebuiltAarFile.withOutputStream { output -> output << input }
+      }
+    }
+
+    logger.lifecycle("[NitroGeolocation] Using Android prebuilt native libraries from ${prebuiltAarFile}")
+    return true
+  } catch (Throwable error) {
+    if (prebuiltAarFile.exists()) {
+      prebuiltAarFile.delete()
+    }
+    logger.warn("[NitroGeolocation] Android prebuilt unavailable (${error.message}). Falling back to source build.")
+    return false
+  }
+}
+
+def extractNitroGeolocationPrebuilt = {
+  try {
+    delete(prebuiltJniDir)
+    copy {
+      from(zipTree(prebuiltAarFile))
+      include("jni/**/*.so")
+      into(prebuiltJniDir)
+      eachFile { details ->
+        details.relativePath = new RelativePath(true, details.relativePath.segments.drop(1) as String[])
+      }
+      includeEmptyDirs = false
+    }
+
+    if (fileTree(prebuiltJniDir).matching { include("**/libnitrogeolocation.so") }.empty) {
+      throw new GradleException("AAR did not contain libnitrogeolocation.so")
+    }
+  } catch (Throwable error) {
+    if (prebuiltAarFile.exists()) {
+      prebuiltAarFile.delete()
+    }
+    throw new GradleException("Failed to prepare Android prebuilt native libraries: ${error.message}", error)
+  }
+}
+
+def shouldAttemptPrebuilt = getNitroGeolocationBooleanProperty("usePrebuilt", !isNitroGeolocationSourceCheckout())
+if (shouldAttemptPrebuilt && !isAndroidPrebuiltAbiCompatible()) {
+  logger.lifecycle(
+    "[NitroGeolocation] Android prebuilt disabled for React Native ${consumerReactNativeVersion ?: 'unknown'} " +
+      "and NitroModules ${consumerNitroModulesVersion ?: 'unknown'}; " +
+      "assets target React Native ${bundledReactNativeVersion} and NitroModules ${bundledNitroModulesVersion}."
+  )
+}
+def usePrebuilt = shouldAttemptPrebuilt && isAndroidPrebuiltAbiCompatible() && downloadNitroGeolocationPrebuiltIfAvailable()
+
+def preparePrebuiltTaskProvider = null
+if (usePrebuilt) {
+  preparePrebuiltTaskProvider = tasks.register("prepareNitroGeolocationPrebuilt") {
+    outputs.dir(prebuiltJniDir)
+
+    doLast {
+      extractNitroGeolocationPrebuilt()
+    }
+  }
+}
+
 android {
   namespace "com.margelo.nitro.nitrogeolocation"
 
@@ -43,27 +194,31 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
 
-    externalNativeBuild {
-      cmake {
-        cppFlags "-frtti -fexceptions -Wall -fstack-protector-all"
-        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
-        abiFilters (*reactNativeArchitectures())
+    if (!usePrebuilt) {
+      externalNativeBuild {
+        cmake {
+          cppFlags "-frtti -fexceptions -Wall -fstack-protector-all"
+          arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+          abiFilters (*reactNativeArchitectures())
 
-        buildTypes {
-          debug {
-            cppFlags "-O1 -g"
-          }
-          release {
-            cppFlags "-O2"
+          buildTypes {
+            debug {
+              cppFlags "-O1 -g"
+            }
+            release {
+              cppFlags "-O2"
+            }
           }
         }
       }
     }
   }
 
-  externalNativeBuild {
-    cmake {
-      path "CMakeLists.txt"
+  if (!usePrebuilt) {
+    externalNativeBuild {
+      cmake {
+        path "CMakeLists.txt"
+      }
     }
   }
 
@@ -114,7 +269,20 @@ android {
         "generated/java",
         "generated/jni"
       ]
+      if (usePrebuilt) {
+        jniLibs.srcDirs += [prebuiltJniDir]
+      }
     }
+  }
+}
+
+if (usePrebuilt) {
+  tasks.matching { task ->
+    task.name == "preBuild" ||
+      task.name.endsWith("PreBuild") ||
+      (task.name.startsWith("merge") && task.name.endsWith("JniLibFolders"))
+  }.configureEach {
+    dependsOn(preparePrebuiltTaskProvider)
   }
 }
 

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -62,10 +62,12 @@
   "files": [
     "src",
     "nitrogen",
+    "scripts/*.rb",
     "android/build.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",
     "android/src/**/*",
+    "prebuilds/**",
     "ios/**/*.h",
     "ios/**/*.m",
     "ios/**/*.mm",

--- a/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
+++ b/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
@@ -1,0 +1,91 @@
+require "fileutils"
+require "json"
+require "open-uri"
+require "uri"
+
+module NitroGeolocationPrebuiltIOS
+  module_function
+
+  FRAMEWORK_NAME = "NitroGeolocation.xcframework"
+
+  def env_name(name)
+    "NITRO_GEOLOCATION_#{name.gsub(/([A-Z])/, '_\1').upcase}"
+  end
+
+  def false_like?(value)
+    ["0", "false", "no", "off"].include?(value.to_s.downcase)
+  end
+
+  def source_checkout?(package_dir)
+    real_package_dir = File.realpath(package_dir)
+    workspace_package_json = File.expand_path("../../package.json", real_package_dir)
+    return false unless File.exist?(workspace_package_json)
+
+    workspace_package = JSON.parse(File.read(workspace_package_json))
+    workspace_package["name"] == "react-native-nitro-geolocation-monorepo"
+  rescue StandardError
+    false
+  end
+
+  def use_prebuilt?(package_dir)
+    value = ENV[env_name("usePrebuilt")]
+    return !false_like?(value) unless value.nil?
+
+    !source_checkout?(package_dir)
+  end
+
+  def string_config(name, default_value)
+    value = ENV[env_name(name)]
+    value.nil? || value.empty? ? default_value : value
+  end
+
+  def ensure_framework(package_dir, package)
+    version = package.fetch("version")
+    tag = "react-native-nitro-geolocation@#{version}"
+    encoded_tag = URI.encode_www_form_component(tag)
+    asset_name = "react-native-nitro-geolocation-#{version}-ios.xcframework.zip"
+    default_url_base = "https://github.com/jingjing2222/react-native-nitro-geolocation/releases/download/#{encoded_tag}"
+    url = "#{string_config('prebuiltUrlBase', default_url_base)}/#{asset_name}"
+
+    destination_dir = File.join(package_dir, "prebuilds", "ios")
+    framework_path = File.join(destination_dir, FRAMEWORK_NAME)
+    marker_path = File.join(destination_dir, ".version")
+    if File.directory?(framework_path) && File.exist?(marker_path) && File.read(marker_path).strip == version
+      return true
+    end
+
+    cache_dir = File.expand_path("~/Library/Caches/react-native-nitro-geolocation/#{version}")
+    zip_path = File.join(cache_dir, asset_name)
+
+    FileUtils.mkdir_p(cache_dir)
+    unless File.exist?(zip_path)
+      Pod::UI.puts "[NitroGeolocation] Downloading iOS prebuilt XCFramework: #{url}"
+      uri = URI.parse(url)
+      if uri.scheme == "file"
+        FileUtils.cp(uri.path, zip_path)
+      else
+        URI.open(url) do |input|
+          File.open(zip_path, "wb") { |output| IO.copy_stream(input, output) }
+        end
+      end
+    end
+
+    FileUtils.rm_rf(destination_dir)
+    FileUtils.mkdir_p(destination_dir)
+    unless system("/usr/bin/ditto", "-x", "-k", zip_path, destination_dir)
+      raise "failed to extract #{asset_name}"
+    end
+
+    unless File.directory?(framework_path)
+      raise "zip did not contain #{FRAMEWORK_NAME}"
+    end
+
+    File.write(marker_path, version)
+    Pod::UI.puts "[NitroGeolocation] Using iOS prebuilt XCFramework from #{framework_path}"
+    true
+  rescue StandardError => error
+    FileUtils.rm_f(zip_path) if defined?(zip_path) && zip_path
+    Pod::UI.warn "[NitroGeolocation] iOS prebuilt unavailable (#{error.message}). Falling back to source build."
+    false
+  end
+end

--- a/scripts/build-prebuilt-android.sh
+++ b/scripts/build-prebuilt-android.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_DIR="$ROOT_DIR/packages/react-native-nitro-geolocation"
+EXAMPLE_ANDROID_DIR="$ROOT_DIR/examples/v0.81.1/android"
+OUT_DIR="${1:-$ROOT_DIR/build/prebuilt}"
+
+VERSION="$(node -p "require('$PACKAGE_DIR/package.json').version")"
+ASSET_NAME="react-native-nitro-geolocation-${VERSION}-android.aar"
+
+mkdir -p "$OUT_DIR"
+
+(
+  cd "$EXAMPLE_ANDROID_DIR"
+  NITRO_GEOLOCATION_USE_PREBUILT=0 ./gradlew \
+    :react-native-nitro-geolocation:assembleRelease \
+    -PNitroGeolocation_usePrebuilt=false \
+    -PreactNativeArchitectures=armeabi-v7a,x86,x86_64,arm64-v8a \
+    --no-daemon \
+    --console=plain
+)
+
+AAR_PATH="$(find "$PACKAGE_DIR/android/build/outputs/aar" -name "*release.aar" -print -quit)"
+if [[ -z "$AAR_PATH" ]]; then
+  echo "release AAR not found under $PACKAGE_DIR/android/build/outputs/aar" >&2
+  exit 1
+fi
+
+cp "$AAR_PATH" "$OUT_DIR/$ASSET_NAME"
+shasum -a 256 "$OUT_DIR/$ASSET_NAME" > "$OUT_DIR/$ASSET_NAME.sha256"
+
+echo "$OUT_DIR/$ASSET_NAME"

--- a/scripts/build-prebuilt-ios.sh
+++ b/scripts/build-prebuilt-ios.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_DIR="$ROOT_DIR/packages/react-native-nitro-geolocation"
+EXAMPLE_DIR="$ROOT_DIR/examples/v0.81.1"
+IOS_DIR="$EXAMPLE_DIR/ios"
+OUT_DIR="${1:-$ROOT_DIR/build/prebuilt}"
+BUILD_DIR="$ROOT_DIR/build/ios-prebuilt"
+
+VERSION="$(node -p "require('$PACKAGE_DIR/package.json').version")"
+ASSET_NAME="react-native-nitro-geolocation-${VERSION}-ios.xcframework.zip"
+WORKSPACE="$IOS_DIR/NitroGeolocationExample.xcworkspace"
+SCHEME="NitroGeolocation"
+
+mkdir -p "$OUT_DIR" "$BUILD_DIR"
+
+(
+  if [[ -f "$EXAMPLE_DIR/Gemfile" ]]; then
+    cd "$EXAMPLE_DIR"
+    USE_FRAMEWORKS=static NITRO_GEOLOCATION_USE_PREBUILT=0 bundle exec pod install --project-directory=ios
+  else
+    cd "$IOS_DIR"
+    USE_FRAMEWORKS=static NITRO_GEOLOCATION_USE_PREBUILT=0 pod install
+  fi
+)
+
+rm -rf "$BUILD_DIR/NitroGeolocation.xcframework" \
+  "$BUILD_DIR/ios.xcarchive" \
+  "$BUILD_DIR/ios-simulator.xcarchive"
+
+xcodebuild archive \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -configuration Release \
+  -destination "generic/platform=iOS" \
+  -archivePath "$BUILD_DIR/ios.xcarchive" \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+xcodebuild archive \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -configuration Release \
+  -destination "generic/platform=iOS Simulator" \
+  -archivePath "$BUILD_DIR/ios-simulator.xcarchive" \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+xcodebuild -create-xcframework \
+  -framework "$BUILD_DIR/ios.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework" \
+  -framework "$BUILD_DIR/ios-simulator.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework" \
+  -output "$BUILD_DIR/NitroGeolocation.xcframework"
+
+rm -f "$OUT_DIR/$ASSET_NAME" "$OUT_DIR/$ASSET_NAME.sha256"
+(
+  cd "$BUILD_DIR"
+  /usr/bin/ditto -c -k --sequesterRsrc --keepParent NitroGeolocation.xcframework "$OUT_DIR/$ASSET_NAME"
+)
+shasum -a 256 "$OUT_DIR/$ASSET_NAME" > "$OUT_DIR/$ASSET_NAME.sha256"
+
+echo "$OUT_DIR/$ASSET_NAME"


### PR DESCRIPTION
## Summary

Adds a release flow for prebuilt native artifacts so installs can use GitHub Release assets instead of rebuilding native sources whenever matching binaries are available.

## Changes

- Adds Android prebuilt AAR resolution in Gradle with source-build fallback.
- Adds iOS XCFramework resolution in the podspec with source-build fallback.
- Adds scripts to build the Android AAR and iOS XCFramework assets.
- Adds a tag/workflow-dispatch GitHub Actions workflow that uploads those assets to the package release.

## SSoT / Cleanup

- Uses package version and the `react-native-nitro-geolocation@<version>` tag as the single asset naming source.
- Keeps local source checkouts on source builds by default, while npm installs prefer prebuilts.
- Supports `NITRO_GEOLOCATION_USE_PREBUILT=0` to force source builds and `NITRO_GEOLOCATION_PREBUILT_URL_BASE` for mirrors.

## Changeset

- Added a patch changeset for `react-native-nitro-geolocation`.

## Documentation

- Updated README and quick-start docs with prebuilt behavior and the source-build override.