### PR TITLE
feat: update Nitro Modules to 0.35.10 [E2E]

### DIFF
--- a/.changeset/nitro-modules-0-35-10.md
+++ b/.changeset/nitro-modules-0-35-10.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Update `react-native-nitro-modules` to 0.35.10 and regenerate Nitrogen bindings.

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -14,7 +14,7 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-nitro-geolocation": "workspace:*",
-    "react-native-nitro-modules": "^0.35.0",
+    "react-native-nitro-modules": "^0.35.10",
     "react-native-safe-area-context": "^5.5.2"
   },
   "devDependencies": {

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -33,7 +33,7 @@
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-nitro-geolocation": "workspace: *",
-    "react-native-nitro-modules": "^0.35.0",
+    "react-native-nitro-modules": "^0.35.10",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "4.19.0",
     "react-native-webview": "13.16.1"

--- a/packages/react-native-nitro-geolocation/nitro.json
+++ b/packages/react-native-nitro-geolocation/nitro.json
@@ -10,16 +10,34 @@
   },
   "autolinking": {
     "NitroGeolocation": {
-      "swift": "NitroGeolocation",
-      "kotlin": "NitroGeolocation"
+      "ios": {
+        "language": "swift",
+        "implementationClassName": "NitroGeolocation"
+      },
+      "android": {
+        "language": "kotlin",
+        "implementationClassName": "NitroGeolocation"
+      }
     },
     "NitroGeolocationCompat": {
-      "swift": "NitroGeolocationCompat",
-      "kotlin": "NitroGeolocationCompat"
+      "ios": {
+        "language": "swift",
+        "implementationClassName": "NitroGeolocationCompat"
+      },
+      "android": {
+        "language": "kotlin",
+        "implementationClassName": "NitroGeolocationCompat"
+      }
     },
     "NitroBackgroundLocation": {
-      "swift": "NitroBackgroundLocation",
-      "kotlin": "NitroBackgroundLocation"
+      "ios": {
+        "language": "swift",
+        "implementationClassName": "NitroBackgroundLocation"
+      },
+      "android": {
+        "language": "kotlin",
+        "implementationClassName": "NitroBackgroundLocation"
+      }
     }
   },
   "ignorePaths": ["node_modules", "example"]

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAccuracyAuthorization.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAccuracyAuthorization.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AccuracyAuthorization" and the the Kotlin enum "AccuracyAuthorization".
+   * The C++ JNI bridge between the C++ enum "AccuracyAuthorization" and the Kotlin enum "AccuracyAuthorization".
    */
   struct JAccuracyAuthorization final: public jni::JavaClass<JAccuracyAuthorization> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JActivityRecognitionOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JActivityRecognitionOptions.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "ActivityRecognitionOptions" and the the Kotlin data class "ActivityRecognitionOptions".
+   * The C++ JNI bridge between the C++ struct "ActivityRecognitionOptions" and the Kotlin data class "ActivityRecognitionOptions".
    */
   struct JActivityRecognitionOptions final: public jni::JavaClass<JActivityRecognitionOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidAccuracyPreset.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidAccuracyPreset.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AndroidAccuracyPreset" and the the Kotlin enum "AndroidAccuracyPreset".
+   * The C++ JNI bridge between the C++ enum "AndroidAccuracyPreset" and the Kotlin enum "AndroidAccuracyPreset".
    */
   struct JAndroidAccuracyPreset final: public jni::JavaClass<JAndroidAccuracyPreset> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundLocationOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundLocationOptions.hpp
@@ -22,7 +22,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "AndroidBackgroundLocationOptions" and the the Kotlin data class "AndroidBackgroundLocationOptions".
+   * The C++ JNI bridge between the C++ struct "AndroidBackgroundLocationOptions" and the Kotlin data class "AndroidBackgroundLocationOptions".
    */
   struct JAndroidBackgroundLocationOptions final: public jni::JavaClass<JAndroidBackgroundLocationOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundLocationStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundLocationStatus.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "AndroidBackgroundLocationStatus" and the the Kotlin data class "AndroidBackgroundLocationStatus".
+   * The C++ JNI bridge between the C++ struct "AndroidBackgroundLocationStatus" and the Kotlin data class "AndroidBackgroundLocationStatus".
    */
   struct JAndroidBackgroundLocationStatus final: public jni::JavaClass<JAndroidBackgroundLocationStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundProvider.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidBackgroundProvider.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AndroidBackgroundProvider" and the the Kotlin enum "AndroidBackgroundProvider".
+   * The C++ JNI bridge between the C++ enum "AndroidBackgroundProvider" and the Kotlin enum "AndroidBackgroundProvider".
    */
   struct JAndroidBackgroundProvider final: public jni::JavaClass<JAndroidBackgroundProvider> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidForegroundServiceOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidForegroundServiceOptions.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "AndroidForegroundServiceOptions" and the the Kotlin data class "AndroidForegroundServiceOptions".
+   * The C++ JNI bridge between the C++ struct "AndroidForegroundServiceOptions" and the Kotlin data class "AndroidForegroundServiceOptions".
    */
   struct JAndroidForegroundServiceOptions final: public jni::JavaClass<JAndroidForegroundServiceOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidGranularity.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAndroidGranularity.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AndroidGranularity" and the the Kotlin enum "AndroidGranularity".
+   * The C++ JNI bridge between the C++ enum "AndroidGranularity" and the Kotlin enum "AndroidGranularity".
    */
   struct JAndroidGranularity final: public jni::JavaClass<JAndroidGranularity> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAuthorizationLevel.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAuthorizationLevel.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AuthorizationLevel" and the the Kotlin enum "AuthorizationLevel".
+   * The C++ JNI bridge between the C++ enum "AuthorizationLevel" and the Kotlin enum "AuthorizationLevel".
    */
   struct JAuthorizationLevel final: public jni::JavaClass<JAuthorizationLevel> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAuthorizationLevelInternal.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JAuthorizationLevelInternal.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "AuthorizationLevelInternal" and the the Kotlin enum "AuthorizationLevelInternal".
+   * The C++ JNI bridge between the C++ enum "AuthorizationLevelInternal" and the Kotlin enum "AuthorizationLevelInternal".
    */
   struct JAuthorizationLevelInternal final: public jni::JavaClass<JAuthorizationLevelInternal> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundEventEnvelope.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundEventEnvelope.hpp
@@ -53,7 +53,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundEventEnvelope" and the the Kotlin data class "BackgroundEventEnvelope".
+   * The C++ JNI bridge between the C++ struct "BackgroundEventEnvelope" and the Kotlin data class "BackgroundEventEnvelope".
    */
   struct JBackgroundEventEnvelope final: public jni::JavaClass<JBackgroundEventEnvelope> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundEventType.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundEventType.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundEventType" and the the Kotlin enum "BackgroundEventType".
+   * The C++ JNI bridge between the C++ enum "BackgroundEventType" and the Kotlin enum "BackgroundEventType".
    */
   struct JBackgroundEventType final: public jni::JavaClass<JBackgroundEventType> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpMethod.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpMethod.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundHttpMethod" and the the Kotlin enum "BackgroundHttpMethod".
+   * The C++ JNI bridge between the C++ enum "BackgroundHttpMethod" and the Kotlin enum "BackgroundHttpMethod".
    */
   struct JBackgroundHttpMethod final: public jni::JavaClass<JBackgroundHttpMethod> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpSyncOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpSyncOptions.hpp
@@ -25,7 +25,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundHttpSyncOptions" and the the Kotlin data class "BackgroundHttpSyncOptions".
+   * The C++ JNI bridge between the C++ struct "BackgroundHttpSyncOptions" and the Kotlin data class "BackgroundHttpSyncOptions".
    */
   struct JBackgroundHttpSyncOptions final: public jni::JavaClass<JBackgroundHttpSyncOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpSyncResult.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundHttpSyncResult.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundHttpSyncResult" and the the Kotlin data class "BackgroundHttpSyncResult".
+   * The C++ JNI bridge between the C++ struct "BackgroundHttpSyncResult" and the Kotlin data class "BackgroundHttpSyncResult".
    */
   struct JBackgroundHttpSyncResult final: public jni::JavaClass<JBackgroundHttpSyncResult> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocation.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocation.hpp
@@ -34,7 +34,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundLocation" and the the Kotlin data class "BackgroundLocation".
+   * The C++ JNI bridge between the C++ struct "BackgroundLocation" and the Kotlin data class "BackgroundLocation".
    */
   struct JBackgroundLocation final: public jni::JavaClass<JBackgroundLocation> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationOptions.hpp
@@ -54,7 +54,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundLocationOptions" and the the Kotlin data class "BackgroundLocationOptions".
+   * The C++ JNI bridge between the C++ struct "BackgroundLocationOptions" and the Kotlin data class "BackgroundLocationOptions".
    */
   struct JBackgroundLocationOptions final: public jni::JavaClass<JBackgroundLocationOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationSource.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationSource.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundLocationSource" and the the Kotlin enum "BackgroundLocationSource".
+   * The C++ JNI bridge between the C++ enum "BackgroundLocationSource" and the Kotlin enum "BackgroundLocationSource".
    */
   struct JBackgroundLocationSource final: public jni::JavaClass<JBackgroundLocationSource> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationState.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationState.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundLocationState" and the the Kotlin enum "BackgroundLocationState".
+   * The C++ JNI bridge between the C++ enum "BackgroundLocationState" and the Kotlin enum "BackgroundLocationState".
    */
   struct JBackgroundLocationState final: public jni::JavaClass<JBackgroundLocationState> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationStatus.hpp
@@ -34,7 +34,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundLocationStatus" and the the Kotlin data class "BackgroundLocationStatus".
+   * The C++ JNI bridge between the C++ struct "BackgroundLocationStatus" and the Kotlin data class "BackgroundLocationStatus".
    */
   struct JBackgroundLocationStatus final: public jni::JavaClass<JBackgroundLocationStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundPermissionResult.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundPermissionResult.hpp
@@ -23,7 +23,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BackgroundPermissionResult" and the the Kotlin data class "BackgroundPermissionResult".
+   * The C++ JNI bridge between the C++ struct "BackgroundPermissionResult" and the Kotlin data class "BackgroundPermissionResult".
    */
   struct JBackgroundPermissionResult final: public jni::JavaClass<JBackgroundPermissionResult> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundPermissionStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundPermissionStatus.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundPermissionStatus" and the the Kotlin enum "BackgroundPermissionStatus".
+   * The C++ JNI bridge between the C++ enum "BackgroundPermissionStatus" and the Kotlin enum "BackgroundPermissionStatus".
    */
   struct JBackgroundPermissionStatus final: public jni::JavaClass<JBackgroundPermissionStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundTrackingMode.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundTrackingMode.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "BackgroundTrackingMode" and the the Kotlin enum "BackgroundTrackingMode".
+   * The C++ JNI bridge between the C++ enum "BackgroundTrackingMode" and the Kotlin enum "BackgroundTrackingMode".
    */
   struct JBackgroundTrackingMode final: public jni::JavaClass<JBackgroundTrackingMode> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBatterySnapshot.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBatterySnapshot.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "BatterySnapshot" and the the Kotlin data class "BatterySnapshot".
+   * The C++ JNI bridge between the C++ struct "BatterySnapshot" and the Kotlin data class "BatterySnapshot".
    */
   struct JBatterySnapshot final: public jni::JavaClass<JBatterySnapshot> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationConfigurationInternal.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationConfigurationInternal.hpp
@@ -21,7 +21,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "CompatGeolocationConfigurationInternal" and the the Kotlin data class "CompatGeolocationConfigurationInternal".
+   * The C++ JNI bridge between the C++ struct "CompatGeolocationConfigurationInternal" and the Kotlin data class "CompatGeolocationConfigurationInternal".
    */
   struct JCompatGeolocationConfigurationInternal final: public jni::JavaClass<JCompatGeolocationConfigurationInternal> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationError.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationError.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "CompatGeolocationError" and the the Kotlin data class "CompatGeolocationError".
+   * The C++ JNI bridge between the C++ struct "CompatGeolocationError" and the Kotlin data class "CompatGeolocationError".
    */
   struct JCompatGeolocationError final: public jni::JavaClass<JCompatGeolocationError> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationOptions.hpp
@@ -25,7 +25,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "CompatGeolocationOptions" and the the Kotlin data class "CompatGeolocationOptions".
+   * The C++ JNI bridge between the C++ struct "CompatGeolocationOptions" and the Kotlin data class "CompatGeolocationOptions".
    */
   struct JCompatGeolocationOptions final: public jni::JavaClass<JCompatGeolocationOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationResponse.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JCompatGeolocationResponse.hpp
@@ -23,7 +23,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "CompatGeolocationResponse" and the the Kotlin data class "CompatGeolocationResponse".
+   * The C++ JNI bridge between the C++ struct "CompatGeolocationResponse" and the Kotlin data class "CompatGeolocationResponse".
    */
   struct JCompatGeolocationResponse final: public jni::JavaClass<JCompatGeolocationResponse> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JDetectedActivity.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JDetectedActivity.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "DetectedActivity" and the the Kotlin data class "DetectedActivity".
+   * The C++ JNI bridge between the C++ struct "DetectedActivity" and the Kotlin data class "DetectedActivity".
    */
   struct JDetectedActivity final: public jni::JavaClass<JDetectedActivity> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JDetectedActivityType.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JDetectedActivityType.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "DetectedActivityType" and the the Kotlin enum "DetectedActivityType".
+   * The C++ JNI bridge between the C++ enum "DetectedActivityType" and the Kotlin enum "DetectedActivityType".
    */
   struct JDetectedActivityType final: public jni::JavaClass<JDetectedActivityType> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeocodedLocation.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeocodedLocation.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeocodedLocation" and the the Kotlin data class "GeocodedLocation".
+   * The C++ JNI bridge between the C++ struct "GeocodedLocation" and the Kotlin data class "GeocodedLocation".
    */
   struct JGeocodedLocation final: public jni::JavaClass<JGeocodedLocation> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeocodingCoordinates.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeocodingCoordinates.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeocodingCoordinates" and the the Kotlin data class "GeocodingCoordinates".
+   * The C++ JNI bridge between the C++ struct "GeocodingCoordinates" and the Kotlin data class "GeocodingCoordinates".
    */
   struct JGeocodingCoordinates final: public jni::JavaClass<JGeocodingCoordinates> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceEvent.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceEvent.hpp
@@ -42,7 +42,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeofenceEvent" and the the Kotlin data class "GeofenceEvent".
+   * The C++ JNI bridge between the C++ struct "GeofenceEvent" and the Kotlin data class "GeofenceEvent".
    */
   struct JGeofenceEvent final: public jni::JavaClass<JGeofenceEvent> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceRegion.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceRegion.hpp
@@ -23,7 +23,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeofenceRegion" and the the Kotlin data class "GeofenceRegion".
+   * The C++ JNI bridge between the C++ struct "GeofenceRegion" and the Kotlin data class "GeofenceRegion".
    */
   struct JGeofenceRegion final: public jni::JavaClass<JGeofenceRegion> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceTransition.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofenceTransition.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "GeofenceTransition" and the the Kotlin enum "GeofenceTransition".
+   * The C++ JNI bridge between the C++ enum "GeofenceTransition" and the Kotlin enum "GeofenceTransition".
    */
   struct JGeofenceTransition final: public jni::JavaClass<JGeofenceTransition> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofencingOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeofencingOptions.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeofencingOptions" and the the Kotlin data class "GeofencingOptions".
+   * The C++ JNI bridge between the C++ struct "GeofencingOptions" and the Kotlin data class "GeofencingOptions".
    */
   struct JGeofencingOptions final: public jni::JavaClass<JGeofencingOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationConfiguration.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationConfiguration.hpp
@@ -21,7 +21,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeolocationConfiguration" and the the Kotlin data class "GeolocationConfiguration".
+   * The C++ JNI bridge between the C++ struct "GeolocationConfiguration" and the Kotlin data class "GeolocationConfiguration".
    */
   struct JGeolocationConfiguration final: public jni::JavaClass<JGeolocationConfiguration> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationCoordinates.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationCoordinates.hpp
@@ -21,7 +21,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeolocationCoordinates" and the the Kotlin data class "GeolocationCoordinates".
+   * The C++ JNI bridge between the C++ struct "GeolocationCoordinates" and the Kotlin data class "GeolocationCoordinates".
    */
   struct JGeolocationCoordinates final: public jni::JavaClass<JGeolocationCoordinates> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationResponse.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGeolocationResponse.hpp
@@ -25,7 +25,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GeolocationResponse" and the the Kotlin data class "GeolocationResponse".
+   * The C++ JNI bridge between the C++ struct "GeolocationResponse" and the Kotlin data class "GeolocationResponse".
    */
   struct JGeolocationResponse final: public jni::JavaClass<JGeolocationResponse> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGetStoredBackgroundEventsOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGetStoredBackgroundEventsOptions.hpp
@@ -20,7 +20,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GetStoredBackgroundEventsOptions" and the the Kotlin data class "GetStoredBackgroundEventsOptions".
+   * The C++ JNI bridge between the C++ struct "GetStoredBackgroundEventsOptions" and the Kotlin data class "GetStoredBackgroundEventsOptions".
    */
   struct JGetStoredBackgroundEventsOptions final: public jni::JavaClass<JGetStoredBackgroundEventsOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGetStoredBackgroundLocationsOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JGetStoredBackgroundLocationsOptions.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "GetStoredBackgroundLocationsOptions" and the the Kotlin data class "GetStoredBackgroundLocationsOptions".
+   * The C++ JNI bridge between the C++ struct "GetStoredBackgroundLocationsOptions" and the Kotlin data class "GetStoredBackgroundLocationsOptions".
    */
   struct JGetStoredBackgroundLocationsOptions final: public jni::JavaClass<JGetStoredBackgroundLocationsOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHeading.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHeading.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "Heading" and the the Kotlin data class "Heading".
+   * The C++ JNI bridge between the C++ struct "Heading" and the Kotlin data class "Heading".
    */
   struct JHeading final: public jni::JavaClass<JHeading> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHeadingOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHeadingOptions.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "HeadingOptions" and the the Kotlin data class "HeadingOptions".
+   * The C++ JNI bridge between the C++ struct "HeadingOptions" and the Kotlin data class "HeadingOptions".
    */
   struct JHeadingOptions final: public jni::JavaClass<JHeadingOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSAccuracyPreset.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSAccuracyPreset.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "IOSAccuracyPreset" and the the Kotlin enum "IOSAccuracyPreset".
+   * The C++ JNI bridge between the C++ enum "IOSAccuracyPreset" and the Kotlin enum "IOSAccuracyPreset".
    */
   struct JIOSAccuracyPreset final: public jni::JavaClass<JIOSAccuracyPreset> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSActivityType.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSActivityType.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "IOSActivityType" and the the Kotlin enum "IOSActivityType".
+   * The C++ JNI bridge between the C++ enum "IOSActivityType" and the Kotlin enum "IOSActivityType".
    */
   struct JIOSActivityType final: public jni::JavaClass<JIOSActivityType> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundActivityType.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundActivityType.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "IOSBackgroundActivityType" and the the Kotlin enum "IOSBackgroundActivityType".
+   * The C++ JNI bridge between the C++ enum "IOSBackgroundActivityType" and the Kotlin enum "IOSBackgroundActivityType".
    */
   struct JIOSBackgroundActivityType final: public jni::JavaClass<JIOSBackgroundActivityType> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundLocationOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundLocationOptions.hpp
@@ -19,7 +19,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "IOSBackgroundLocationOptions" and the the Kotlin data class "IOSBackgroundLocationOptions".
+   * The C++ JNI bridge between the C++ struct "IOSBackgroundLocationOptions" and the Kotlin data class "IOSBackgroundLocationOptions".
    */
   struct JIOSBackgroundLocationOptions final: public jni::JavaClass<JIOSBackgroundLocationOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundLocationStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JIOSBackgroundLocationStatus.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "IOSBackgroundLocationStatus" and the the Kotlin data class "IOSBackgroundLocationStatus".
+   * The C++ JNI bridge between the C++ struct "IOSBackgroundLocationStatus" and the Kotlin data class "IOSBackgroundLocationStatus".
    */
   struct JIOSBackgroundLocationStatus final: public jni::JavaClass<JIOSBackgroundLocationStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationAccuracyOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationAccuracyOptions.hpp
@@ -21,7 +21,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationAccuracyOptions" and the the Kotlin data class "LocationAccuracyOptions".
+   * The C++ JNI bridge between the C++ struct "LocationAccuracyOptions" and the Kotlin data class "LocationAccuracyOptions".
    */
   struct JLocationAccuracyOptions final: public jni::JavaClass<JLocationAccuracyOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationAvailability.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationAvailability.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationAvailability" and the the Kotlin data class "LocationAvailability".
+   * The C++ JNI bridge between the C++ struct "LocationAvailability" and the Kotlin data class "LocationAvailability".
    */
   struct JLocationAvailability final: public jni::JavaClass<JLocationAvailability> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationError.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationError.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationError" and the the Kotlin data class "LocationError".
+   * The C++ JNI bridge between the C++ struct "LocationError" and the Kotlin data class "LocationError".
    */
   struct JLocationError final: public jni::JavaClass<JLocationError> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProvider.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProvider.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "LocationProvider" and the the Kotlin enum "LocationProvider".
+   * The C++ JNI bridge between the C++ enum "LocationProvider" and the Kotlin enum "LocationProvider".
    */
   struct JLocationProvider final: public jni::JavaClass<JLocationProvider> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderInternal.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderInternal.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "LocationProviderInternal" and the the Kotlin enum "LocationProviderInternal".
+   * The C++ JNI bridge between the C++ enum "LocationProviderInternal" and the Kotlin enum "LocationProviderInternal".
    */
   struct JLocationProviderInternal final: public jni::JavaClass<JLocationProviderInternal> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderStatus.hpp
@@ -17,7 +17,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationProviderStatus" and the the Kotlin data class "LocationProviderStatus".
+   * The C++ JNI bridge between the C++ struct "LocationProviderStatus" and the Kotlin data class "LocationProviderStatus".
    */
   struct JLocationProviderStatus final: public jni::JavaClass<JLocationProviderStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderUsed.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationProviderUsed.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "LocationProviderUsed" and the the Kotlin enum "LocationProviderUsed".
+   * The C++ JNI bridge between the C++ enum "LocationProviderUsed" and the Kotlin enum "LocationProviderUsed".
    */
   struct JLocationProviderUsed final: public jni::JavaClass<JLocationProviderUsed> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationRequestOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationRequestOptions.hpp
@@ -27,7 +27,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationRequestOptions" and the the Kotlin data class "LocationRequestOptions".
+   * The C++ JNI bridge between the C++ struct "LocationRequestOptions" and the Kotlin data class "LocationRequestOptions".
    */
   struct JLocationRequestOptions final: public jni::JavaClass<JLocationRequestOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationSettingsOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationSettingsOptions.hpp
@@ -23,7 +23,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "LocationSettingsOptions" and the the Kotlin data class "LocationSettingsOptions".
+   * The C++ JNI bridge between the C++ struct "LocationSettingsOptions" and the Kotlin data class "LocationSettingsOptions".
    */
   struct JLocationSettingsOptions final: public jni::JavaClass<JLocationSettingsOptions> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JPermissionStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JPermissionStatus.hpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ enum "PermissionStatus" and the the Kotlin enum "PermissionStatus".
+   * The C++ JNI bridge between the C++ enum "PermissionStatus" and the Kotlin enum "PermissionStatus".
    */
   struct JPermissionStatus final: public jni::JavaClass<JPermissionStatus> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JReverseGeocodedAddress.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JReverseGeocodedAddress.hpp
@@ -18,7 +18,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "ReverseGeocodedAddress" and the the Kotlin data class "ReverseGeocodedAddress".
+   * The C++ JNI bridge between the C++ struct "ReverseGeocodedAddress" and the Kotlin data class "ReverseGeocodedAddress".
    */
   struct JReverseGeocodedAddress final: public jni::JavaClass<JReverseGeocodedAddress> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JStoredBackgroundEventEnvelope.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JStoredBackgroundEventEnvelope.hpp
@@ -55,7 +55,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "StoredBackgroundEventEnvelope" and the the Kotlin data class "StoredBackgroundEventEnvelope".
+   * The C++ JNI bridge between the C++ struct "StoredBackgroundEventEnvelope" and the Kotlin data class "StoredBackgroundEventEnvelope".
    */
   struct JStoredBackgroundEventEnvelope final: public jni::JavaClass<JStoredBackgroundEventEnvelope> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JStoredBackgroundLocation.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JStoredBackgroundLocation.hpp
@@ -34,7 +34,7 @@ namespace margelo::nitro::nitrogeolocation {
   using namespace facebook;
 
   /**
-   * The C++ JNI bridge between the C++ struct "StoredBackgroundLocation" and the the Kotlin data class "StoredBackgroundLocation".
+   * The C++ JNI bridge between the C++ struct "StoredBackgroundLocation" and the Kotlin data class "StoredBackgroundLocation".
    */
   struct JStoredBackgroundLocation final: public jni::JavaClass<JStoredBackgroundLocation> {
   public:

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/ActivityRecognitionOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/ActivityRecognitionOptions.kt
@@ -43,7 +43,7 @@ data class ActivityRecognitionOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       enabled,
       interval,
       stopOnStill,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidBackgroundLocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidBackgroundLocationOptions.kt
@@ -43,7 +43,7 @@ data class AndroidBackgroundLocationOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       locationProvider,
       foregroundService,
       requestNotificationPermission,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidBackgroundLocationStatus.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidBackgroundLocationStatus.kt
@@ -39,7 +39,7 @@ data class AndroidBackgroundLocationStatus(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       isForegroundServiceRunning,
       isIgnoringBatteryOptimizations,
       notificationPermission

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidForegroundServiceOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/AndroidForegroundServiceOptions.kt
@@ -63,7 +63,7 @@ data class AndroidForegroundServiceOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       notificationId,
       notificationTitle,
       notificationText,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundEventEnvelope.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundEventEnvelope.kt
@@ -67,7 +67,7 @@ data class BackgroundEventEnvelope(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       location,
       geofence,
       activity,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundHttpSyncOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundHttpSyncOptions.kt
@@ -71,7 +71,7 @@ data class BackgroundHttpSyncOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       url,
       method,
       headers,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundHttpSyncResult.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundHttpSyncResult.kt
@@ -47,7 +47,7 @@ data class BackgroundHttpSyncResult(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       success,
       statusCode,
       syncedLocationIds,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocation.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocation.kt
@@ -67,7 +67,7 @@ data class BackgroundLocation(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       id,
       source,
       isFromBackground,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationOptions.kt
@@ -99,7 +99,7 @@ data class BackgroundLocationOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       trackingMode,
       accuracy,
       granularity,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationStatus.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationStatus.kt
@@ -83,7 +83,7 @@ data class BackgroundLocationStatus(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       state,
       isRunning,
       isConfigured,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundPermissionResult.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundPermissionResult.kt
@@ -47,7 +47,7 @@ data class BackgroundPermissionResult(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       foreground,
       background,
       accuracyAuthorization,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BatterySnapshot.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BatterySnapshot.kt
@@ -35,7 +35,7 @@ data class BatterySnapshot(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       level,
       isCharging
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationConfigurationInternal.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationConfigurationInternal.kt
@@ -43,7 +43,7 @@ data class CompatGeolocationConfigurationInternal(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       skipPermissionRequests,
       authorizationLevel,
       enableBackgroundLocationUpdates,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationError.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationError.kt
@@ -47,7 +47,7 @@ data class CompatGeolocationError(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       code,
       message,
       PERMISSION_DENIED,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationOptions.kt
@@ -71,7 +71,7 @@ data class CompatGeolocationOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       timeout,
       maximumAge,
       enableHighAccuracy,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationResponse.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/CompatGeolocationResponse.kt
@@ -35,7 +35,7 @@ data class CompatGeolocationResponse(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       coords,
       timestamp
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/DetectedActivity.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/DetectedActivity.kt
@@ -39,7 +39,7 @@ data class DetectedActivity(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       type,
       confidence,
       timestamp

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeocodedLocation.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeocodedLocation.kt
@@ -39,7 +39,7 @@ data class GeocodedLocation(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       latitude,
       longitude,
       accuracy

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeocodingCoordinates.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeocodingCoordinates.kt
@@ -35,7 +35,7 @@ data class GeocodingCoordinates(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       latitude,
       longitude
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofenceEvent.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofenceEvent.kt
@@ -43,7 +43,7 @@ data class GeofenceEvent(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       region,
       transition,
       location,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofenceRegion.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofenceRegion.kt
@@ -67,7 +67,7 @@ data class GeofenceRegion(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       identifier,
       latitude,
       longitude,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofencingOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeofencingOptions.kt
@@ -35,7 +35,7 @@ data class GeofencingOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       initialTrigger,
       notificationResponsiveness
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationConfiguration.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationConfiguration.kt
@@ -43,7 +43,7 @@ data class GeolocationConfiguration(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       autoRequestPermission,
       authorizationLevel,
       enableBackgroundLocationUpdates,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationCoordinates.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationCoordinates.kt
@@ -55,7 +55,7 @@ data class GeolocationCoordinates(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       latitude,
       longitude,
       altitude,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationResponse.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GeolocationResponse.kt
@@ -43,7 +43,7 @@ data class GeolocationResponse(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       coords,
       timestamp,
       mocked,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GetStoredBackgroundEventsOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GetStoredBackgroundEventsOptions.kt
@@ -43,7 +43,7 @@ data class GetStoredBackgroundEventsOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       types,
       limit,
       since,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GetStoredBackgroundLocationsOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/GetStoredBackgroundLocationsOptions.kt
@@ -43,7 +43,7 @@ data class GetStoredBackgroundLocationsOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       limit,
       since,
       includeDelivered,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/Heading.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/Heading.kt
@@ -43,7 +43,7 @@ data class Heading(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       magneticHeading,
       trueHeading,
       accuracy,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HeadingOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HeadingOptions.kt
@@ -31,7 +31,7 @@ data class HeadingOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       headingFilter
     ).contentDeepHashCode()
   }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/IOSBackgroundLocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/IOSBackgroundLocationOptions.kt
@@ -51,7 +51,7 @@ data class IOSBackgroundLocationOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       activityType,
       pausesLocationUpdatesAutomatically,
       showsBackgroundLocationIndicator,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/IOSBackgroundLocationStatus.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/IOSBackgroundLocationStatus.kt
@@ -35,7 +35,7 @@ data class IOSBackgroundLocationStatus(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       allowsBackgroundLocationUpdates,
       significantChangesEnabled
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationAccuracyOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationAccuracyOptions.kt
@@ -35,7 +35,7 @@ data class LocationAccuracyOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       android,
       ios
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationAvailability.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationAvailability.kt
@@ -35,7 +35,7 @@ data class LocationAvailability(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       available,
       reason
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationError.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationError.kt
@@ -35,7 +35,7 @@ data class LocationError(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       code,
       message
     ).contentDeepHashCode()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationProviderStatus.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationProviderStatus.kt
@@ -55,7 +55,7 @@ data class LocationProviderStatus(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       locationServicesEnabled,
       backgroundModeEnabled,
       gpsAvailable,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationRequestOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationRequestOptions.kt
@@ -91,7 +91,7 @@ data class LocationRequestOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       timeout,
       maximumAge,
       enableHighAccuracy,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationSettingsOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationSettingsOptions.kt
@@ -55,7 +55,7 @@ data class LocationSettingsOptions(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       enableHighAccuracy,
       accuracy,
       interval,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/ReverseGeocodedAddress.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/ReverseGeocodedAddress.kt
@@ -55,7 +55,7 @@ data class ReverseGeocodedAddress(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       country,
       region,
       city,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/StoredBackgroundEventEnvelope.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/StoredBackgroundEventEnvelope.kt
@@ -51,7 +51,7 @@ data class StoredBackgroundEventEnvelope(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       event,
       createdAt,
       id,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/StoredBackgroundLocation.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/StoredBackgroundLocation.kt
@@ -79,7 +79,7 @@ data class StoredBackgroundLocation(
   }
 
   override fun hashCode(): Int {
-    return arrayOf(
+    return arrayOf<Any?>(
       id,
       deliveredToJS,
       synced,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationProviderStatus.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationProviderStatus.swift
@@ -56,12 +56,12 @@ public extension LocationProviderStatus {
   var locationServicesEnabled: Bool {
     return self.__locationServicesEnabled
   }
-  
+
   @inline(__always)
   var backgroundModeEnabled: Bool {
     return self.__backgroundModeEnabled
   }
-  
+
   @inline(__always)
   var gpsAvailable: Bool? {
     return { () -> Bool? in
@@ -73,7 +73,7 @@ public extension LocationProviderStatus {
       }
     }()
   }
-  
+
   @inline(__always)
   var networkAvailable: Bool? {
     return { () -> Bool? in
@@ -85,7 +85,7 @@ public extension LocationProviderStatus {
       }
     }()
   }
-  
+
   @inline(__always)
   var passiveAvailable: Bool? {
     return { () -> Bool? in
@@ -109,7 +109,7 @@ public extension LocationProviderStatus {
       }
     }()
   }
-  
+
   @inline(__always)
   var googleLocationAccuracyEnabled: Bool? {
     return { () -> Bool? in

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -86,7 +86,7 @@
     "@types/react-test-renderer": "^18.0.0",
     "react": "19.1.0",
     "react-native": "0.81.1",
-    "react-native-nitro-modules": "0.35.0",
+    "react-native-nitro-modules": "0.35.10",
     "typescript": "5.9.3",
     "vitest": "4.1.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,7 +6124,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.81.4"
     react-native-nitro-geolocation: "workspace:*"
-    react-native-nitro-modules: "npm:^0.35.0"
+    react-native-nitro-modules: "npm:^0.35.10"
     react-native-safe-area-context: "npm:^5.5.2"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -12832,7 +12832,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.40.13"
     react-native-monorepo-config: "npm:^0.1.9"
     react-native-nitro-geolocation: "workspace: *"
-    react-native-nitro-modules: "npm:^0.35.0"
+    react-native-nitro-modules: "npm:^0.35.10"
     react-native-safe-area-context: "npm:^5.5.2"
     react-native-screens: "npm:4.19.0"
     react-native-webview: "npm:13.16.1"
@@ -12870,7 +12870,7 @@ __metadata:
     "@types/react-test-renderer": "npm:^18.0.0"
     react: "npm:19.1.0"
     react-native: "npm:0.81.1"
-    react-native-nitro-modules: "npm:0.35.0"
+    react-native-nitro-modules: "npm:0.35.10"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.5"
   peerDependencies:
@@ -12880,13 +12880,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-nitro-modules@npm:0.35.0, react-native-nitro-modules@npm:^0.35.0":
-  version: 0.35.0
-  resolution: "react-native-nitro-modules@npm:0.35.0"
+"react-native-nitro-modules@npm:0.35.10, react-native-nitro-modules@npm:^0.35.10":
+  version: 0.35.10
+  resolution: "react-native-nitro-modules@npm:0.35.10"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/3e1360081b0b9b6fc315f062a65d48dc5398ca03effdf8869c00dce808ddd320a3fe1869077784c86c3b9dd3d500cb6fd84e0d0b07a73ecbe1598fb800a4b0bb
+  checksum: 10c0/55c117c418abfb1223053eb93b8604bd7b6edc22ee9568a7017888a78f51dfa8ae5f2d11906c4cf6c87ae41b05ba099dc8958082b8aa1cfe8e1c7c1f3e9aff0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Update `react-native-nitro-modules` from 0.35.0 to 0.35.10 in the package and examples
- Regenerate Nitrogen bindings with `npx nitrogen@0.35.10 .`
- Update `nitro.json` autolinking config to the current `ios`/`android` schema
- Add a patch Changeset for `react-native-nitro-geolocation`

## Validation
- `npx nitrogen@0.35.10 .`
- `yarn workspace react-native-nitro-geolocation typecheck`
- `yarn workspace react-native-nitro-geolocation test`
- `yarn format:check`
- `yarn lint`
- `git diff --check`