### PR TITLE
chore: use mise-managed Node 24 in CI

### DIFF
--- a/.changeset/fresh-masks-roll.md
+++ b/.changeset/fresh-masks-roll.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Use the mise-managed Node.js 24.18.0 toolchain in CI.

--- a/.github/workflows/changeset-ci.yml
+++ b/.github/workflows/changeset-ci.yml
@@ -15,13 +15,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
         with:
           install: false
 
-      - name: Install tools via mise
+      - name: Trust and install tools via mise
         run: |
+          mise trust --yes
           mise install biome
 
       - name: Run Biome format check
@@ -41,8 +42,9 @@ jobs:
         with:
           install: false
 
-      - name: Install tools via mise
+      - name: Trust and install tools via mise
         run: |
+          mise trust --yes
           mise install biome
 
       - name: Run Biome lint
@@ -57,13 +59,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |
@@ -82,13 +91,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |
@@ -107,13 +123,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -15,13 +15,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
 
       - name: Enable Corepack
         run: |
           corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -28,18 +28,20 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.tag }}
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          distribution: temurin
-          java-version: 17
+          install: false
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install java node
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: yarn install
@@ -69,12 +71,20 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 20
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node ruby
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          mise reshim node
 
       - name: Install JS dependencies
         run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v3
         with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
+
+      - name: Configure npm registry
+        run: |
+          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          mise reshim node
 
       - name: Install dependencies
         run: yarn install

--- a/mise.toml
+++ b/mise.toml
@@ -2,5 +2,5 @@
 biome = "1.9.4"
 java = "17.0.2"
 maestro = "latest"
-node = "22"
+node = "24.18.0"
 ruby = "3.3.0"


### PR DESCRIPTION
## Summary
- Replace direct `actions/setup-node` and `actions/setup-java` version setup in CI with the `mise trust --yes` -> `mise install ...` flow.
- Run `node`, `corepack`, `yarn`, `biome`, and `bundle` directly from the mise-managed PATH.
- Rebuild mise's Node shims after `corepack enable` so CI resolves Yarn 4.9.4 instead of the runner's global Yarn 1.22.
- Pin Node.js in `mise.toml` to the current official Node 24 LTS release, `24.18.0`.
- Add a patch Changeset for the CI toolchain change.

## Validation
- `corepack enable && mise reshim node && yarn --version` -> `4.9.4`
- `node --version` -> `v24.18.0`
- `biome --version` -> `1.9.4`
- `yarn install`
- `biome ci --formatter-enabled=true --linter-enabled=false .`
- `yarn changeset status --verbose`
- `git diff --check`

## Notes
- The Node.js release index lists `v24.18.0` as the 2026-06-23 `Krypton` LTS release: https://nodejs.org/download/release/index.json