### PR TITLE
Add E2E comment command

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - mac-mini-e2e
+    - e2e

--- a/.github/workflows/e2e-command.yml
+++ b/.github/workflows/e2e-command.yml
@@ -1,0 +1,104 @@
+name: E2E Command
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch-e2e:
+    name: Dispatch E2E
+    runs-on: ubuntu-latest
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'jingjing2222' &&
+      contains(github.event.comment.body, '@E2E')
+
+    steps:
+      - name: Validate command
+        id: command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if printf '%s\n' "$COMMENT_BODY" | grep -Eq '(^|[[:space:]])@E2E([[:space:]]|$)'; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read pull request
+        id: pr
+        if: steps.command.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          echo "head_sha=$(jq -r '.head.sha' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(jq -r '.head.ref' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$(jq -r '.head.repo.full_name' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: Create iOS E2E progress comment
+        id: ios-comment
+        if: steps.command.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          body="$(printf '@jingjing2222 iOS E2E: queued\n\n- Detail: Waiting for runner\n- Revision: %s@%s\n- SHA: %s\n' \
+            "$HEAD_REPO" \
+            "$HEAD_REF" \
+            "$HEAD_SHA")"
+
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -f body="$body" \
+            --jq '.id')"
+          echo "id=$comment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Create Android E2E progress comment
+        id: android-comment
+        if: steps.command.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          body="$(printf '@jingjing2222 Android E2E: queued\n\n- Detail: Waiting for runner\n- Revision: %s@%s\n- SHA: %s\n' \
+            "$HEAD_REPO" \
+            "$HEAD_REF" \
+            "$HEAD_SHA")"
+
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -f body="$body" \
+            --jq '.id')"
+          echo "id=$comment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch E2E workflow
+        if: steps.command.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh workflow run e2e.yml \
+            --ref "${DEFAULT_BRANCH}" \
+            -f pr_number="${PR_NUMBER}" \
+            -f pr_sha="${HEAD_SHA}" \
+            -f pr_repository="${HEAD_REPO}" \
+            -f ios_comment_id="${{ steps.ios-comment.outputs.id }}" \
+            -f android_comment_id="${{ steps.android-comment.outputs.id }}" \
+            -f requested_by="jingjing2222"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,36 +1,74 @@
 name: E2E
 
 on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - ready_for_review
-      - synchronize
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to report E2E results to.
+        required: false
+        type: string
+      pr_sha:
+        description: Pull request head SHA to test.
+        required: false
+        type: string
+      pr_repository:
+        description: Pull request head repository to checkout.
+        required: false
+        type: string
+      ios_comment_id:
+        description: Issue comment id to update with iOS E2E progress.
+        required: false
+        type: string
+      android_comment_id:
+        description: Issue comment id to update with Android E2E progress.
+        required: false
+        type: string
+      requested_by:
+        description: GitHub username that requested the run.
+        required: false
+        type: string
 
 permissions:
   contents: read
+  issues: write
+
+env:
+  RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  TESTED_REPOSITORY: ${{ inputs.pr_repository || github.repository }}
+  TESTED_SHA: ${{ inputs.pr_sha || github.sha }}
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-${{ inputs.pr_number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   ios-e2e:
     name: iOS E2E
-    runs-on: macos-15
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - mac-mini-e2e
     timeout-minutes: 90
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.title, '[E2E]')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.pr_repository || github.repository }}
+          ref: ${{ inputs.pr_sha || github.ref }}
           persist-credentials: false
+
+      - name: Update iOS E2E progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Bootstrapping runner"
+
+      - name: Bootstrap iOS E2E runner
+        run: |
+          scripts/ci/bootstrap-e2e-runner.sh ios
 
       - name: Compute iOS app fingerprint
         id: ios-app-fingerprint
@@ -69,51 +107,52 @@ jobs:
           path: examples/v0.81.1/ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
           key: ${{ steps.ios-app-fingerprint.outputs.key }}
 
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: false
-
-      - name: Trust mise config
-        run: |
-          mise trust --yes
-
-      - name: Install iOS E2E tools via mise
-        run: |
-          mise install java maestro node
-
-      - name: Install iOS native build tools via mise
-        if: steps.ios-app-cache.outputs.cache-hit != 'true'
-        run: |
-          mise install ruby
-
       - name: Enable Corepack
         run: |
           corepack enable
-          mise reshim node
 
       - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Installing JavaScript dependencies"
           yarn install
 
       - name: Build packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Building packages"
           yarn build:all
 
       - name: Install iOS gems
         if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          ../../scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Installing iOS gems"
           bundle install
 
       - name: Install iOS pods
         if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          ../../scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Installing iOS pods"
           bundle exec pod install --project-directory=ios
 
       - name: Boot iOS simulator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Booting iOS simulator"
           SIMULATOR_UDID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
           if [ -z "$SIMULATOR_UDID" ]; then
             echo "No available iPhone simulator found." >&2
@@ -126,7 +165,11 @@ jobs:
       - name: Build iOS release app
         if: steps.ios-app-cache.outputs.cache-hit != 'true'
         working-directory: examples/v0.81.1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          ../../scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Building iOS release app"
           xcodebuild \
             -workspace ios/NitroGeolocationExample.xcworkspace \
             -scheme NitroGeolocationExample \
@@ -146,11 +189,19 @@ jobs:
 
       - name: Install iOS release app
         working-directory: examples/v0.81.1
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          ../../scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Installing iOS release app"
           xcrun simctl install "$SIMULATOR_UDID" ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
 
       - name: Run iOS E2E
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Running Maestro flows"
           yarn test:e2e:ios
 
       - name: Upload iOS E2E artifacts
@@ -162,19 +213,41 @@ jobs:
           path: |
             ~/.maestro/tests
 
+      - name: Update iOS E2E result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "${{ job.status }}" "Finished iOS E2E"
+
   android-e2e:
     name: Android E2E
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - mac-mini-e2e
     timeout-minutes: 90
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.title, '[E2E]')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.pr_repository || github.repository }}
+          ref: ${{ inputs.pr_sha || github.ref }}
           persist-credentials: false
+
+      - name: Update Android E2E progress
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Bootstrapping runner"
+
+      - name: Bootstrap Android E2E runner
+        run: |
+          scripts/ci/bootstrap-e2e-runner.sh android
 
       - name: Compute Android app fingerprint
         id: android-app-fingerprint
@@ -199,8 +272,8 @@ jobs:
                 examples/v0.81.1/react-native.config.js \
                 examples/v0.81.1/src \
                 examples/v0.81.1/android \
-                | xargs -0 sha256sum
-            } | sha256sum | awk '{ print $1 }'
+                | xargs -0 shasum -a 256
+            } | shasum -a 256 | awk '{ print $1 }'
           )"
           echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
           echo "key=android-e2e-app-$fingerprint" >> "$GITHUB_OUTPUT"
@@ -213,35 +286,33 @@ jobs:
           path: examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
           key: ${{ steps.android-app-fingerprint.outputs.key }}
 
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          install: false
-
-      - name: Trust mise config
-        run: |
-          mise trust --yes
-
-      - name: Install Android E2E tools via mise
-        run: |
-          mise install java maestro node
-
       - name: Enable Corepack
         run: |
           corepack enable
-          mise reshim node
 
       - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Installing JavaScript dependencies"
           yarn install
 
       - name: Build packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Building packages"
           yarn build:all
 
       - name: Build Android release app
         if: steps.android-app-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Building Android release app"
           ./examples/v0.81.1/android/gradlew -p examples/v0.81.1/android --no-daemon --console=plain assembleRelease
 
       - name: Save Android release app cache
@@ -252,29 +323,59 @@ jobs:
           path: examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
           key: ${{ steps.android-app-fingerprint.outputs.key }}
 
-      - name: Enable KVM
+      - name: Boot Android emulator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Booting Android emulator"
+          adb emu kill || true
+          adb kill-server || true
+          emulator -avd nitro-e2e-api-34 -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none >/tmp/nitro-e2e-emulator.log 2>&1 &
+          echo "ANDROID_EMULATOR_PID=$!" >> "$GITHUB_ENV"
+
+          booted=0
+          for _ in $(seq 1 120); do
+            if [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; then
+              booted=1
+              break
+            fi
+            adb reconnect offline || true
+            adb devices
+            sleep 5
+          done
+
+          if [ "$booted" != "1" ]; then
+            echo "Android emulator did not boot." >&2
+            tail -120 /tmp/nitro-e2e-emulator.log >&2
+            exit 1
+          fi
+
+          adb shell input keyevent 82 || true
+
+      - name: Install Android release app
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Installing Android release app"
+          adb install -r examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
 
       - name: Run Android E2E
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          arch: x86_64
-          target: google_apis
-          profile: pixel_6
-          emulator-boot-timeout: 600
-          disable-animations: true
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
-          script: |
-            adb devices
-            timeout 180 bash -c 'until [[ "$(adb get-state 2>/dev/null)" == "device" ]]; do adb reconnect offline || true; adb devices; sleep 5; done'
-            timeout 180 bash -c 'until [[ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" == "1" ]]; do adb devices; sleep 5; done'
-            adb shell input keyevent 82 || true
-            adb install -r examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
-            yarn test:e2e:android
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Running Maestro flows"
+          yarn test:e2e:android
+
+      - name: Stop Android emulator
+        if: always()
+        run: |
+          adb emu kill || true
+          if [ -n "${ANDROID_EMULATOR_PID:-}" ]; then
+            kill "$ANDROID_EMULATOR_PID" || true
+          fi
 
       - name: Upload Android E2E artifacts
         if: always()
@@ -284,3 +385,50 @@ jobs:
           if-no-files-found: ignore
           path: |
             ~/.maestro/tests
+
+      - name: Update Android E2E result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "${{ job.status }}" "Finished Android E2E"
+
+  notify-e2e-result:
+    name: Notify E2E Result
+    runs-on: ubuntu-latest
+    needs:
+      - ios-e2e
+      - android-e2e
+    if: always() && inputs.pr_number != ''
+
+    steps:
+      - name: Comment E2E result
+        env:
+          ANDROID_RESULT: ${{ needs.android-e2e.result }}
+          GH_TOKEN: ${{ github.token }}
+          IOS_RESULT: ${{ needs.ios-e2e.result }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TESTED_REPOSITORY: ${{ inputs.pr_repository || github.repository }}
+          TESTED_SHA: ${{ inputs.pr_sha }}
+        run: |
+          status="failed"
+          if [ "$IOS_RESULT" = "success" ] && [ "$ANDROID_RESULT" = "success" ]; then
+            status="passed"
+          elif [ "$IOS_RESULT" = "cancelled" ] || [ "$ANDROID_RESULT" = "cancelled" ]; then
+            status="cancelled"
+          fi
+
+          body="$(printf '@%s E2E %s.\n\n- iOS: %s\n- Android: %s\n- Revision: %s@%s\n- Run: %s\n' \
+            "$REQUESTED_BY" \
+            "$status" \
+            "$IOS_RESULT" \
+            "$ANDROID_RESULT" \
+            "$TESTED_REPOSITORY" \
+            "$TESTED_SHA" \
+            "$RUN_URL")"
+
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -f body="$body" || echo "Warning: failed to create final E2E result comment" >&2

--- a/scripts/ci/bootstrap-e2e-runner.sh
+++ b/scripts/ci/bootstrap-e2e-runner.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLATFORM="${1:-}"
+if [[ "$PLATFORM" != "ios" && "$PLATFORM" != "android" ]]; then
+  echo "Usage: $0 ios|android" >&2
+  exit 2
+fi
+
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+GITHUB_PATH="${GITHUB_PATH:-/dev/null}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "E2E self-hosted runner bootstrap only supports macOS." >&2
+  exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required on the E2E runner before bootstrap can install tools." >&2
+  exit 1
+fi
+
+if ! command -v mise >/dev/null 2>&1; then
+  brew install mise
+fi
+
+mise trust --yes
+mise install node java maestro
+if [[ "$PLATFORM" == "ios" ]]; then
+  mise install ruby
+fi
+mise reshim
+
+NODE_BIN="$(mise which node)"
+COREPACK_BIN="$(mise which corepack)"
+JAVA_HOME_VALUE="$(mise where java)"
+MAESTRO_BIN="$(mise which maestro)"
+MISE_SHIMS_DIR="$HOME/.local/share/mise/shims"
+
+{
+  echo "$MISE_SHIMS_DIR"
+  echo "$(dirname "$NODE_BIN")"
+  echo "$JAVA_HOME_VALUE/bin"
+  echo "$(dirname "$MAESTRO_BIN")"
+} >> "$GITHUB_PATH"
+
+{
+  echo "JAVA_HOME=$JAVA_HOME_VALUE"
+  echo "MAESTRO=$MAESTRO_BIN"
+  echo "NODE=$NODE_BIN"
+} >> "$GITHUB_ENV"
+
+"$NODE_BIN" -v
+"$COREPACK_BIN" enable
+"$COREPACK_BIN" prepare yarn@4.9.4 --activate
+"$(mise which yarn)" --version
+"$JAVA_HOME_VALUE/bin/java" -version
+"$MAESTRO_BIN" --version
+
+if [[ "$PLATFORM" == "ios" ]]; then
+  if ! xcodebuild -version >/dev/null 2>&1 && [[ -d /Applications/Xcode.app/Contents/Developer ]]; then
+    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+  fi
+
+  if ! xcodebuild -version >/dev/null 2>&1; then
+    echo "Full Xcode is required for iOS E2E. Install Xcode and run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
+    exit 1
+  fi
+
+  echo "DEVELOPER_DIR=${DEVELOPER_DIR:-$(xcode-select -p)}" >> "$GITHUB_ENV"
+
+  BUNDLE_BIN="$(mise which bundle || true)"
+  POD_BIN="$(mise which pod || true)"
+
+  if [[ -z "$BUNDLE_BIN" ]] || ! "$BUNDLE_BIN" --version >/dev/null 2>&1; then
+    mise exec ruby -- gem install bundler --no-document
+  fi
+  if [[ -z "$POD_BIN" ]] || ! "$POD_BIN" --version >/dev/null 2>&1; then
+    mise exec ruby -- gem install cocoapods --no-document
+  fi
+  mise reshim ruby
+
+  {
+    echo "$(dirname "$(mise which ruby)")"
+    echo "$(dirname "$(mise which bundle)")"
+    echo "$(dirname "$(mise which pod)")"
+  } >> "$GITHUB_PATH"
+
+  mise which ruby
+  mise which bundle
+  mise which pod
+  xcodebuild -version
+fi
+
+if [[ "$PLATFORM" == "android" ]]; then
+  ANDROID_HOME_VALUE="${ANDROID_HOME:-/opt/homebrew/share/android-commandlinetools}"
+  if ! command -v sdkmanager >/dev/null 2>&1; then
+    brew install --cask android-commandlinetools
+  fi
+
+  export ANDROID_HOME="$ANDROID_HOME_VALUE"
+  export ANDROID_SDK_ROOT="$ANDROID_HOME_VALUE"
+  export JAVA_HOME="$JAVA_HOME_VALUE"
+  export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$JAVA_HOME/bin:$PATH"
+
+  mkdir -p "$ANDROID_HOME"
+  set +o pipefail
+  yes | sdkmanager --licenses >/dev/null
+  license_status=$?
+  set -o pipefail
+  if [[ "$license_status" -ne 0 && "$license_status" -ne 141 ]]; then
+    echo "Failed to accept Android SDK licenses." >&2
+    exit "$license_status"
+  fi
+  sdkmanager \
+    "platform-tools" \
+    "emulator" \
+    "platforms;android-34" \
+    "build-tools;34.0.0" \
+    "system-images;android-34;google_apis;arm64-v8a"
+
+  if ! avdmanager list avd | grep -q '^    Name: nitro-e2e-api-34$'; then
+    echo no | avdmanager create avd \
+      -n nitro-e2e-api-34 \
+      -k "system-images;android-34;google_apis;arm64-v8a" \
+      -d pixel_6 \
+      --force
+  fi
+
+  {
+    echo "$ANDROID_HOME/emulator"
+    echo "$ANDROID_HOME/platform-tools"
+    echo "$ANDROID_HOME/cmdline-tools/latest/bin"
+  } >> "$GITHUB_PATH"
+
+  {
+    echo "ANDROID_HOME=$ANDROID_HOME"
+    echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+  } >> "$GITHUB_ENV"
+
+  adb version
+  emulator -version
+  sdkmanager --list_installed
+  avdmanager list avd
+fi

--- a/scripts/ci/update-e2e-comment.sh
+++ b/scripts/ci/update-e2e-comment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMENT_ID="${1:-}"
+PLATFORM="${2:-}"
+STATE="${3:-}"
+DETAIL="${4:-}"
+
+if [[ -z "$COMMENT_ID" || "$COMMENT_ID" == "null" ]]; then
+  exit 0
+fi
+if [[ -z "$PLATFORM" || -z "$STATE" ]]; then
+  echo "Usage: $0 comment-id platform state [detail]" >&2
+  exit 2
+fi
+
+REQUESTER="${REQUESTED_BY:-jingjing2222}"
+REVISION="${TESTED_REPOSITORY:-${GITHUB_REPOSITORY}}@${TESTED_SHA:-${GITHUB_SHA}}"
+RUN_LINK="${RUN_URL:-https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}}"
+UPDATED_AT="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+
+body="$(printf '@%s %s E2E: %s\n\n- Detail: %s\n- Revision: %s\n- Run: %s\n- Updated: %s\n' \
+  "$REQUESTER" \
+  "$PLATFORM" \
+  "$STATE" \
+  "${DETAIL:-No detail}" \
+  "$REVISION" \
+  "$RUN_LINK" \
+  "$UPDATED_AT")"
+
+if ! gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+  -f body="$body" >/dev/null; then
+  echo "Warning: failed to update E2E progress comment ${COMMENT_ID}" >&2
+fi


### PR DESCRIPTION
## What changed

- Replaced automatic E2E PR/title triggers with a `workflow_dispatch` E2E workflow.
- Added an `E2E Command` workflow that only lets `jingjing2222` trigger E2E from a PR comment containing the exact `@E2E` token.
- Routes iOS and Android E2E jobs to the `mac-mini-e2e` self-hosted macOS ARM64 runner label.
- Added per-platform E2E progress comments. The command workflow creates separate iOS and Android comments, and each job edits its own comment as it moves through bootstrap, install, build, simulator/emulator, and Maestro steps.
- Adds runner bootstrap scripts that check required tools and install missing pieces before E2E runs.
- Added actionlint config for the custom runner labels.

## Runner setup

- Registered two Mac mini runner instances: `mac-mini-e2e` and `mac-mini-e2e-2`.
- Both runners have labels `self-hosted`, `macOS`, `ARM64`, `mac-mini-e2e`, and `e2e`, so iOS and Android jobs can run in parallel.
- Preinstalled global Node/Yarn, Java, Ruby/Bundler/CocoaPods, Maestro, Android command-line tools, API 34 ARM64 system image, and AVD `nitro-e2e-api-34`.
- Xcode 26.6 is installed. The bootstrap script auto-sets `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` when `xcode-select` still points at Command Line Tools.

## Validation

- Parsed workflow YAML with Ruby YAML.
- Ran actionlint against the changed workflows.
- Confirmed both runners are online.
- Confirmed iOS and Android jobs schedule in parallel across the two runner instances.
- Confirmed Android E2E passed on the Mac mini in run `28947939249`.
- Confirmed iOS builds and starts Maestro flows on the Mac mini before that run was cancelled to test the new progress-comment flow.
- Confirmed manual branch-run comments can be permission-restricted by GitHub; progress comment update failures are now warnings and do not fail E2E.
