### PR TITLE
Use slash command for E2E

### DIFF
--- a/.github/workflows/e2e-command.yml
+++ b/.github/workflows/e2e-command.yml
@@ -10,7 +10,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch-e2e:
@@ -19,7 +19,8 @@ jobs:
     if: >
       github.event.issue.pull_request &&
       github.event.comment.user.login == 'jingjing2222' &&
-      contains(github.event.comment.body, '@E2E')
+      (contains(github.event.comment.body, '/e2e') ||
+        contains(github.event.comment.body, '/E2E'))
 
     steps:
       - name: Validate command
@@ -27,7 +28,7 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if printf '%s\n' "$COMMENT_BODY" | grep -Eq '(^|[[:space:]])@E2E([[:space:]]|$)'; then
+          if printf '%s\n' "$COMMENT_BODY" | grep -Eiq '(^|[[:space:]])/e2e([[:space:]]|$)'; then
             echo "matched=true" >> "$GITHUB_OUTPUT"
           else
             echo "matched=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed

- Replaces the `@E2E` mention-style command with `/e2e` so the command does not collide with a real GitHub user mention.
- Allows `/E2E` as well, while exact validation remains case-insensitive for the slash command token.
- Raises `pull-requests` permission to `write` for the command workflow because PR conversation comments were returning 403 with the current token permissions.

## Validation

- Parsed workflow YAML with Ruby YAML.
- Ran actionlint for `.github/workflows/e2e-command.yml`.
- Verified the previous `@E2E` attempt on PR #142 failed before dispatch due comment permissions, so this PR fixes the command shape and requested permissions before retesting.
