### PR TITLE
Fix E2E command workflow dispatch

### DIFF
--- a/.github/workflows/e2e-command.yml
+++ b/.github/workflows/e2e-command.yml
@@ -42,9 +42,11 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
-          echo "head_sha=$(jq -r '.head.sha' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(jq -r '.head.ref' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
-          echo "head_repo=$(jq -r '.head.repo.full_name' <<< "$pr_json")" >> "$GITHUB_OUTPUT"
+          {
+            echo "head_sha=$(jq -r '.head.sha' <<< "$pr_json")"
+            echo "head_ref=$(jq -r '.head.ref' <<< "$pr_json")"
+            echo "head_repo=$(jq -r '.head.repo.full_name' <<< "$pr_json")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create iOS E2E progress comment
         id: ios-comment
@@ -96,6 +98,7 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh workflow run e2e.yml \
+            -R "${GITHUB_REPOSITORY}" \
             --ref "${DEFAULT_BRANCH}" \
             -f pr_number="${PR_NUMBER}" \
             -f pr_sha="${HEAD_SHA}" \


### PR DESCRIPTION
## Summary

Fixes the `/e2e` comment command dispatch step so it works from an `issue_comment` workflow without a checked-out git repository.

## Root cause

`gh workflow run e2e.yml` was executed in the GitHub-hosted command workflow without checkout, so `gh` tried to resolve repository context through local git and failed with `fatal: not a git repository`.

## Changes

- Pass `-R "$GITHUB_REPOSITORY"` to `gh workflow run`.
- Clean up the PR metadata output writes so `actionlint` passes locally.

## Validation

- `actionlint .github/workflows/e2e-command.yml`