### PR TITLE
fix permission reentrancy

### DIFF
--- a/.changeset/fix-ios-permission-reentrancy.md
+++ b/.changeset/fix-ios-permission-reentrancy.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix iOS permission callback re-entrancy so nested permission requests are not dropped.

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -509,15 +509,18 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         let status = getCurrentAuthorizationStatus(from: manager)
         let mappedStatus = mapCLAuthorizationStatus(status)
 
-        // Resolve pending permission requests
-        for resolver in pendingPermissionResolvers {
+        // Snapshot state before invoking JS callbacks because they can re-enter this instance.
+        let resolvers = pendingPermissionResolvers
+        pendingPermissionResolvers.removeAll()
+        let shouldStartMonitoring = !pendingPositionRequests.isEmpty || !watchSubscriptions.isEmpty
+
+        for resolver in resolvers {
             resolver(mappedStatus)
         }
-        pendingPermissionResolvers.removeAll()
 
         // If authorized, start monitoring
         if status == .authorizedAlways || status == .authorizedWhenInUse {
-            if !pendingPositionRequests.isEmpty || !watchSubscriptions.isEmpty {
+            if shouldStartMonitoring {
                 startMonitoring()
             }
         }


### PR DESCRIPTION
  ## Description

  Fix a re-entrancy bug in iOS permission handling.

  JavaScript callbacks can synchronously re-enter `NitroGeolocation`. The implementation now snapshots and
  clears pending permission resolvers before invoking callbacks, and captures the monitoring decision before
  callback execution.

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Code refactoring

  ## Checklist

  - [x] My code follows the project style
  - [x] I've tested my changes locally
  - [ ] Documentation updated (if needed)

  ## E2E Test Results

  Not run.

  **Platform tested:**

  - [x] iOS
  - [ ] Android
  - [ ] N/A (docs only)

  **Test artifacts:**

  None.

  ---

  ## Additional Notes

  This is the upstream version of the existing patch for `react-native-nitro-geolocation@1.4.2`. I have done localy + is in a published production app in the Appstore.