### PR TITLE
Fix iOS source line budget

### DIFF
--- a/.changeset/fix-ios-source-line-budget.md
+++ b/.changeset/fix-ios-source-line-budget.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restore the iOS native adapter source line budget guard.

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -513,16 +513,13 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         let resolvers = pendingPermissionResolvers
         pendingPermissionResolvers.removeAll()
         let shouldStartMonitoring = !pendingPositionRequests.isEmpty || !watchSubscriptions.isEmpty
-
         for resolver in resolvers {
             resolver(mappedStatus)
         }
 
         // If authorized, start monitoring
-        if status == .authorizedAlways || status == .authorizedWhenInUse {
-            if shouldStartMonitoring {
-                startMonitoring()
-            }
+        if shouldStartMonitoring && (status == .authorizedAlways || status == .authorizedWhenInUse) {
+            startMonitoring()
         }
     }
 


### PR DESCRIPTION
## Summary

- keep the permission resolver snapshot behavior introduced by #145
- flatten the authorization and monitoring condition
- return `NitroGeolocation.swift` to its existing 1,096-line exception budget
- add an empty changeset because this CI-only cleanup does not require a package release

## Root cause

The permission reentrancy fix added three net lines to `NitroGeolocation.swift`, causing the source line-count guard to report 1,099 lines against the existing 1,096-line exception budget.

## Impact

This restores the failing CI guardrail without increasing the exception budget or changing the permission callback behavior.

## Validation

- `yarn source-lines:check`
- `yarn deadcode`
- `yarn deadcode:prod`
- `yarn pack:check`
- `yarn lint`
- `yarn format:check`
- `yarn build:all`
- `yarn test:unit` (52 tests)
- `yarn changeset status --since=origin/main`

The full local `yarn typecheck` was also attempted, but the docs and example workspace tasks could not find their local `tsc` binaries in this checkout. The changed package's typecheck completed, and GitHub Actions will provide the clean-environment result.