### PR TITLE
fix(e2e): unblock full macOS test runs

### DIFF
--- a/examples/v0.81.1/ios/Podfile.lock
+++ b/examples/v0.81.1/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroGeolocation (1.3.1):
+  - NitroGeolocation (1.4.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -38,7 +38,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroModules (0.35.0):
+  - NitroModules (0.35.10):
     - boost
     - DoubleConversion
     - fast_float
@@ -2767,8 +2767,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroGeolocation: 911c6655cd0ef8455f13dc51508e2ce8d6068e2f
-  NitroModules: 1dc73273d6e3aee937eec41ef3ed9470804b9884
+  NitroGeolocation: 8062747b8bb6751225dae6211c68c301dbe2a528
+  NitroModules: b5c5baefa71a65c40e129876a8b7943a9aef6aa5
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
@@ -2841,4 +2841,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f61ed94d0740686f1d830520b809de11f8780cd4
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -16,7 +16,7 @@
     "build:ios:release": "react-native build-ios --mode Release",
     "typecheck": "tsc --noEmit",
     "typecheck:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
-    "test:e2e:android": "bash ./scripts/test-e2e-android.sh",
+    "test:e2e:android": "bash ./scripts/test-maestro-retry-flows.sh && bash ./scripts/test-e2e-android.sh",
     "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh",
     "test:e2e:background-long-run:android": "bash ./scripts/test-background-long-run-android.sh",
     "test:e2e:background-long-run:ios": "bash ./scripts/test-background-long-run-ios.sh",

--- a/examples/v0.81.1/scripts/maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/maestro-retry-flows.sh
@@ -122,15 +122,15 @@ recover_android_driver() {
   [[ "$PLATFORM" == "android" ]] || return
 
   local adb_bin="${ADB:-adb}"
-  local adb_device_args=()
+  local adb_device_command=("$adb_bin")
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
-    adb_device_args=(-s "$ANDROID_SERIAL")
+    adb_device_command+=(-s "$ANDROID_SERIAL")
   fi
 
   if command -v "$adb_bin" >/dev/null 2>&1; then
     "$adb_bin" kill-server >/dev/null 2>&1 || true
     "$adb_bin" start-server >/dev/null 2>&1 || true
-    "$adb_bin" "${adb_device_args[@]}" wait-for-device >/dev/null 2>&1 || true
+    "${adb_device_command[@]}" wait-for-device >/dev/null 2>&1 || true
     sleep 3
   fi
 }

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -93,20 +93,23 @@ run_maestro_flows() {
   local suite_name="$1"
   shift
 
-  local maestro_extra_args=()
+  local retry_args=(
+    --platform android
+    --flow-dir "$FLOW_DIR"
+    --maestro "$MAESTRO_BIN"
+    --suite-name "$suite_name"
+  )
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
-    maestro_extra_args+=(--maestro-arg --udid --maestro-arg "$ANDROID_SERIAL")
+    retry_args+=(--maestro-arg --udid --maestro-arg "$ANDROID_SERIAL")
   fi
 
-  "$SCRIPT_DIR/maestro-retry-flows.sh" \
-    --platform android \
-    --flow-dir "$FLOW_DIR" \
-    --maestro "$MAESTRO_BIN" \
-    --suite-name "$suite_name" \
-    "${maestro_extra_args[@]}" \
+  retry_args+=( \
     --env "RUN_ANDROID_PROVIDER_SELECTION=$RUN_ANDROID_PROVIDER_SELECTION_VALUE" \
     --env "PROVIDER_SELECTION_PHYSICAL_DEVICE=$PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE" \
-    -- "$@"
+    -- "$@" \
+  )
+
+  "$SCRIPT_DIR/maestro-retry-flows.sh" "${retry_args[@]}"
 }
 
 adb_cmd reverse tcp:8081 tcp:8081 >/dev/null

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -59,6 +59,13 @@ restore_location() {
   adb_cmd reverse --remove tcp:8081 >/dev/null 2>&1 || true
 }
 
+restore_location_on_exit() {
+  local status=$?
+  trap - EXIT
+  restore_location
+  exit "$status"
+}
+
 is_emulator() {
   [[ "$(adb_cmd shell getprop ro.kernel.qemu | tr -d '\r')" == "1" ]]
 }
@@ -67,7 +74,7 @@ connected_device_count() {
   "$ADB_BIN" devices | awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }'
 }
 
-trap restore_location EXIT
+trap restore_location_on_exit EXIT
 
 RUN_ANDROID_PROVIDER_SELECTION_VALUE="${RUN_ANDROID_PROVIDER_SELECTION:-0}"
 PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="0"
@@ -84,10 +91,22 @@ if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
   PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="1"
 fi
 
+if ! android_flow_output="$(
+  "$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" android
+)"; then
+  echo "Failed to discover android Maestro flows." >&2
+  exit 1
+fi
+
+if [[ -z "$android_flow_output" ]]; then
+  echo "No android Maestro flows were discovered." >&2
+  exit 1
+fi
+
 ANDROID_FLOWS=()
 while IFS= read -r flow; do
   ANDROID_FLOWS+=("$flow")
-done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" android)
+done <<<"$android_flow_output"
 
 run_maestro_flows() {
   local suite_name="$1"

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -8,10 +8,22 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
 
+if ! ios_flow_output="$(
+  "$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" ios
+)"; then
+  echo "Failed to discover ios Maestro flows." >&2
+  exit 1
+fi
+
+if [[ -z "$ios_flow_output" ]]; then
+  echo "No ios Maestro flows were discovered." >&2
+  exit 1
+fi
+
 IOS_FLOWS=()
 while IFS= read -r flow; do
   IOS_FLOWS+=("$flow")
-done < <("$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" ios)
+done <<<"$ios_flow_output"
 
 "$SCRIPT_DIR/maestro-retry-flows.sh" \
   --platform ios \

--- a/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nitro-maestro-retry.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/flows"
+: >"$TEST_ROOT/flows/smoke.yaml"
+
+cat >"$TEST_ROOT/bin/maestro" <<'MAESTRO'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f "$FAKE_MAESTRO_STATE" ]]; then
+  : >"$FAKE_MAESTRO_STATE"
+  echo "Maestro Android driver did not start up in time" >&2
+  exit 1
+fi
+MAESTRO
+
+cat >"$TEST_ROOT/bin/adb" <<'ADB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_ADB_LOG"
+ADB
+
+cat >"$TEST_ROOT/bin/sleep" <<'SLEEP'
+#!/usr/bin/env bash
+exit 0
+SLEEP
+
+chmod +x "$TEST_ROOT/bin/maestro" "$TEST_ROOT/bin/adb" "$TEST_ROOT/bin/sleep"
+
+run_case() {
+  local case_name="$1"
+  local serial="$2"
+  local case_dir="$TEST_ROOT/$case_name"
+  local output_path="$case_dir/output.log"
+  local adb_log_path="$case_dir/adb.log"
+  local maestro_state_path="$case_dir/maestro.state"
+
+  mkdir -p "$case_dir"
+
+  if [[ -n "$serial" ]]; then
+    ANDROID_SERIAL="$serial" \
+      PATH="$TEST_ROOT/bin:$PATH" \
+      ADB="$TEST_ROOT/bin/adb" \
+      FAKE_ADB_LOG="$adb_log_path" \
+      FAKE_MAESTRO_STATE="$maestro_state_path" \
+      MAESTRO_INFRA_RETRIES=1 \
+      MAESTRO_RETRY_RUN_DIR="$case_dir/retry-logs" \
+      "$SCRIPT_DIR/maestro-retry-flows.sh" \
+      --platform android \
+      --flow-dir "$TEST_ROOT/flows" \
+      --attempts 1 \
+      --maestro "$TEST_ROOT/bin/maestro" \
+      --suite-name "retry self-test" \
+      -- smoke.yaml >"$output_path"
+  else
+    (
+      unset ANDROID_SERIAL
+      PATH="$TEST_ROOT/bin:$PATH" \
+        ADB="$TEST_ROOT/bin/adb" \
+        FAKE_ADB_LOG="$adb_log_path" \
+        FAKE_MAESTRO_STATE="$maestro_state_path" \
+        MAESTRO_INFRA_RETRIES=1 \
+        MAESTRO_RETRY_RUN_DIR="$case_dir/retry-logs" \
+        "$SCRIPT_DIR/maestro-retry-flows.sh" \
+        --platform android \
+        --flow-dir "$TEST_ROOT/flows" \
+        --attempts 1 \
+        --maestro "$TEST_ROOT/bin/maestro" \
+        --suite-name "retry self-test" \
+        -- smoke.yaml >"$output_path"
+    )
+  fi
+
+  grep -Fq "driver recovery 1/1" "$output_path"
+  grep -Fq "All Maestro retry self-test flows passed after attempt 1/1." "$output_path"
+  grep -Fxq "kill-server" "$adb_log_path"
+  grep -Fxq "start-server" "$adb_log_path"
+
+  if [[ -n "$serial" ]]; then
+    grep -Fxq -- "-s $serial wait-for-device" "$adb_log_path"
+  else
+    grep -Fxq "wait-for-device" "$adb_log_path"
+  fi
+}
+
+run_case without-serial ""
+run_case with-serial "emulator-5554"
+
+echo "Maestro retry recovery self-test passed."

--- a/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
@@ -34,7 +34,38 @@ cat >"$TEST_ROOT/bin/sleep" <<'SLEEP'
 exit 0
 SLEEP
 
-chmod +x "$TEST_ROOT/bin/maestro" "$TEST_ROOT/bin/adb" "$TEST_ROOT/bin/sleep"
+cat >"$TEST_ROOT/bin/node" <<'NODE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$FAKE_NODE_SCENARIO" in
+  parser-error)
+    echo "heading.yaml"
+    echo "Synthetic Maestro suite parser failure" >&2
+    exit 23
+    ;;
+  empty)
+    exit 0
+    ;;
+  *)
+    echo "Unknown fake Node scenario: $FAKE_NODE_SCENARIO" >&2
+    exit 2
+    ;;
+esac
+NODE
+
+cat >"$TEST_ROOT/bin/maestro-recorder" <<'MAESTRO_RECORDER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_MAESTRO_LOG"
+MAESTRO_RECORDER
+
+chmod +x \
+  "$TEST_ROOT/bin/maestro" \
+  "$TEST_ROOT/bin/adb" \
+  "$TEST_ROOT/bin/sleep" \
+  "$TEST_ROOT/bin/node" \
+  "$TEST_ROOT/bin/maestro-recorder"
 
 run_case() {
   local case_name="$1"
@@ -94,5 +125,64 @@ run_case() {
 
 run_case without-serial ""
 run_case with-serial "emulator-5554"
+
+run_flow_discovery_failure_case() {
+  local platform="$1"
+  local scenario="$2"
+  local expected_error="$3"
+  local case_dir="$TEST_ROOT/$platform-$scenario"
+  local output_path="$case_dir/output.log"
+  local adb_log_path="$case_dir/adb.log"
+  local maestro_log_path="$case_dir/maestro.log"
+  local test_script="$SCRIPT_DIR/test-e2e-$platform.sh"
+  local command_status
+
+  mkdir -p "$case_dir"
+
+  if (
+    unset ANDROID_SERIAL
+    PATH="$TEST_ROOT/bin:$PATH" \
+      ADB="$TEST_ROOT/bin/adb" \
+      NODE="$TEST_ROOT/bin/node" \
+      MAESTRO="$TEST_ROOT/bin/maestro-recorder" \
+      FAKE_ADB_LOG="$adb_log_path" \
+      FAKE_NODE_SCENARIO="$scenario" \
+      FAKE_MAESTRO_LOG="$maestro_log_path" \
+      "$test_script"
+  ) >"$output_path" 2>&1; then
+    command_status=0
+  else
+    command_status=$?
+  fi
+
+  if [[ "$command_status" -eq 0 ]]; then
+    echo "$platform E2E unexpectedly accepted $scenario flow discovery." >&2
+    return 1
+  fi
+
+  grep -Fq "$expected_error" "$output_path"
+
+  if [[ -e "$maestro_log_path" ]]; then
+    echo "$platform E2E invoked Maestro after $scenario flow discovery." >&2
+    return 1
+  fi
+}
+
+run_flow_discovery_failure_case \
+  android \
+  parser-error \
+  "Failed to discover android Maestro flows."
+run_flow_discovery_failure_case \
+  android \
+  empty \
+  "No android Maestro flows were discovered."
+run_flow_discovery_failure_case \
+  ios \
+  parser-error \
+  "Failed to discover ios Maestro flows."
+run_flow_discovery_failure_case \
+  ios \
+  empty \
+  "No ios Maestro flows were discovered."
 
 echo "Maestro retry recovery self-test passed."


### PR DESCRIPTION
## Summary

- make the Android Maestro wrapper safe on macOS Bash 3.2 when `ANDROID_SERIAL` is unset
- make Android-driver recovery use a consistently non-empty command array
- make Android and iOS flow discovery fail closed when the parser fails or returns no flows
- preserve the original Android E2E exit status across device cleanup
- run deterministic shell integration tests before Android device E2E
- refresh the example iOS lockfile to the versions declared by the workspace and its Bundler-locked CocoaPods version

This is a prerequisite for the v2 roadmap stack: without it, the required full E2E gate could either stop before the first Maestro flow or falsely report success after discovering no flows on the default macOS shell.

## Red → green evidence

- **Red 1:** on `origin/main`, `yarn test:e2e:android` stopped at `test-e2e-android.sh:102: maestro_extra_args[@]: unbound variable` before the first flow.
- **Green 1:** the same command with `ANDROID_SERIAL` intentionally unset executes the complete Android suite.
- **Red 2:** adversarial review reproduced the same Bash 3.2 empty-array failure in the Android-driver recovery path.
- **Green 2:** the shell self-test forces driver failure/recovery with and without `ANDROID_SERIAL`.
- **Red 3:** adversarial review reproduced a parser-error path that printed an empty-array error but returned status 0 without running the enabled Android flows.
- **Green 3:** the shell self-test injects partial-output parser failures and successful empty output on both platforms, asserts a nonzero wrapper result, and asserts Maestro was never invoked.

## Verification

- Android Release build + native unit tasks: passed
- iOS Release simulator build: passed
- Android native E2E: all 22 enabled + 1 disabled flows passed
- iOS native E2E: all 20 flows passed
- Android WebView E2E: success, denied, unavailable passed
- iOS WebView E2E: success, denied passed
- deterministic shell harness self-tests: driver recovery, parser failure, and empty discovery passed
- library unit tests: 52 passed
- format, lint, diff check, Bash syntax: passed
- package dry-run and source-line guard: passed
- web/docs/devtools build: passed

Roadmap context: #98