### PR TITLE
feat!: remove modern configuration alias

### DIFF
--- a/.changeset/clean-maps-retire.md
+++ b/.changeset/clean-maps-retire.md
@@ -1,0 +1,6 @@
+---
+"react-native-nitro-geolocation": major
+---
+
+Remove the deprecated `ModernGeolocationConfiguration` alias. Use
+`GeolocationConfiguration` for the root modern API instead.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "docs": "1.0.1",
+    "benchmark": "0.0.1",
+    "react-native-nitro-geolocation-example": "0.0.1",
+    "react-native-nitro-geolocation-web-e2e": "0.0.1",
+    "react-native-nitro-geolocation": "1.4.3",
+    "@react-native-nitro-geolocation/rozenite-plugin": "1.1.2"
+  },
+  "changesets": []
+}

--- a/examples/v0.81.1/src/type-contracts/v2.ts
+++ b/examples/v0.81.1/src/type-contracts/v2.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error v2 removes the duplicate Modern configuration alias.
+import type { ModernGeolocationConfiguration } from "react-native-nitro-geolocation";
+
+void (undefined as unknown as ModernGeolocationConfiguration);

--- a/knip.json
+++ b/knip.json
@@ -95,6 +95,7 @@
         "index.js",
         "src/App.tsx",
         "src/backgroundLongRunTask.ts",
+        "src/type-contracts/*.ts",
         ".maestro/scripts/wait-15s.js"
       ],
       "project": ["src/**/*.{ts,tsx}", "index.js", ".maestro/scripts/*.js"],

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -103,8 +103,7 @@ export type {
   AuthorizationLevel,
   LocationProvider,
   LocationProviderUsed,
-  GeolocationConfiguration,
-  ModernGeolocationConfiguration
+  GeolocationConfiguration
 } from "./publicTypes";
 
 // Pure utility functions (advanced users only)

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -34,8 +34,7 @@ export type {
   AuthorizationLevel,
   LocationProvider,
   LocationProviderUsed,
-  GeolocationConfiguration,
-  ModernGeolocationConfiguration
+  GeolocationConfiguration
 } from "./publicTypes";
 
 export * from "./utils";

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -80,12 +80,6 @@ export type GeolocationConfiguration = Omit<
   locationProvider?: LocationProvider;
 };
 
-/**
- * @deprecated Use `GeolocationConfiguration` instead.
- * This alias is kept only for backward compatibility.
- */
-export type ModernGeolocationConfiguration = GeolocationConfiguration;
-
 export type CompatGeolocationConfiguration = Omit<
   CompatGeolocationConfigurationInternal,
   "locationProvider"


### PR DESCRIPTION
## Summary

- remove the deprecated `ModernGeolocationConfiguration` type alias
- remove the alias from both native and browser root exports
- keep `GeolocationConfiguration` and the separate compat configuration surface unchanged
- add a compile-only consumer contract and a major changeset

This PR implements only the first definite v2 roadmap checkbox from #98. It is stacked on #148, which makes the required macOS full-E2E gate reliable.

## Red → green

- **Red:** with the alias still exported, the consumer contract failed with `TS2578: Unused '@ts-expect-error' directive`.
- **Green:** after removing the definition and both root exports, normal and no-unused example typechecks pass while the contract confirms that importing the removed alias is an error.

## Verification

- Android Release install + Nitro native debug/release unit tasks: passed
- iOS Release simulator build/install: passed
- Android native E2E: 22 location-enabled + 1 location-disabled flow passed
- iOS native E2E: 20 flows passed
- Android WebView E2E: success, denied, unavailable passed
- iOS WebView E2E: success, denied passed
- library unit tests: 52 passed
- example normal/no-unused and library typechecks: passed
- format, lint, diff check: passed
- package dry-run and source-line guard: passed
- web/docs/devtools build: passed

Roadmap: #98
Prerequisite: #148