### PR TITLE
feat: remove enableHighAccuracy from Modern API

### DIFF
--- a/.changeset/silly-cats-focus.md
+++ b/.changeset/silly-cats-focus.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": major
+---
+
+Remove `enableHighAccuracy` from the Modern API. Modern requests and Android
+settings now use explicit platform `accuracy` presets, while the `/compat`
+entry point retains `enableHighAccuracy` for drop-in compatibility.

--- a/examples/v0.81.1/.maestro/accuracy-presets.yaml
+++ b/examples/v0.81.1/.maestro/accuracy-presets.yaml
@@ -81,11 +81,11 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "accuracy-presets-scenario-2"
 - assertVisible:
-    text: ".*(iOS bestForNavigation overrides enableHighAccuracy=false|Android high overrides enableHighAccuracy=false).*"
+    text: ".*(iOS bestForNavigation for turn-by-turn navigation|Android high accuracy for turn-by-turn navigation).*"
 - assertVisible:
-    text: ".*(iOS nearestTenMeters returns fixture coordinates|Android balanced overrides enableHighAccuracy=true).*"
+    text: ".*(iOS nearestTenMeters for nearby search|Android balanced accuracy for nearby search).*"
 - assertVisible:
-    text: ".*(iOS reduced overrides enableHighAccuracy=true|Android low overrides enableHighAccuracy=true).*"
+    text: ".*(iOS reduced accuracy for weather refresh|Android low accuracy for weather refresh).*"
 - assertVisible:
     text: ".*37.566500, 126.978000.*"
 

--- a/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
+++ b/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
@@ -106,10 +106,9 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
   if (Platform.OS === "android") {
     return [
       {
-        id: "android-high-overrides-false",
-        title: "Android high overrides enableHighAccuracy=false",
+        id: "android-high",
+        title: "Android high accuracy for turn-by-turn navigation",
         options: {
-          enableHighAccuracy: false,
           accuracy: {
             android: "high"
           },
@@ -118,10 +117,9 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
         }
       },
       {
-        id: "android-balanced-overrides-true",
-        title: "Android balanced overrides enableHighAccuracy=true",
+        id: "android-balanced",
+        title: "Android balanced accuracy for nearby search",
         options: {
-          enableHighAccuracy: true,
           accuracy: {
             android: "balanced"
           },
@@ -130,10 +128,9 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
         }
       },
       {
-        id: "android-low-overrides-true",
-        title: "Android low overrides enableHighAccuracy=true",
+        id: "android-low",
+        title: "Android low accuracy for weather refresh",
         options: {
-          enableHighAccuracy: true,
           accuracy: {
             android: "low"
           },
@@ -146,10 +143,9 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
 
   return [
     {
-      id: "ios-best-navigation-overrides-false",
-      title: "iOS bestForNavigation overrides enableHighAccuracy=false",
+      id: "ios-best-navigation",
+      title: "iOS bestForNavigation for turn-by-turn navigation",
       options: {
-        enableHighAccuracy: false,
         accuracy: {
           ios: "bestForNavigation"
         },
@@ -161,7 +157,7 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
     },
     {
       id: "ios-nearest-ten",
-      title: "iOS nearestTenMeters returns fixture coordinates",
+      title: "iOS nearestTenMeters for nearby search",
       options: {
         accuracy: {
           ios: "nearestTenMeters"
@@ -173,10 +169,9 @@ const getPositiveScenarios = (): AccuracyScenario[] => {
       }
     },
     {
-      id: "ios-reduced-overrides-true",
-      title: "iOS reduced overrides enableHighAccuracy=true",
+      id: "ios-reduced",
+      title: "iOS reduced accuracy for weather refresh",
       options: {
-        enableHighAccuracy: true,
         accuracy: {
           ios: "reduced"
         },

--- a/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
@@ -24,7 +24,7 @@ import {
 import type { CapturedLocationError } from "./scenario";
 
 const TIMEOUT_CONTRACT_OPTIONS = {
-  enableHighAccuracy: true,
+  accuracy: { android: "high", ios: "best" } as const,
   maximumAge: 0,
   timeout: 0
 };
@@ -94,7 +94,7 @@ export default function ApiErrorsScreen() {
     try {
       const nextPosition = await runWithNativeGeolocation(() =>
         getCurrentPosition({
-          enableHighAccuracy: true,
+          accuracy: { android: "high", ios: "best" },
           timeout: 15000
         })
       );

--- a/examples/v0.81.1/src/screens/DefaultScreen.tsx
+++ b/examples/v0.81.1/src/screens/DefaultScreen.tsx
@@ -76,7 +76,7 @@ export default function DefaultScreen({
     isWatching
   } = useWatchPosition({
     enabled: watchEnabled,
-    enableHighAccuracy: true,
+    accuracy: { android: "high", ios: "best" },
     distanceFilter: 10,
     interval: 5000
   });
@@ -109,12 +109,12 @@ export default function DefaultScreen({
       const position = await (nativeGeolocation
         ? runWithNativeGeolocation(() =>
             getCurrentPosition({
-              enableHighAccuracy: true,
+              accuracy: { android: "high", ios: "best" },
               timeout: 15000
             })
           )
         : getCurrentPosition({
-            enableHighAccuracy: true,
+            accuracy: { android: "high", ios: "best" },
             timeout: 15000
           }));
       setCurrentPosition(position);

--- a/examples/v0.81.1/src/screens/Issue67Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue67Screen.tsx
@@ -20,7 +20,7 @@ type AndroidPermissionState = {
 };
 
 const LOW_ACCURACY_OPTIONS = {
-  enableHighAccuracy: false,
+  accuracy: { android: "balanced" } as const,
   timeout: 12000,
   maximumAge: 120000
 };
@@ -149,7 +149,7 @@ export default function Issue67Screen() {
       <ScenarioSection
         index={2}
         title="Low Accuracy Request"
-        description="Calls getCurrentPosition with enableHighAccuracy=false, timeout=12000, maximumAge=120000."
+        description="Calls getCurrentPosition with Android balanced accuracy, timeout=12000, maximumAge=120000."
         divided
       >
         <ScenarioButton

--- a/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
@@ -89,7 +89,7 @@ export default function ProviderSettingsScreen() {
       }
 
       const status = await requestLocationSettings({
-        enableHighAccuracy: true,
+        accuracy: { android: "high" },
         interval: 5000,
         fastestInterval: 1000,
         alwaysShow: true
@@ -113,7 +113,7 @@ export default function ProviderSettingsScreen() {
 
     try {
       const currentPosition = await getCurrentPosition({
-        enableHighAccuracy: true,
+        accuracy: { android: "high", ios: "best" },
         maximumAge: 0,
         timeout: 15000
       });

--- a/examples/v0.81.1/src/screens/scenario/components/ScenarioMessageList.tsx
+++ b/examples/v0.81.1/src/screens/scenario/components/ScenarioMessageList.tsx
@@ -60,7 +60,7 @@ export type ScenarioMessageListProps = {
  *   messages={[
  *     {
  *       id: "android-high-overrides-false",
- *       title: "Android high overrides enableHighAccuracy=false",
+ *       title: "Android high accuracy for navigation",
  *       message: "contract passed with injected location 37.566500, 126.978000"
  *     }
  *   ]}

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
@@ -32,7 +32,7 @@ const NEARBY_MOVE_MAX_METERS = 1000;
 
 const guardedWatchOptions: LocationRequestOptions = {
   distanceFilter: DISTANCE_FILTER_METERS,
-  enableHighAccuracy: true,
+  accuracy: { ios: "best" },
   maximumAge: 0
 };
 

--- a/examples/v0.81.1/src/type-contracts/v2.ts
+++ b/examples/v0.81.1/src/type-contracts/v2.ts
@@ -1,4 +1,44 @@
+<<<<<<< HEAD
 // @ts-expect-error v2 removes the duplicate Modern configuration alias.
 import type { ModernGeolocationConfiguration } from "react-native-nitro-geolocation";
+import type {
+  LocationRequestOptions,
+  LocationSettingsOptions,
+  LocationRequest as MergedLocationRequest
+} from "react-native-nitro-geolocation";
+import type { GeolocationOptions as CompatGeolocationOptions } from "react-native-nitro-geolocation/compat";
 
 void (undefined as unknown as ModernGeolocationConfiguration);
+
+const modernRequest: LocationRequestOptions = {
+  // @ts-expect-error v2 Modern callers choose an explicit accuracy preset.
+  enableHighAccuracy: true
+};
+
+const modernSettings: LocationSettingsOptions = {
+  // @ts-expect-error v2 Modern settings use accuracy.android.
+  enableHighAccuracy: true
+};
+
+const compatRequest: CompatGeolocationOptions = {
+  enableHighAccuracy: true
+};
+
+const mergedRequest: MergedLocationRequest = {
+  accuracy: "high",
+  distanceFilter: 10
+};
+
+const legacyMergedRequest: MergedLocationRequest = {
+  // @ts-expect-error v2 advanced utilities use an explicit accuracy level.
+  enableHighAccuracy: true,
+  distanceFilter: 10
+};
+
+void [
+  modernRequest,
+  modernSettings,
+  compatRequest,
+  mergedRequest,
+  legacyMergedRequest
+];

--- a/examples/v0.81.1/src/type-contracts/v2.ts
+++ b/examples/v0.81.1/src/type-contracts/v2.ts
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 // @ts-expect-error v2 removes the duplicate Modern configuration alias.
 import type { ModernGeolocationConfiguration } from "react-native-nitro-geolocation";
 import type {
@@ -6,6 +5,7 @@ import type {
   LocationSettingsOptions,
   LocationRequest as MergedLocationRequest
 } from "react-native-nitro-geolocation";
+import { selectProvider } from "react-native-nitro-geolocation";
 import type { GeolocationOptions as CompatGeolocationOptions } from "react-native-nitro-geolocation/compat";
 
 void (undefined as unknown as ModernGeolocationConfiguration);
@@ -34,6 +34,10 @@ const legacyMergedRequest: MergedLocationRequest = {
   enableHighAccuracy: true,
   distanceFilter: 10
 };
+
+selectProvider("high", true, true);
+// @ts-expect-error v2 advanced provider selection uses an explicit accuracy preset.
+selectProvider(true, true, true);
 
 void [
   modernRequest,

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -488,7 +488,7 @@ export async function runUnavailableCheck() {
   setScenario("position-unavailable", "running");
   try {
     const positionResult = await getCurrentPosition({
-      enableHighAccuracy: true,
+      accuracy: { android: "high" },
       maximumAge: 0,
       timeout: 10000
     });
@@ -517,7 +517,7 @@ export async function runTimeoutCheck() {
   setScenario("timeout", "running");
   try {
     await getCurrentPosition({
-      enableHighAccuracy: true,
+      accuracy: { android: "high" },
       maximumAge: 0,
       timeout: 1
     });

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
@@ -30,7 +30,6 @@ internal data class ParsedOptions(
             options: LocationRequestOptions?,
             defaultMaximumAge: Double = DEFAULT_MAXIMUM_AGE
         ): ParsedOptions {
-            val enableHighAccuracy = options?.enableHighAccuracy ?: false
             val maxUpdates = options?.maxUpdates?.let { value ->
                 if (!value.isFinite()) {
                     0
@@ -44,7 +43,7 @@ internal data class ParsedOptions(
                 maximumAge = options?.maximumAge ?: defaultMaximumAge,
                 androidAccuracy = resolveAndroidAccuracy(
                     options?.accuracy,
-                    enableHighAccuracy
+                    enableHighAccuracy = false
                 ),
                 interval = options?.interval ?: DEFAULT_INTERVAL,
                 fastestInterval = options?.fastestInterval ?: DEFAULT_FASTEST_INTERVAL,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationSettings.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationSettings.kt
@@ -45,11 +45,10 @@ internal class AndroidLocationSettings(
             private const val DEFAULT_DISTANCE_FILTER_METERS = 0.0
 
             fun parse(options: LocationSettingsOptions?): ParsedSettingsOptions {
-                val enableHighAccuracy = options?.enableHighAccuracy ?: true
                 return ParsedSettingsOptions(
                     androidAccuracy = resolveAndroidAccuracy(
                         options?.accuracy,
-                        enableHighAccuracy
+                        enableHighAccuracy = true
                     ),
                     intervalMillis = coercePositiveMillis(
                         options?.interval,

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
@@ -20,11 +20,7 @@ struct ParsedOptions {
     ) -> ParsedOptions {
         let timeout = options?.timeout ?? DEFAULT_TIMEOUT
         let maximumAge = options?.maximumAge ?? defaultMaximumAge
-        let enableHighAccuracy = options?.enableHighAccuracy ?? false
-        let accuracy = resolveAccuracy(
-            preset: options?.accuracy?.ios,
-            enableHighAccuracy: enableHighAccuracy
-        )
+        let accuracy = resolveAccuracy(preset: options?.accuracy?.ios)
         let distanceFilter = options?.distanceFilter ?? kCLDistanceFilterNone
         let useSignificantChanges = options?.useSignificantChanges ?? false
 
@@ -44,14 +40,9 @@ struct ParsedOptions {
         return parse(from: options, defaultMaximumAge: Double.infinity)
     }
 
-    private static func resolveAccuracy(
-        preset: IOSAccuracyPreset?,
-        enableHighAccuracy: Bool
-    ) -> CLLocationAccuracy {
+    private static func resolveAccuracy(preset: IOSAccuracyPreset?) -> CLLocationAccuracy {
         guard let preset else {
-            return enableHighAccuracy
-                ? kCLLocationAccuracyBest
-                : kCLLocationAccuracyHundredMeters
+            return kCLLocationAccuracyHundredMeters
         }
 
         switch preset {

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationRequestOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationRequestOptions.hpp
@@ -45,8 +45,6 @@ namespace margelo::nitro::nitrogeolocation {
       jni::local_ref<jni::JDouble> timeout = this->getFieldValue(fieldTimeout);
       static const auto fieldMaximumAge = clazz->getField<jni::JDouble>("maximumAge");
       jni::local_ref<jni::JDouble> maximumAge = this->getFieldValue(fieldMaximumAge);
-      static const auto fieldEnableHighAccuracy = clazz->getField<jni::JBoolean>("enableHighAccuracy");
-      jni::local_ref<jni::JBoolean> enableHighAccuracy = this->getFieldValue(fieldEnableHighAccuracy);
       static const auto fieldAccuracy = clazz->getField<JLocationAccuracyOptions>("accuracy");
       jni::local_ref<JLocationAccuracyOptions> accuracy = this->getFieldValue(fieldAccuracy);
       static const auto fieldInterval = clazz->getField<jni::JDouble>("interval");
@@ -76,7 +74,6 @@ namespace margelo::nitro::nitrogeolocation {
       return LocationRequestOptions(
         timeout != nullptr ? std::make_optional(timeout->value()) : std::nullopt,
         maximumAge != nullptr ? std::make_optional(maximumAge->value()) : std::nullopt,
-        enableHighAccuracy != nullptr ? std::make_optional(static_cast<bool>(enableHighAccuracy->value())) : std::nullopt,
         accuracy != nullptr ? std::make_optional(accuracy->toCpp()) : std::nullopt,
         interval != nullptr ? std::make_optional(interval->value()) : std::nullopt,
         fastestInterval != nullptr ? std::make_optional(fastestInterval->value()) : std::nullopt,
@@ -99,14 +96,13 @@ namespace margelo::nitro::nitrogeolocation {
      */
     [[maybe_unused]]
     static jni::local_ref<JLocationRequestOptions::javaobject> fromCpp(const LocationRequestOptions& value) {
-      using JSignature = JLocationRequestOptions(jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<JLocationAccuracyOptions>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JAndroidGranularity>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<JIOSActivityType>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
+      using JSignature = JLocationRequestOptions(jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JLocationAccuracyOptions>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<JAndroidGranularity>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<JIOSActivityType>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
         value.timeout.has_value() ? jni::JDouble::valueOf(value.timeout.value()) : nullptr,
         value.maximumAge.has_value() ? jni::JDouble::valueOf(value.maximumAge.value()) : nullptr,
-        value.enableHighAccuracy.has_value() ? jni::JBoolean::valueOf(value.enableHighAccuracy.value()) : nullptr,
         value.accuracy.has_value() ? JLocationAccuracyOptions::fromCpp(value.accuracy.value()) : nullptr,
         value.interval.has_value() ? jni::JDouble::valueOf(value.interval.value()) : nullptr,
         value.fastestInterval.has_value() ? jni::JDouble::valueOf(value.fastestInterval.value()) : nullptr,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationSettingsOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JLocationSettingsOptions.hpp
@@ -37,8 +37,6 @@ namespace margelo::nitro::nitrogeolocation {
     [[nodiscard]]
     LocationSettingsOptions toCpp() const {
       static const auto clazz = javaClassStatic();
-      static const auto fieldEnableHighAccuracy = clazz->getField<jni::JBoolean>("enableHighAccuracy");
-      jni::local_ref<jni::JBoolean> enableHighAccuracy = this->getFieldValue(fieldEnableHighAccuracy);
       static const auto fieldAccuracy = clazz->getField<JLocationAccuracyOptions>("accuracy");
       jni::local_ref<JLocationAccuracyOptions> accuracy = this->getFieldValue(fieldAccuracy);
       static const auto fieldInterval = clazz->getField<jni::JDouble>("interval");
@@ -52,7 +50,6 @@ namespace margelo::nitro::nitrogeolocation {
       static const auto fieldNeedBle = clazz->getField<jni::JBoolean>("needBle");
       jni::local_ref<jni::JBoolean> needBle = this->getFieldValue(fieldNeedBle);
       return LocationSettingsOptions(
-        enableHighAccuracy != nullptr ? std::make_optional(static_cast<bool>(enableHighAccuracy->value())) : std::nullopt,
         accuracy != nullptr ? std::make_optional(accuracy->toCpp()) : std::nullopt,
         interval != nullptr ? std::make_optional(interval->value()) : std::nullopt,
         fastestInterval != nullptr ? std::make_optional(fastestInterval->value()) : std::nullopt,
@@ -68,12 +65,11 @@ namespace margelo::nitro::nitrogeolocation {
      */
     [[maybe_unused]]
     static jni::local_ref<JLocationSettingsOptions::javaobject> fromCpp(const LocationSettingsOptions& value) {
-      using JSignature = JLocationSettingsOptions(jni::alias_ref<jni::JBoolean>, jni::alias_ref<JLocationAccuracyOptions>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
+      using JSignature = JLocationSettingsOptions(jni::alias_ref<JLocationAccuracyOptions>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
-        value.enableHighAccuracy.has_value() ? jni::JBoolean::valueOf(value.enableHighAccuracy.value()) : nullptr,
         value.accuracy.has_value() ? JLocationAccuracyOptions::fromCpp(value.accuracy.value()) : nullptr,
         value.interval.has_value() ? jni::JDouble::valueOf(value.interval.value()) : nullptr,
         value.fastestInterval.has_value() ? jni::JDouble::valueOf(value.fastestInterval.value()) : nullptr,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationRequestOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationRequestOptions.kt
@@ -26,9 +26,6 @@ data class LocationRequestOptions(
   val maximumAge: Double?,
   @DoNotStrip
   @Keep
-  val enableHighAccuracy: Boolean?,
-  @DoNotStrip
-  @Keep
   val accuracy: LocationAccuracyOptions?,
   @DoNotStrip
   @Keep
@@ -74,7 +71,6 @@ data class LocationRequestOptions(
     if (other !is LocationRequestOptions) return false
     return Objects.deepEquals(this.timeout, other.timeout)
       && Objects.deepEquals(this.maximumAge, other.maximumAge)
-      && Objects.deepEquals(this.enableHighAccuracy, other.enableHighAccuracy)
       && Objects.deepEquals(this.accuracy, other.accuracy)
       && Objects.deepEquals(this.interval, other.interval)
       && Objects.deepEquals(this.fastestInterval, other.fastestInterval)
@@ -94,7 +90,6 @@ data class LocationRequestOptions(
     return arrayOf<Any?>(
       timeout,
       maximumAge,
-      enableHighAccuracy,
       accuracy,
       interval,
       fastestInterval,
@@ -119,8 +114,8 @@ data class LocationRequestOptions(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(timeout: Double?, maximumAge: Double?, enableHighAccuracy: Boolean?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, granularity: AndroidGranularity?, waitForAccurateLocation: Boolean?, maxUpdateAge: Double?, maxUpdateDelay: Double?, maxUpdates: Double?, useSignificantChanges: Boolean?, activityType: IOSActivityType?, pausesLocationUpdatesAutomatically: Boolean?, showsBackgroundLocationIndicator: Boolean?): LocationRequestOptions {
-      return LocationRequestOptions(timeout, maximumAge, enableHighAccuracy, accuracy, interval, fastestInterval, distanceFilter, granularity, waitForAccurateLocation, maxUpdateAge, maxUpdateDelay, maxUpdates, useSignificantChanges, activityType, pausesLocationUpdatesAutomatically, showsBackgroundLocationIndicator)
+    private fun fromCpp(timeout: Double?, maximumAge: Double?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, granularity: AndroidGranularity?, waitForAccurateLocation: Boolean?, maxUpdateAge: Double?, maxUpdateDelay: Double?, maxUpdates: Double?, useSignificantChanges: Boolean?, activityType: IOSActivityType?, pausesLocationUpdatesAutomatically: Boolean?, showsBackgroundLocationIndicator: Boolean?): LocationRequestOptions {
+      return LocationRequestOptions(timeout, maximumAge, accuracy, interval, fastestInterval, distanceFilter, granularity, waitForAccurateLocation, maxUpdateAge, maxUpdateDelay, maxUpdates, useSignificantChanges, activityType, pausesLocationUpdatesAutomatically, showsBackgroundLocationIndicator)
     }
   }
 }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationSettingsOptions.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/LocationSettingsOptions.kt
@@ -20,9 +20,6 @@ import java.util.Objects
 data class LocationSettingsOptions(
   @DoNotStrip
   @Keep
-  val enableHighAccuracy: Boolean?,
-  @DoNotStrip
-  @Keep
   val accuracy: LocationAccuracyOptions?,
   @DoNotStrip
   @Keep
@@ -45,8 +42,7 @@ data class LocationSettingsOptions(
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is LocationSettingsOptions) return false
-    return Objects.deepEquals(this.enableHighAccuracy, other.enableHighAccuracy)
-      && Objects.deepEquals(this.accuracy, other.accuracy)
+    return Objects.deepEquals(this.accuracy, other.accuracy)
       && Objects.deepEquals(this.interval, other.interval)
       && Objects.deepEquals(this.fastestInterval, other.fastestInterval)
       && Objects.deepEquals(this.distanceFilter, other.distanceFilter)
@@ -56,7 +52,6 @@ data class LocationSettingsOptions(
 
   override fun hashCode(): Int {
     return arrayOf<Any?>(
-      enableHighAccuracy,
       accuracy,
       interval,
       fastestInterval,
@@ -74,8 +69,8 @@ data class LocationSettingsOptions(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(enableHighAccuracy: Boolean?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, alwaysShow: Boolean?, needBle: Boolean?): LocationSettingsOptions {
-      return LocationSettingsOptions(enableHighAccuracy, accuracy, interval, fastestInterval, distanceFilter, alwaysShow, needBle)
+    private fun fromCpp(accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, alwaysShow: Boolean?, needBle: Boolean?): LocationSettingsOptions {
+      return LocationSettingsOptions(accuracy, interval, fastestInterval, distanceFilter, alwaysShow, needBle)
     }
   }
 }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationRequestOptions.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationRequestOptions.swift
@@ -18,7 +18,7 @@ public extension LocationRequestOptions {
   /**
    * Create a new instance of `LocationRequestOptions`.
    */
-  init(timeout: Double?, maximumAge: Double?, enableHighAccuracy: Bool?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, granularity: AndroidGranularity?, waitForAccurateLocation: Bool?, maxUpdateAge: Double?, maxUpdateDelay: Double?, maxUpdates: Double?, useSignificantChanges: Bool?, activityType: IOSActivityType?, pausesLocationUpdatesAutomatically: Bool?, showsBackgroundLocationIndicator: Bool?) {
+  init(timeout: Double?, maximumAge: Double?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, granularity: AndroidGranularity?, waitForAccurateLocation: Bool?, maxUpdateAge: Double?, maxUpdateDelay: Double?, maxUpdates: Double?, useSignificantChanges: Bool?, activityType: IOSActivityType?, pausesLocationUpdatesAutomatically: Bool?, showsBackgroundLocationIndicator: Bool?) {
     self.init({ () -> bridge.std__optional_double_ in
       if let __unwrappedValue = timeout {
         return bridge.create_std__optional_double_(__unwrappedValue)
@@ -28,12 +28,6 @@ public extension LocationRequestOptions {
     }(), { () -> bridge.std__optional_double_ in
       if let __unwrappedValue = maximumAge {
         return bridge.create_std__optional_double_(__unwrappedValue)
-      } else {
-        return .init()
-      }
-    }(), { () -> bridge.std__optional_bool_ in
-      if let __unwrappedValue = enableHighAccuracy {
-        return bridge.create_std__optional_bool_(__unwrappedValue)
       } else {
         return .init()
       }
@@ -129,7 +123,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var maximumAge: Double? {
     return { () -> Double? in
@@ -141,24 +135,12 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
-  @inline(__always)
-  var enableHighAccuracy: Bool? {
-    return { () -> Bool? in
-      if bridge.has_value_std__optional_bool_(self.__enableHighAccuracy) {
-        let __unwrapped = bridge.get_std__optional_bool_(self.__enableHighAccuracy)
-        return __unwrapped
-      } else {
-        return nil
-      }
-    }()
-  }
-  
+
   @inline(__always)
   var accuracy: LocationAccuracyOptions? {
     return self.__accuracy.value
   }
-  
+
   @inline(__always)
   var interval: Double? {
     return { () -> Double? in
@@ -170,7 +152,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var fastestInterval: Double? {
     return { () -> Double? in
@@ -182,7 +164,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var distanceFilter: Double? {
     return { () -> Double? in
@@ -194,12 +176,12 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var granularity: AndroidGranularity? {
     return self.__granularity.value
   }
-  
+
   @inline(__always)
   var waitForAccurateLocation: Bool? {
     return { () -> Bool? in
@@ -211,7 +193,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var maxUpdateAge: Double? {
     return { () -> Double? in
@@ -223,7 +205,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var maxUpdateDelay: Double? {
     return { () -> Double? in
@@ -235,7 +217,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var maxUpdates: Double? {
     return { () -> Double? in
@@ -247,7 +229,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var useSignificantChanges: Bool? {
     return { () -> Bool? in
@@ -259,12 +241,12 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var activityType: IOSActivityType? {
     return self.__activityType.value
   }
-  
+
   @inline(__always)
   var pausesLocationUpdatesAutomatically: Bool? {
     return { () -> Bool? in
@@ -276,7 +258,7 @@ public extension LocationRequestOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var showsBackgroundLocationIndicator: Bool? {
     return { () -> Bool? in

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationSettingsOptions.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/LocationSettingsOptions.swift
@@ -18,14 +18,8 @@ public extension LocationSettingsOptions {
   /**
    * Create a new instance of `LocationSettingsOptions`.
    */
-  init(enableHighAccuracy: Bool?, accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, alwaysShow: Bool?, needBle: Bool?) {
-    self.init({ () -> bridge.std__optional_bool_ in
-      if let __unwrappedValue = enableHighAccuracy {
-        return bridge.create_std__optional_bool_(__unwrappedValue)
-      } else {
-        return .init()
-      }
-    }(), { () -> bridge.std__optional_LocationAccuracyOptions_ in
+  init(accuracy: LocationAccuracyOptions?, interval: Double?, fastestInterval: Double?, distanceFilter: Double?, alwaysShow: Bool?, needBle: Bool?) {
+    self.init({ () -> bridge.std__optional_LocationAccuracyOptions_ in
       if let __unwrappedValue = accuracy {
         return bridge.create_std__optional_LocationAccuracyOptions_(__unwrappedValue)
       } else {
@@ -65,22 +59,10 @@ public extension LocationSettingsOptions {
   }
 
   @inline(__always)
-  var enableHighAccuracy: Bool? {
-    return { () -> Bool? in
-      if bridge.has_value_std__optional_bool_(self.__enableHighAccuracy) {
-        let __unwrapped = bridge.get_std__optional_bool_(self.__enableHighAccuracy)
-        return __unwrapped
-      } else {
-        return nil
-      }
-    }()
-  }
-  
-  @inline(__always)
   var accuracy: LocationAccuracyOptions? {
     return self.__accuracy.value
   }
-  
+
   @inline(__always)
   var interval: Double? {
     return { () -> Double? in
@@ -92,7 +74,7 @@ public extension LocationSettingsOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var fastestInterval: Double? {
     return { () -> Double? in
@@ -104,7 +86,7 @@ public extension LocationSettingsOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var distanceFilter: Double? {
     return { () -> Double? in
@@ -116,7 +98,7 @@ public extension LocationSettingsOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var alwaysShow: Bool? {
     return { () -> Bool? in
@@ -128,7 +110,7 @@ public extension LocationSettingsOptions {
       }
     }()
   }
-  
+
   @inline(__always)
   var needBle: Bool? {
     return { () -> Bool? in

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/LocationRequestOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/LocationRequestOptions.hpp
@@ -49,7 +49,6 @@ namespace margelo::nitro::nitrogeolocation {
   public:
     std::optional<double> timeout     SWIFT_PRIVATE;
     std::optional<double> maximumAge     SWIFT_PRIVATE;
-    std::optional<bool> enableHighAccuracy     SWIFT_PRIVATE;
     std::optional<LocationAccuracyOptions> accuracy     SWIFT_PRIVATE;
     std::optional<double> interval     SWIFT_PRIVATE;
     std::optional<double> fastestInterval     SWIFT_PRIVATE;
@@ -66,7 +65,7 @@ namespace margelo::nitro::nitrogeolocation {
 
   public:
     LocationRequestOptions() = default;
-    explicit LocationRequestOptions(std::optional<double> timeout, std::optional<double> maximumAge, std::optional<bool> enableHighAccuracy, std::optional<LocationAccuracyOptions> accuracy, std::optional<double> interval, std::optional<double> fastestInterval, std::optional<double> distanceFilter, std::optional<AndroidGranularity> granularity, std::optional<bool> waitForAccurateLocation, std::optional<double> maxUpdateAge, std::optional<double> maxUpdateDelay, std::optional<double> maxUpdates, std::optional<bool> useSignificantChanges, std::optional<IOSActivityType> activityType, std::optional<bool> pausesLocationUpdatesAutomatically, std::optional<bool> showsBackgroundLocationIndicator): timeout(timeout), maximumAge(maximumAge), enableHighAccuracy(enableHighAccuracy), accuracy(accuracy), interval(interval), fastestInterval(fastestInterval), distanceFilter(distanceFilter), granularity(granularity), waitForAccurateLocation(waitForAccurateLocation), maxUpdateAge(maxUpdateAge), maxUpdateDelay(maxUpdateDelay), maxUpdates(maxUpdates), useSignificantChanges(useSignificantChanges), activityType(activityType), pausesLocationUpdatesAutomatically(pausesLocationUpdatesAutomatically), showsBackgroundLocationIndicator(showsBackgroundLocationIndicator) {}
+    explicit LocationRequestOptions(std::optional<double> timeout, std::optional<double> maximumAge, std::optional<LocationAccuracyOptions> accuracy, std::optional<double> interval, std::optional<double> fastestInterval, std::optional<double> distanceFilter, std::optional<AndroidGranularity> granularity, std::optional<bool> waitForAccurateLocation, std::optional<double> maxUpdateAge, std::optional<double> maxUpdateDelay, std::optional<double> maxUpdates, std::optional<bool> useSignificantChanges, std::optional<IOSActivityType> activityType, std::optional<bool> pausesLocationUpdatesAutomatically, std::optional<bool> showsBackgroundLocationIndicator): timeout(timeout), maximumAge(maximumAge), accuracy(accuracy), interval(interval), fastestInterval(fastestInterval), distanceFilter(distanceFilter), granularity(granularity), waitForAccurateLocation(waitForAccurateLocation), maxUpdateAge(maxUpdateAge), maxUpdateDelay(maxUpdateDelay), maxUpdates(maxUpdates), useSignificantChanges(useSignificantChanges), activityType(activityType), pausesLocationUpdatesAutomatically(pausesLocationUpdatesAutomatically), showsBackgroundLocationIndicator(showsBackgroundLocationIndicator) {}
 
   public:
     friend bool operator==(const LocationRequestOptions& lhs, const LocationRequestOptions& rhs) = default;
@@ -84,7 +83,6 @@ namespace margelo::nitro {
       return margelo::nitro::nitrogeolocation::LocationRequestOptions(
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "timeout"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maximumAge"))),
-        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy"))),
         JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accuracy"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "interval"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval"))),
@@ -104,7 +102,6 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "timeout"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.timeout));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "maximumAge"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.maximumAge));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.enableHighAccuracy));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "accuracy"), JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::toJSI(runtime, arg.accuracy));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "interval"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.interval));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.fastestInterval));
@@ -130,7 +127,6 @@ namespace margelo::nitro {
       }
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "timeout")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maximumAge")))) return false;
-      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accuracy")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "interval")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval")))) return false;

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/LocationSettingsOptions.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/LocationSettingsOptions.hpp
@@ -31,8 +31,8 @@
 // Forward declaration of `LocationAccuracyOptions` to properly resolve imports.
 namespace margelo::nitro::nitrogeolocation { struct LocationAccuracyOptions; }
 
-#include <optional>
 #include "LocationAccuracyOptions.hpp"
+#include <optional>
 
 namespace margelo::nitro::nitrogeolocation {
 
@@ -41,7 +41,6 @@ namespace margelo::nitro::nitrogeolocation {
    */
   struct LocationSettingsOptions final {
   public:
-    std::optional<bool> enableHighAccuracy     SWIFT_PRIVATE;
     std::optional<LocationAccuracyOptions> accuracy     SWIFT_PRIVATE;
     std::optional<double> interval     SWIFT_PRIVATE;
     std::optional<double> fastestInterval     SWIFT_PRIVATE;
@@ -51,7 +50,7 @@ namespace margelo::nitro::nitrogeolocation {
 
   public:
     LocationSettingsOptions() = default;
-    explicit LocationSettingsOptions(std::optional<bool> enableHighAccuracy, std::optional<LocationAccuracyOptions> accuracy, std::optional<double> interval, std::optional<double> fastestInterval, std::optional<double> distanceFilter, std::optional<bool> alwaysShow, std::optional<bool> needBle): enableHighAccuracy(enableHighAccuracy), accuracy(accuracy), interval(interval), fastestInterval(fastestInterval), distanceFilter(distanceFilter), alwaysShow(alwaysShow), needBle(needBle) {}
+    explicit LocationSettingsOptions(std::optional<LocationAccuracyOptions> accuracy, std::optional<double> interval, std::optional<double> fastestInterval, std::optional<double> distanceFilter, std::optional<bool> alwaysShow, std::optional<bool> needBle): accuracy(accuracy), interval(interval), fastestInterval(fastestInterval), distanceFilter(distanceFilter), alwaysShow(alwaysShow), needBle(needBle) {}
 
   public:
     friend bool operator==(const LocationSettingsOptions& lhs, const LocationSettingsOptions& rhs) = default;
@@ -67,7 +66,6 @@ namespace margelo::nitro {
     static inline margelo::nitro::nitrogeolocation::LocationSettingsOptions fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::nitrogeolocation::LocationSettingsOptions(
-        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy"))),
         JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accuracy"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "interval"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval"))),
@@ -78,7 +76,6 @@ namespace margelo::nitro {
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitrogeolocation::LocationSettingsOptions& arg) {
       jsi::Object obj(runtime);
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.enableHighAccuracy));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "accuracy"), JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::toJSI(runtime, arg.accuracy));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "interval"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.interval));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.fastestInterval));
@@ -95,7 +92,6 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
-      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "enableHighAccuracy")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationAccuracyOptions>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accuracy")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "interval")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fastestInterval")))) return false;

--- a/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
@@ -83,22 +83,7 @@ export interface LocationRequestOptions {
   maximumAge?: number;
 
   /**
-   * Enable high accuracy mode (GPS).
-   *
-   * @deprecated Since v1.2, use `accuracy` for explicit platform-native
-   * presets. This remains available for v1 compatibility and is planned for
-   * removal from the Modern API in v2.
-   */
-  enableHighAccuracy?: boolean;
-
-  /**
    * Platform-specific accuracy preset.
-   *
-   * Available since v1.2.
-   *
-   * When provided, this takes precedence over `enableHighAccuracy` on the
-   * matching platform while keeping `enableHighAccuracy` available for the
-   * legacy true/false contract.
    */
   accuracy?: LocationAccuracyOptions;
 
@@ -186,20 +171,7 @@ export interface LocationRequestOptions {
  */
 export interface LocationSettingsOptions {
   /**
-   * Request high accuracy Android location settings.
-   * Defaults to true because this API is primarily used before user-facing
-   * precise location flows.
-   *
-   * @deprecated Since v1.2, use `accuracy.android` for explicit Android
-   * settings priorities. This remains available for v1 compatibility and is
-   * planned for removal from the Modern API in v2.
-   */
-  enableHighAccuracy?: boolean;
-
-  /**
    * Platform-specific accuracy preset for settings checks.
-   *
-   * Available since v1.2.
    *
    * Android uses `accuracy.android` to map to the native location request
    * priority. iOS ignores this option because iOS has no equivalent settings

--- a/packages/react-native-nitro-geolocation/src/utils/config.test.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { mergeConfigurations } from "./config";
+
+describe("mergeConfigurations", () => {
+  it("uses low-power defaults when there are no active requests", () => {
+    expect(mergeConfigurations([])).toEqual({
+      bestAccuracy: "low",
+      smallestDistanceFilter: 0
+    });
+  });
+
+  it("preserves a medium-only accuracy request", () => {
+    expect(
+      mergeConfigurations([{ accuracy: "medium", distanceFilter: 25 }])
+    ).toEqual({
+      bestAccuracy: "medium",
+      smallestDistanceFilter: 25
+    });
+  });
+
+  it("combines the highest accuracy with the smallest distance filter", () => {
+    expect(
+      mergeConfigurations([
+        { accuracy: "low", distanceFilter: 100 },
+        { accuracy: "high", distanceFilter: 50 },
+        { accuracy: "medium", distanceFilter: 10 }
+      ])
+    ).toEqual({
+      bestAccuracy: "high",
+      smallestDistanceFilter: 10
+    });
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/utils/config.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/config.ts
@@ -2,8 +2,8 @@
  * Represents a location request with its configuration options.
  */
 export interface LocationRequest {
-  /** Whether high accuracy mode is enabled */
-  enableHighAccuracy: boolean;
+  /** Explicit accuracy level requested by the caller. */
+  accuracy: AccuracyLevel;
   /** Minimum distance change (in meters) for updates */
   distanceFilter: number;
 }
@@ -46,9 +46,9 @@ export interface MergedConfiguration {
  * @example
  * ```ts
  * const requests = [
- *   { enableHighAccuracy: false, distanceFilter: 100 },
- *   { enableHighAccuracy: true, distanceFilter: 10 },
- *   { enableHighAccuracy: false, distanceFilter: 50 }
+ *   { accuracy: "low", distanceFilter: 100 },
+ *   { accuracy: "high", distanceFilter: 10 },
+ *   { accuracy: "medium", distanceFilter: 50 }
  * ];
  *
  * const merged = mergeConfigurations(requests);
@@ -71,9 +71,8 @@ export function mergeConfigurations(
 
   // Iterate through all requests to find the most demanding settings
   for (const request of requests) {
-    // If any request needs high accuracy, use high accuracy
-    if (request.enableHighAccuracy) {
-      bestAccuracy = "high";
+    if (accuracyRank(request.accuracy) > accuracyRank(bestAccuracy)) {
+      bestAccuracy = request.accuracy;
     }
 
     // Use the smallest distance filter
@@ -90,4 +89,15 @@ export function mergeConfigurations(
         ? 0
         : smallestDistanceFilter
   };
+}
+
+function accuracyRank(accuracy: AccuracyLevel): number {
+  switch (accuracy) {
+    case "low":
+      return 0;
+    case "medium":
+      return 1;
+    case "high":
+      return 2;
+  }
 }

--- a/packages/react-native-nitro-geolocation/src/utils/provider.test.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/provider.test.ts
@@ -2,8 +2,29 @@ import { describe, expect, it } from "vitest";
 import {
   getAndroidProviderOrder,
   resolveAndroidAccuracy,
+  selectProvider,
   selectProviderForAndroidPermissions
 } from "./provider";
+
+describe("selectProvider", () => {
+  it("prefers GPS for high accuracy and falls back to network", () => {
+    expect(selectProvider("high", true, true)).toBe("gps");
+    expect(selectProvider("high", false, true)).toBe("network");
+  });
+
+  it("uses only providers compatible with explicit lower-power presets", () => {
+    expect(selectProvider("balanced", true, true)).toBe("network");
+    expect(selectProvider("balanced", true, false)).toBeNull();
+    expect(selectProvider("low", true, false, true)).toBe("passive");
+    expect(selectProvider("passive", true, true, true)).toBe("passive");
+  });
+
+  it("returns null when no compatible provider is available", () => {
+    expect(selectProvider("high", false, false)).toBeNull();
+    expect(selectProvider("low", true, false, false)).toBeNull();
+    expect(selectProvider("passive", true, true, false)).toBeNull();
+  });
+});
 
 describe("resolveAndroidAccuracy", () => {
   it("keeps enableHighAccuracy as the legacy default", () => {

--- a/packages/react-native-nitro-geolocation/src/utils/provider.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/provider.ts
@@ -26,60 +26,53 @@ export interface AndroidProviderSelectionInput {
 }
 
 /**
- * Selects the best available location provider based on user preferences
- * and provider availability.
+ * Selects the best available location provider for an explicit Android
+ * accuracy preset and the providers currently available on the device.
  *
  * This function implements a fallback strategy:
- * - If high accuracy is requested, prefer GPS, fallback to Network
- * - If low power is preferred, prefer Network, fallback to GPS
+ * - High accuracy prefers GPS and falls back to Network
+ * - Balanced accuracy uses Network
+ * - Low accuracy prefers Network and falls back to Passive
+ * - Passive accuracy uses Passive only
  *
- * @param enableHighAccuracy - Whether high accuracy mode is requested
+ * @param accuracy - The Android accuracy preset requested by the caller
  * @param gpsAvailable - Whether GPS provider is available and enabled
  * @param networkAvailable - Whether Network provider is available and enabled
+ * @param passiveAvailable - Whether Passive provider is available and enabled
  * @returns The selected provider, or null if no providers are available
  *
  * @example
  * ```ts
- * // High accuracy mode with both providers available
- * selectProvider(true, true, true); // 'gps'
+ * // Turn-by-turn navigation with both providers available
+ * selectProvider('high', true, true); // 'gps'
  *
- * // High accuracy mode but GPS is disabled
- * selectProvider(true, false, true); // 'network'
+ * // Nearby search prefers the network provider
+ * selectProvider('balanced', true, true); // 'network'
  *
- * // Low power mode with both providers available
- * selectProvider(false, true, true); // 'network'
+ * // A low-power refresh can fall back to the passive provider
+ * selectProvider('low', true, false, true); // 'passive'
  *
- * // No providers available
- * selectProvider(true, false, false); // null
+ * // No compatible providers are available
+ * selectProvider('high', false, false); // null
  * ```
  */
 export function selectProvider(
-  enableHighAccuracy: boolean,
+  accuracy: AndroidAccuracyPreset,
   gpsAvailable: boolean,
-  networkAvailable: boolean
+  networkAvailable: boolean,
+  passiveAvailable = false
 ): Provider {
-  // Determine preferred and fallback providers based on accuracy requirement
-  const preferredProvider = enableHighAccuracy ? "gps" : "network";
-  const fallbackProvider = enableHighAccuracy ? "network" : "gps";
+  const providers = {
+    gps: gpsAvailable,
+    network: networkAvailable,
+    passive: passiveAvailable
+  };
+  const providerOrder = getAndroidProviderOrder({
+    mode: accuracy,
+    explicitPreset: accuracy
+  });
 
-  // Check if preferred provider is available
-  const isPreferredAvailable =
-    preferredProvider === "gps" ? gpsAvailable : networkAvailable;
-
-  // Check if fallback provider is available
-  const isFallbackAvailable =
-    fallbackProvider === "gps" ? gpsAvailable : networkAvailable;
-
-  // Return the best available provider
-  if (isPreferredAvailable) {
-    return preferredProvider;
-  }
-
-  if (isFallbackAvailable) {
-    return fallbackProvider;
-  }
-
-  return null;
+  return providerOrder.find((provider) => providers[provider]) ?? null;
 }
 
 export function resolveAndroidAccuracy(

--- a/packages/react-native-nitro-geolocation/src/web/browser.ts
+++ b/packages/react-native-nitro-geolocation/src/web/browser.ts
@@ -79,9 +79,7 @@ export function toPositionOptions(
 
   return {
     enableHighAccuracy:
-      androidAccuracy !== undefined
-        ? androidAccuracy === "high"
-        : options?.enableHighAccuracy,
+      androidAccuracy !== undefined ? androidAccuracy === "high" : undefined,
     timeout: options?.timeout ?? defaultTimeoutMs,
     maximumAge: options?.maximumAge ?? 0
   };

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -63,7 +63,10 @@ describe("web Modern API", () => {
     });
 
     await expect(
-      getCurrentPosition({ enableHighAccuracy: true, timeout: 1234 })
+      getCurrentPosition({
+        accuracy: { android: "high" },
+        timeout: 1234
+      })
     ).resolves.toEqual({
       coords: {
         latitude: 37.5665,
@@ -104,7 +107,7 @@ describe("web Modern API", () => {
     });
   });
 
-  it("lets explicit Android accuracy override legacy enableHighAccuracy", async () => {
+  it("maps Modern Android accuracy presets to browser accuracy", async () => {
     const getCurrentPositionMock = vi.fn((success) => {
       success(createPosition());
     });
@@ -117,7 +120,6 @@ describe("web Modern API", () => {
     });
 
     await getCurrentPosition({
-      enableHighAccuracy: false,
       accuracy: { android: "high" }
     });
     expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
@@ -125,7 +127,6 @@ describe("web Modern API", () => {
     });
 
     await getCurrentPosition({
-      enableHighAccuracy: true,
       accuracy: { android: "low" }
     });
     expect(getCurrentPositionMock.mock.calls[1][2]).toMatchObject({


### PR DESCRIPTION
## Summary
- remove enableHighAccuracy from Modern LocationRequestOptions and LocationSettingsOptions
- keep enableHighAccuracy on the /compat surface and generated compat bridge
- migrate native, web, example, and advanced utility behavior to explicit accuracy presets
- make the accuracy screen describe natural navigation, nearby-search, and weather-refresh use cases
- make the public selectProvider helper accept an Android accuracy preset instead of the legacy boolean

## Red to green
- red: the consumer contract produced TS2578 while Modern request/settings still accepted enableHighAccuracy
- red: the provider contract rejected "high" and still accepted the legacy boolean; lower-power provider tests also exposed the old GPS fallback
- green: Modern request/settings, merge utilities, and provider selection reject the legacy field while /compat still accepts it
- add unit coverage for configuration merging and high/balanced/low/passive provider selection

## Runtime verification
- Android Release build/install plus debug and release native unit tasks
- iOS Release build/install on iPhone 17 Pro simulator
- Android Native E2E: 22 location-enabled plus 1 location-disabled flow
- iOS Native E2E: 20 flows
- Android WebView E2E: success, denied, unavailable
- iOS WebView E2E: success, denied

## Static verification
- 58 unit tests
- package and example TypeScript checks including no-unused consumer contract
- format, lint, deadcode, production deadcode, pack, source-line, and all workspace builds

Independent PR against main. Roadmap issue: #98, second v2 checkbox.
