### PR TITLE
feat: split last-known position cache APIs

### DIFF
--- a/.changeset/fresh-dogs-remember.md
+++ b/.changeset/fresh-dogs-remember.md
@@ -1,0 +1,8 @@
+---
+"react-native-nitro-geolocation": major
+---
+
+Split last-known position reads into synchronous module-cache and asynchronous
+platform-cache APIs. `getLastKnownPosition()` now returns the module cache
+immediately, while `getLastKnownPositionAsync(options)` queries cached native or
+browser sources without starting a fresh location request.

--- a/.changeset/fresh-dogs-remember.md
+++ b/.changeset/fresh-dogs-remember.md
@@ -4,5 +4,6 @@
 
 Split last-known position reads into synchronous module-cache and asynchronous
 platform-cache APIs. `getLastKnownPosition()` now returns the module cache
-immediately, while `getLastKnownPositionAsync(options)` queries cached native or
-browser sources without starting a fresh location request.
+immediately, while `getLastKnownPositionAsync(options)` queries cache-only native
+sources or filters observed Web and DevTools caches without starting a fresh
+location request.

--- a/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
+++ b/examples/v0.81.1/.maestro/ios-release-options-bridge.yaml
@@ -82,7 +82,7 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "ios-release-options-bridge-maximum-age-zero-result"
 - assertVisible:
-    text: ".*POSITION_UNAVAILABLE.*"
+    text: ".*returned undefined for stale cache.*"
 
 - tapOn:
     id: "e2e-action-ios-release-options-bridge-run-heading-filter-button"

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# getLastKnownPosition(): prove cached success plus stale-cache and permission-denied rejections.
+# Sync/async last-known APIs: prove cold/seeded module cache plus platform cache edges.
 
 - launchApp:
     clearState: true
@@ -45,12 +45,24 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Cached location API contract with rejection paths"
+    visible: "Synchronous module cache and asynchronous platform cache contracts"
     timeout: 10000
 
 - setLocation:
     latitude: 37.5665
     longitude: 126.978
+
+- tapOn:
+    id: "e2e-action-last-known-position-run-cold-button"
+
+- extendedWaitUntil:
+    visible: "Cold module cache: passed"
+    timeout: 10000
+
+- assertVisible:
+    id: "last-known-position-cold-result"
+- assertVisible:
+    text: ".*returned undefined without querying native location sources.*"
 
 - tapOn:
     id: "e2e-action-last-known-position-run-stale-button"
@@ -62,9 +74,7 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "last-known-position-stale-result"
 - assertVisible:
-    text: ".*POSITION_UNAVAILABLE.*"
-- assertVisible:
-    text: ".*without starting a fresh request.*"
+    text: ".*returned undefined without starting a fresh request.*"
 
 - tapOn:
     id: "e2e-action-last-known-position-run-system-button"
@@ -84,7 +94,7 @@ appId: nitrogeolocation.example
 - assertVisible:
     text: ".*37.566500, 126.978000.*"
 - assertVisible:
-    text: ".*timestamp delta.*cache read.*ms.*"
+    text: ".*sync module cache.*timestamp delta.*cache read.*ms.*"
 
 - stopApp
 
@@ -130,7 +140,7 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Cached location API contract with rejection paths"
+    visible: "Synchronous module cache and asynchronous platform cache contracts"
     timeout: 10000
 
 - tapOn:

--- a/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import {
   LocationErrorCode,
   getCurrentPosition,
-  getLastKnownPosition
+  getLastKnownPosition,
+  getLastKnownPositionAsync
 } from "react-native-nitro-geolocation";
 import {
   PermissionStatusBlock,
@@ -12,7 +13,6 @@ import {
   ScenarioSection,
   assertFixtureCoordinates,
   assertLocationErrorCode,
-  captureLocationError,
   createScenarioResults,
   getDisplayErrorMessage,
   runWithNativeGeolocation,
@@ -25,6 +25,7 @@ const SYSTEM_CACHE_RETRY_TIMEOUT_MS = 10000;
 const SYSTEM_CACHE_RETRY_INTERVAL_MS = 500;
 
 const initialResults = createScenarioResults([
+  "cold",
   "stale",
   "system",
   "cache",
@@ -43,61 +44,60 @@ export default function LastKnownPositionScreen() {
 
   const readSystemCacheOnly = async () => {
     const startedAt = Date.now();
-    let lastUnavailableMessage = "No cached location available.";
 
     while (Date.now() - startedAt <= SYSTEM_CACHE_RETRY_TIMEOUT_MS) {
-      try {
-        const position = await runWithNativeGeolocation(() =>
-          getLastKnownPosition()
-        );
+      const position = await runWithNativeGeolocation(() =>
+        getLastKnownPositionAsync()
+      );
+      if (position) {
         return {
           elapsedMs: Date.now() - startedAt,
           position
         };
-      } catch (error) {
-        const locationError = captureLocationError(error);
-        if (locationError.code !== LocationErrorCode.POSITION_UNAVAILABLE) {
-          throw error;
-        }
-
-        lastUnavailableMessage = locationError.message;
-        await sleep(SYSTEM_CACHE_RETRY_INTERVAL_MS);
       }
+
+      await sleep(SYSTEM_CACHE_RETRY_INTERVAL_MS);
     }
 
-    throw new Error(lastUnavailableMessage);
+    throw new Error("No platform cached location became available.");
+  };
+
+  const runColdModuleCacheScenario = () => {
+    setResult("cold", {
+      status: "running",
+      message: "Reading the in-memory cache before requesting a location"
+    });
+
+    const cached = getLastKnownPosition();
+    setResult("cold", {
+      status: cached ? "failed" : "passed",
+      message: cached
+        ? "Cold module cache unexpectedly contained a position."
+        : "Cold module cache returned undefined without querying native location sources."
+    });
   };
 
   const runStaleCacheScenario = async () => {
     setResult("stale", {
       status: "running",
-      message: "Rejecting cached reads that cannot satisfy maximumAge"
+      message: "Filtering out platform cache that cannot satisfy maximumAge"
     });
 
     try {
-      await runWithNativeGeolocation(() =>
-        getLastKnownPosition({ maximumAge: 0 })
+      const cached = await runWithNativeGeolocation(() =>
+        getLastKnownPositionAsync({ maximumAge: 0 })
       );
       setResult("stale", {
-        status: "failed",
-        message: "Stale cache filter unexpectedly resolved."
+        status: cached ? "failed" : "passed",
+        message: cached
+          ? "Stale cache filter unexpectedly returned a position."
+          : "Stale or empty platform cache returned undefined without starting a fresh request."
       });
     } catch (error) {
-      try {
-        const locationError = assertLocationErrorCode(
-          error,
-          LocationErrorCode.POSITION_UNAVAILABLE
-        );
-        setResult("stale", {
-          status: "passed",
-          message: `${locationError.name}: stale or empty cache was rejected without starting a fresh request.`
-        });
-      } catch (assertionError) {
-        setResult("stale", {
-          status: "failed",
-          message: getDisplayErrorMessage(assertionError)
-        });
-      }
+      setResult("stale", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
     }
   };
 
@@ -154,10 +154,11 @@ export default function LastKnownPositionScreen() {
       );
       const freshCoordinates = assertFixtureCoordinates(fresh);
       const startedAt = Date.now();
-      const cached = await runWithNativeGeolocation(() =>
-        getLastKnownPosition()
-      );
+      const cached = getLastKnownPosition();
       const elapsedMs = Date.now() - startedAt;
+      if (!cached) {
+        throw new Error("Seeded module cache unexpectedly returned undefined.");
+      }
       const cachedCoordinates = assertFixtureCoordinates(cached);
       const timestampDelta = Math.abs(cached.timestamp - fresh.timestamp);
 
@@ -175,7 +176,7 @@ export default function LastKnownPositionScreen() {
 
       setResult("cache", {
         status: "passed",
-        message: `Seeded ${freshCoordinates}; cached ${cachedCoordinates}; timestamp delta ${timestampDelta}ms; cache read ${elapsedMs}ms.`
+        message: `Seeded ${freshCoordinates}; sync module cache ${cachedCoordinates}; timestamp delta ${timestampDelta}ms; cache read ${elapsedMs}ms.`
       });
     } catch (error) {
       setResult("cache", {
@@ -194,7 +195,7 @@ export default function LastKnownPositionScreen() {
     });
 
     try {
-      await runWithNativeGeolocation(() => getLastKnownPosition());
+      await runWithNativeGeolocation(() => getLastKnownPositionAsync());
       setResult("denied", {
         status: "failed",
         message: "Permission-denied cached read unexpectedly resolved."
@@ -224,13 +225,28 @@ export default function LastKnownPositionScreen() {
     <ScenarioScreen
       prefix={PREFIX}
       title="Last Known Position"
-      subtitle="Cached location API contract with rejection paths"
+      subtitle="Synchronous module cache and asynchronous platform cache contracts"
     >
       <ScenarioSection index={1} title="Permission">
         <PermissionStatusBlock prefix={PREFIX} status={permissionStatus} />
       </ScenarioSection>
 
-      <ScenarioSection index={2} title="Stale Cache Rejection" divided>
+      <ScenarioSection index={2} title="Cold Module Cache" divided>
+        <ScenarioButton
+          title="Read Cold Module Cache"
+          onPress={runColdModuleCacheScenario}
+          color="#546E7A"
+          testID={`${PREFIX}-run-cold-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="cold"
+          label="Cold module cache"
+          result={results.cold}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={3} title="Stale Platform Cache" divided>
         <ScenarioButton
           title="Reject Stale Cache"
           onPress={runStaleCacheScenario}
@@ -245,7 +261,7 @@ export default function LastKnownPositionScreen() {
         />
       </ScenarioSection>
 
-      <ScenarioSection index={3} title="System Cache Read" divided>
+      <ScenarioSection index={4} title="Platform Cache Read" divided>
         <ScenarioButton
           title="Read System Cache"
           onPress={runSystemCacheReadScenario}
@@ -260,7 +276,7 @@ export default function LastKnownPositionScreen() {
         />
       </ScenarioSection>
 
-      <ScenarioSection index={4} title="Seeded Cache Read" divided>
+      <ScenarioSection index={5} title="Seeded Module Cache Read" divided>
         <ScenarioButton
           title="Seed And Read Cache"
           onPress={runCacheReadScenario}
@@ -274,7 +290,7 @@ export default function LastKnownPositionScreen() {
         />
       </ScenarioSection>
 
-      <ScenarioSection index={5} title="Permission Denied" divided>
+      <ScenarioSection index={6} title="Permission Denied" divided>
         <ScenarioButton
           title="Run Denied Cache Read"
           onPress={runPermissionDeniedScenario}

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/androidRequestOptions.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/androidRequestOptions.ts
@@ -1,14 +1,11 @@
 import {
   LocationErrorCode,
   getCurrentPosition,
-  getLastKnownPosition,
+  getLastKnownPositionAsync,
   unwatch,
   watchPosition
 } from "react-native-nitro-geolocation";
-import type {
-  GeolocationResponse,
-  LocationRequestOptions
-} from "react-native-nitro-geolocation";
+import type { LocationRequestOptions } from "react-native-nitro-geolocation";
 import { usePermissionStatus } from "../hooks/usePermissionStatus";
 import { useScenarioResults } from "../hooks/useScenarioResults";
 import { assertFixtureCoordinates } from "../utils/locationAssertions";
@@ -163,21 +160,16 @@ export const useAndroidRequestOptionsScenario = () => {
         })
       );
 
-      let coarseCachePosition: GeolocationResponse;
-      try {
-        coarseCachePosition = await runWithNativeGeolocation(() =>
-          getLastKnownPosition({
-            granularity: "coarse"
-          })
-        );
-      } catch (error) {
-        const locationError = assertLocationErrorCode(
-          error,
-          LocationErrorCode.POSITION_UNAVAILABLE
-        );
+      const coarseCachePosition = await runWithNativeGeolocation(() =>
+        getLastKnownPositionAsync({
+          granularity: "coarse"
+        })
+      );
+      if (!coarseCachePosition) {
         setResult("coarseCache", {
           status: "passed",
-          message: `${locationError.name}: coarse cache-only read found no coarse-compatible cache.`
+          message:
+            "Coarse cache-only read found no coarse-compatible cache and returned undefined."
         });
         return;
       }

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import {
   LocationErrorCode,
   getCurrentPosition,
-  getLastKnownPosition,
+  getLastKnownPositionAsync,
   unwatch,
   watchHeading,
   watchPosition
@@ -245,29 +245,18 @@ export const useIOSReleaseOptionsBridgeScenario = () => {
         })
       );
 
-      try {
-        await runWithNativeGeolocation(() =>
-          getLastKnownPosition({ maximumAge: 0 })
-        );
-        setResult(
-          "maximumAgeZero",
-          createScenarioResult(
-            "failed",
-            "maximumAge=0 unexpectedly resolved cached data; caller options were dropped before reaching Swift."
-          )
-        );
-      } catch (error) {
-        const locationError = captureLocationError(error);
-        setResult(
-          "maximumAgeZero",
-          createScenarioResult(
-            locationError.code === LocationErrorCode.POSITION_UNAVAILABLE
-              ? "passed"
-              : "failed",
-            `${locationError.name}: ${locationError.message}`
-          )
-        );
-      }
+      const cached = await runWithNativeGeolocation(() =>
+        getLastKnownPositionAsync({ maximumAge: 0 })
+      );
+      setResult(
+        "maximumAgeZero",
+        createScenarioResult(
+          cached ? "failed" : "passed",
+          cached
+            ? "maximumAge=0 unexpectedly returned cached data; caller options may have been dropped before reaching Swift."
+            : "maximumAge=0 reached Swift and returned undefined for stale cache."
+        )
+      );
     } catch (error) {
       setResult(
         "maximumAgeZero",

--- a/examples/v0.81.1/src/type-contracts/v2-last-known-position.ts
+++ b/examples/v0.81.1/src/type-contracts/v2-last-known-position.ts
@@ -1,0 +1,14 @@
+import {
+  getLastKnownPosition,
+  getLastKnownPositionAsync
+} from "react-native-nitro-geolocation";
+import type { GeolocationResponse } from "react-native-nitro-geolocation";
+
+const moduleCache: GeolocationResponse | undefined = getLastKnownPosition();
+const platformCache: Promise<GeolocationResponse | undefined> =
+  getLastKnownPositionAsync({ maximumAge: 30_000 });
+
+// @ts-expect-error v2 sync cache reads do not query native sources or accept filters.
+getLastKnownPosition({ maximumAge: 30_000 });
+
+void [moduleCache, platformCache];

--- a/examples/web-e2e/src/lastKnownAssertions.ts
+++ b/examples/web-e2e/src/lastKnownAssertions.ts
@@ -1,0 +1,43 @@
+import type { GeolocationResponse } from "react-native-nitro-geolocation";
+
+export function expectCacheMiss(
+  cached: GeolocationResponse | undefined,
+  message: string
+): void {
+  if (cached !== undefined) {
+    throw new Error(message);
+  }
+}
+
+export function expectCachedPosition(
+  cached: GeolocationResponse | undefined,
+  message: string
+): GeolocationResponse {
+  if (!cached) {
+    throw new Error(message);
+  }
+  return cached;
+}
+
+export function expectLatestCachedPosition(
+  cached: GeolocationResponse | undefined,
+  expectedTimestamp: number,
+  validate: (position: GeolocationResponse) => void
+): void {
+  const position = expectCachedPosition(
+    cached,
+    "Sync module cache did not return a position."
+  );
+  validate(position);
+  if (position.timestamp !== expectedTimestamp) {
+    throw new Error("Sync module cache did not return the latest position.");
+  }
+}
+
+export function expectValidCachedPosition(
+  cached: GeolocationResponse | undefined,
+  message: string,
+  validate: (position: GeolocationResponse) => void
+): void {
+  validate(expectCachedPosition(cached, message));
+}

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -1,4 +1,6 @@
 import {
+  type GeolocationResponse,
+  type PermissionStatus,
   checkPermission,
   getCurrentPosition,
   getLastKnownPosition,
@@ -8,15 +10,16 @@ import {
   unwatch,
   watchPosition
 } from "react-native-nitro-geolocation";
-import type {
-  GeolocationResponse,
-  PermissionStatus
-} from "react-native-nitro-geolocation";
 import {
   runCompatApiAvailabilityCheck,
   runCompatScenarios
 } from "./compatRunner";
 import { setScenario } from "./dom";
+import {
+  expectCacheMiss,
+  expectLatestCachedPosition,
+  expectValidCachedPosition
+} from "./lastKnownAssertions";
 import {
   type ExpectedLocation,
   assertPosition,
@@ -228,11 +231,18 @@ export async function runSuccessSuite() {
   await runStep(
     "last-known-cold-cache",
     async () => getLastKnownPosition(),
-    (cached) => {
-      if (cached !== undefined) {
-        throw new Error("Cold browser module cache should be empty.");
-      }
-    }
+    (cached) =>
+      expectCacheMiss(cached, "Cold browser module cache should be empty.")
+  );
+
+  await runStep(
+    "last-known-async-cold-cache",
+    () => getLastKnownPositionAsync(),
+    (cached) =>
+      expectCacheMiss(
+        cached,
+        "Cold async browser module cache should be empty."
+      )
   );
 
   await runStep<PermissionStatus>(
@@ -278,28 +288,30 @@ export async function runSuccessSuite() {
   await runStep(
     "last-known-module-cache",
     async () => getLastKnownPosition(),
-    (cached) => {
-      if (!cached) {
-        throw new Error("Sync module cache did not return a position.");
-      }
-      assertPosition(cached);
-      if (cached.timestamp !== position.position.timestamp) {
-        throw new Error(
-          "Sync module cache did not return the latest position."
-        );
-      }
-    }
+    (cached) =>
+      expectLatestCachedPosition(
+        cached,
+        position.position.timestamp,
+        assertPosition
+      )
   );
 
   await runStep(
-    "last-known-platform-cache",
-    () => getLastKnownPositionAsync(),
-    (cached) => {
-      if (!cached) {
-        throw new Error("Browser platform cache did not return a position.");
-      }
-      assertPosition(cached);
-    }
+    "last-known-async-cache",
+    () => getLastKnownPositionAsync({ maximumAge: 30_000 }),
+    (cached) =>
+      expectValidCachedPosition(
+        cached,
+        "Async browser module cache did not return a position.",
+        assertPosition
+      )
+  );
+
+  await runStep(
+    "last-known-stale-cache",
+    () => getLastKnownPositionAsync({ maximumAge: 0 }),
+    (cached) =>
+      expectCacheMiss(cached, "maximumAge=0 should reject the observed cache.")
   );
 
   await runStep(
@@ -485,8 +497,10 @@ export async function runSuccessSuite() {
         "request-permission",
         "get-current-position",
         "last-known-cold-cache",
+        "last-known-async-cold-cache",
         "last-known-module-cache",
-        "last-known-platform-cache",
+        "last-known-async-cache",
+        "last-known-stale-cache",
         "watch-position",
         "unwatch",
         "stop-observing",

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -1,6 +1,8 @@
 import {
   checkPermission,
   getCurrentPosition,
+  getLastKnownPosition,
+  getLastKnownPositionAsync,
   requestPermission,
   stopObserving,
   unwatch,
@@ -209,6 +211,8 @@ export async function runSuccessSuite() {
     checkPermission: typeof checkPermission,
     requestPermission: typeof requestPermission,
     getCurrentPosition: typeof getCurrentPosition,
+    getLastKnownPosition: typeof getLastKnownPosition,
+    getLastKnownPositionAsync: typeof getLastKnownPositionAsync,
     watchPosition: typeof watchPosition,
     unwatch: typeof unwatch,
     stopObserving: typeof stopObserving
@@ -220,6 +224,16 @@ export async function runSuccessSuite() {
   }
 
   runCompatApiAvailabilityCheck();
+
+  await runStep(
+    "last-known-cold-cache",
+    async () => getLastKnownPosition(),
+    (cached) => {
+      if (cached !== undefined) {
+        throw new Error("Cold browser module cache should be empty.");
+      }
+    }
+  );
 
   await runStep<PermissionStatus>(
     "check-permission",
@@ -259,6 +273,33 @@ export async function runSuccessSuite() {
       });
     },
     (result) => assertPosition(result.position)
+  );
+
+  await runStep(
+    "last-known-module-cache",
+    async () => getLastKnownPosition(),
+    (cached) => {
+      if (!cached) {
+        throw new Error("Sync module cache did not return a position.");
+      }
+      assertPosition(cached);
+      if (cached.timestamp !== position.position.timestamp) {
+        throw new Error(
+          "Sync module cache did not return the latest position."
+        );
+      }
+    }
+  );
+
+  await runStep(
+    "last-known-platform-cache",
+    () => getLastKnownPositionAsync(),
+    (cached) => {
+      if (!cached) {
+        throw new Error("Browser platform cache did not return a position.");
+      }
+      assertPosition(cached);
+    }
   );
 
   await runStep(
@@ -443,6 +484,9 @@ export async function runSuccessSuite() {
         "check-permission",
         "request-permission",
         "get-current-position",
+        "last-known-cold-cache",
+        "last-known-module-cache",
+        "last-known-platform-cache",
         "watch-position",
         "unwatch",
         "stop-observing",

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -40,6 +40,26 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
+    id: "last-known-cold-cache",
+    title: "getLastKnownPosition cold cache",
+    detail:
+      "Sync read returns undefined before any Modern position is observed.",
+    status: "idle"
+  },
+  {
+    id: "last-known-module-cache",
+    title: "getLastKnownPosition module cache",
+    detail:
+      "Sync read returns the latest observed position without a platform query.",
+    status: "idle"
+  },
+  {
+    id: "last-known-platform-cache",
+    title: "getLastKnownPositionAsync platform cache",
+    detail: "Async read may query the browser cached location source.",
+    status: "idle"
+  },
+  {
     id: "watch-position",
     title: "watchPosition emits update",
     detail: "Starts real browser watch and receives normalized coords.",

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -47,6 +47,13 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
+    id: "last-known-async-cold-cache",
+    title: "getLastKnownPositionAsync cold cache",
+    detail:
+      "Async read returns undefined without prompting or querying browser geolocation.",
+    status: "idle"
+  },
+  {
     id: "last-known-module-cache",
     title: "getLastKnownPosition module cache",
     detail:
@@ -54,9 +61,15 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
-    id: "last-known-platform-cache",
-    title: "getLastKnownPositionAsync platform cache",
-    detail: "Async read may query the browser cached location source.",
+    id: "last-known-async-cache",
+    title: "getLastKnownPositionAsync module cache",
+    detail: "Async read applies cache filters without a browser query.",
+    status: "idle"
+  },
+  {
+    id: "last-known-stale-cache",
+    title: "getLastKnownPositionAsync stale cache",
+    detail: "maximumAge=0 returns undefined without a browser query.",
     status: "idle"
   },
   {

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -3,6 +3,7 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
 import type { GeolocationResponse } from "../publicTypes";
+import { rememberPosition } from "./positionCache";
 
 /**
  * Get current location (one-time request).
@@ -36,12 +37,12 @@ export function getCurrentPosition(
   if (isDevtoolsEnabled()) {
     const devtoolsResult = getDevtoolsCurrentPosition();
     if (devtoolsResult) {
-      return devtoolsResult;
+      return devtoolsResult.then(rememberPosition);
     }
   }
   return new Promise((resolve, reject) => {
     NitroGeolocationHybridObject.getCurrentPosition(
-      resolve,
+      (position) => resolve(rememberPosition(position)),
       options ?? {},
       reject
     );

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -3,30 +3,53 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
 import type { GeolocationResponse } from "../publicTypes";
+import { LocationErrorCode } from "../utils/errors";
+import { readLastKnownPosition, rememberPosition } from "./positionCache";
 
 /**
- * Get the best cached location without starting a fresh native location
+ * Return the latest position observed by this JavaScript module.
+ *
+ * This synchronous read never calls a native or browser location source.
+ * It returns `undefined` until a Modern current, watch, or async cache call
+ * observes a position.
+ */
+export function getLastKnownPosition(): GeolocationResponse | undefined {
+  return readLastKnownPosition();
+}
+
+/**
+ * Query cached platform/provider sources without starting a fresh location
  * request.
  *
  * @param options - Cache filtering and provider selection options
- * @returns Promise resolving to a cached position
- * @throws LocationError if permission is denied or no cached location exists
+ * @returns A cached position, or `undefined` when no cache satisfies options
+ * @throws LocationError if permission is denied or the cache query fails
  */
-export function getLastKnownPosition(
+export function getLastKnownPositionAsync(
   options?: LocationRequestOptions
-): Promise<GeolocationResponse> {
+): Promise<GeolocationResponse | undefined> {
   if (isDevtoolsEnabled()) {
     const devtoolsResult = getDevtoolsCurrentPosition();
     if (devtoolsResult) {
-      return devtoolsResult;
+      return devtoolsResult.then(rememberPosition);
     }
   }
 
-  return new Promise((resolve, reject) => {
+  return new Promise<GeolocationResponse>((resolve, reject) => {
     NitroGeolocationHybridObject.getLastKnownPosition(
-      resolve,
+      (position) => resolve(rememberPosition(position)),
       options ?? {},
       reject
     );
+  }).catch((error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === LocationErrorCode.POSITION_UNAVAILABLE
+    ) {
+      return undefined;
+    }
+    throw error;
   });
 }

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -1,7 +1,7 @@
 import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
-import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
+import { getDevtoolsLastKnownPosition } from "../devtools/getLastKnownPosition";
 import type { GeolocationResponse } from "../publicTypes";
 import { LocationErrorCode } from "../utils/errors";
 import { readLastKnownPosition, rememberPosition } from "./positionCache";
@@ -21,6 +21,11 @@ export function getLastKnownPosition(): GeolocationResponse | undefined {
  * Query cached platform/provider sources without starting a fresh location
  * request.
  *
+ * Native platforms may query their cache-only APIs. DevTools filters its
+ * configured mock cache. Web filters the observed module cache because the
+ * browser Geolocation API has no cache-only request that can avoid prompting
+ * or starting location acquisition.
+ *
  * @param options - Cache filtering and provider selection options
  * @returns A cached position, or `undefined` when no cache satisfies options
  * @throws LocationError if permission is denied or the cache query fails
@@ -29,10 +34,8 @@ export function getLastKnownPositionAsync(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse | undefined> {
   if (isDevtoolsEnabled()) {
-    const devtoolsResult = getDevtoolsCurrentPosition();
-    if (devtoolsResult) {
-      return devtoolsResult.then(rememberPosition);
-    }
+    const cached = getDevtoolsLastKnownPosition(options);
+    return Promise.resolve(cached ? rememberPosition(cached) : undefined);
   }
 
   return new Promise<GeolocationResponse>((resolve, reject) => {

--- a/packages/react-native-nitro-geolocation/src/api/index.ts
+++ b/packages/react-native-nitro-geolocation/src/api/index.ts
@@ -8,7 +8,10 @@ export { requestLocationSettings } from "./requestLocationSettings";
 export { getAccuracyAuthorization } from "./getAccuracyAuthorization";
 export { requestTemporaryFullAccuracy } from "./requestTemporaryFullAccuracy";
 export { getCurrentPosition } from "./getCurrentPosition";
-export { getLastKnownPosition } from "./getLastKnownPosition";
+export {
+  getLastKnownPosition,
+  getLastKnownPositionAsync
+} from "./getLastKnownPosition";
 export { geocode } from "./geocode";
 export { reverseGeocode } from "./reverseGeocode";
 export { getHeading } from "./getHeading";

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
@@ -3,7 +3,8 @@ import type { GeolocationResponse } from "../publicTypes";
 import {
   clearLastKnownPositionCache,
   readLastKnownPosition,
-  rememberPosition
+  rememberPosition,
+  selectCachedPosition
 } from "./positionCache";
 
 const position: GeolocationResponse = {
@@ -29,5 +30,23 @@ describe("positionCache", () => {
   it("returns the latest observed position synchronously", () => {
     expect(rememberPosition(position)).toBe(position);
     expect(readLastKnownPosition()).toBe(position);
+  });
+
+  it("selects only positions within maximumAge", () => {
+    expect(
+      selectCachedPosition(position, 10_000, position.timestamp + 5_000)
+    ).toBe(position);
+    expect(
+      selectCachedPosition(position, 1_000, position.timestamp + 5_000)
+    ).toBeUndefined();
+    expect(
+      selectCachedPosition(position, 0, position.timestamp)
+    ).toBeUndefined();
+  });
+
+  it("accepts any observed age when maximumAge is infinite", () => {
+    expect(
+      selectCachedPosition(position, Number.POSITIVE_INFINITY, Number.MAX_VALUE)
+    ).toBe(position);
   });
 });

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { GeolocationResponse } from "../publicTypes";
+import {
+  clearLastKnownPositionCache,
+  readLastKnownPosition,
+  rememberPosition
+} from "./positionCache";
+
+const position: GeolocationResponse = {
+  coords: {
+    latitude: 37.5665,
+    longitude: 126.978,
+    altitude: null,
+    accuracy: 10,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null
+  },
+  timestamp: 1_779_015_190_000
+};
+
+afterEach(() => clearLastKnownPositionCache());
+
+describe("positionCache", () => {
+  it("returns undefined before this module observes a position", () => {
+    expect(readLastKnownPosition()).toBeUndefined();
+  });
+
+  it("returns the latest observed position synchronously", () => {
+    expect(rememberPosition(position)).toBe(position);
+    expect(readLastKnownPosition()).toBe(position);
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.ts
@@ -1,0 +1,18 @@
+import type { GeolocationResponse } from "../publicTypes";
+
+let lastKnownPosition: GeolocationResponse | undefined;
+
+export function rememberPosition(
+  position: GeolocationResponse
+): GeolocationResponse {
+  lastKnownPosition = position;
+  return position;
+}
+
+export function readLastKnownPosition(): GeolocationResponse | undefined {
+  return lastKnownPosition;
+}
+
+export function clearLastKnownPositionCache(): void {
+  lastKnownPosition = undefined;
+}

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.ts
@@ -13,6 +13,22 @@ export function readLastKnownPosition(): GeolocationResponse | undefined {
   return lastKnownPosition;
 }
 
+export function selectCachedPosition(
+  position: GeolocationResponse | undefined,
+  maximumAge: number,
+  currentTime = Date.now()
+): GeolocationResponse | undefined {
+  if (!position) {
+    return undefined;
+  }
+  if (maximumAge === Number.POSITIVE_INFINITY) {
+    return position;
+  }
+
+  const age = Math.max(0, currentTime - position.timestamp);
+  return age < maximumAge ? position : undefined;
+}
+
 export function clearLastKnownPositionCache(): void {
   lastKnownPosition = undefined;
 }

--- a/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
@@ -6,6 +6,7 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { devtoolsWatchPosition } from "../devtools/watchPosition";
 import type { GeolocationResponse } from "../publicTypes";
+import { rememberPosition } from "./positionCache";
 
 /**
  * Start watching for continuous location updates.
@@ -36,11 +37,15 @@ export function watchPosition(
   error?: (error: LocationError) => void,
   options?: LocationRequestOptions
 ): string {
+  const rememberAndNotify = (position: GeolocationResponse) => {
+    success(rememberPosition(position));
+  };
+
   if (isDevtoolsEnabled()) {
-    return devtoolsWatchPosition(success, error);
+    return devtoolsWatchPosition(rememberAndNotify, error);
   }
   return NitroGeolocationHybridObject.watchPosition(
-    success,
+    rememberAndNotify,
     options ?? {},
     error
   );

--- a/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.test.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getDevtoolsState } from ".";
+import type { GeolocationResponse } from "../publicTypes";
+import { getDevtoolsLastKnownPosition } from "./getLastKnownPosition";
+
+const now = 1_779_015_190_000;
+const position: GeolocationResponse = {
+  coords: {
+    latitude: 37.5665,
+    longitude: 126.978,
+    altitude: null,
+    accuracy: 10,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null
+  },
+  timestamp: now - 5_000
+};
+
+afterEach(() => {
+  getDevtoolsState().position = null;
+});
+
+describe("getDevtoolsLastKnownPosition", () => {
+  it("returns undefined when DevTools has not observed a position", () => {
+    expect(getDevtoolsLastKnownPosition(undefined, now)).toBeUndefined();
+  });
+
+  it("returns a DevTools position that satisfies maximumAge", () => {
+    getDevtoolsState().position = position;
+
+    expect(getDevtoolsLastKnownPosition({ maximumAge: 10_000 }, now)).toBe(
+      position
+    );
+  });
+
+  it("returns undefined when the DevTools position is stale", () => {
+    getDevtoolsState().position = position;
+
+    expect(
+      getDevtoolsLastKnownPosition({ maximumAge: 1_000 }, now)
+    ).toBeUndefined();
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.ts
@@ -1,0 +1,20 @@
+import { getDevtoolsState } from ".";
+import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
+import { selectCachedPosition } from "../api/positionCache";
+import type { GeolocationResponse } from "../publicTypes";
+
+export function getDevtoolsLastKnownPosition(
+  options?: LocationRequestOptions,
+  currentTime = Date.now()
+): GeolocationResponse | undefined {
+  const maximumAge = Math.min(
+    options?.maximumAge ?? Number.POSITIVE_INFINITY,
+    options?.maxUpdateAge ?? Number.POSITIVE_INFINITY
+  );
+
+  return selectCachedPosition(
+    getDevtoolsState().position ?? undefined,
+    maximumAge,
+    currentTime
+  );
+}

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -61,6 +61,7 @@ export {
   requestTemporaryFullAccuracy,
   getCurrentPosition,
   getLastKnownPosition,
+  getLastKnownPositionAsync,
   geocode,
   reverseGeocode,
   getHeading,

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -3,12 +3,14 @@ import {
   checkPermission,
   getCurrentPosition,
   getLastKnownPosition,
+  getLastKnownPositionAsync,
   getLocationAvailability,
   requestPermission,
   stopObserving,
   unwatch,
   watchPosition
 } from ".";
+import { clearLastKnownPositionCache } from "../api/positionCache";
 
 type TestNavigator = {
   geolocation?: {
@@ -45,11 +47,26 @@ function createPosition(latitude = 37.5665, longitude = 126.978) {
 
 afterEach(() => {
   stopObserving();
+  clearLastKnownPositionCache();
   vi.restoreAllMocks();
   Reflect.deleteProperty(globalThis, "navigator");
 });
 
 describe("web Modern API", () => {
+  it("returns undefined from a cold sync module cache without querying the browser", () => {
+    const getCurrentPositionMock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    expect(getLastKnownPosition()).toBeUndefined();
+    expect(getCurrentPositionMock).not.toHaveBeenCalled();
+  });
+
   it("wraps navigator.geolocation.getCurrentPosition and normalizes nullable coords", async () => {
     const getCurrentPositionMock = vi.fn((success) => {
       success(createPosition());
@@ -84,6 +101,10 @@ describe("web Modern API", () => {
       enableHighAccuracy: true,
       timeout: 1234,
       maximumAge: 0
+    });
+    expect(getLastKnownPosition()).toMatchObject({
+      coords: { latitude: 37.5665, longitude: 126.978 },
+      timestamp: 1779015190000
     });
   });
 
@@ -151,7 +172,7 @@ describe("web Modern API", () => {
     });
   });
 
-  it("maps getLastKnownPosition cache miss to POSITION_UNAVAILABLE", async () => {
+  it("maps an async browser cache miss to undefined", async () => {
     const getCurrentPositionMock = vi.fn((_success, error) => {
       error({ code: 3, message: "Timeout expired" });
     });
@@ -163,14 +184,55 @@ describe("web Modern API", () => {
       }
     });
 
-    await expect(getLastKnownPosition()).rejects.toEqual({
-      code: 2,
-      message: "No cached browser location is available."
-    });
+    await expect(getLastKnownPositionAsync()).resolves.toBeUndefined();
     expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
       maximumAge: Number.POSITIVE_INFINITY,
       timeout: 0
     });
+  });
+
+  it("queries the browser cache asynchronously and updates the sync module cache", async () => {
+    const getCurrentPositionMock = vi.fn((success) => {
+      success(createPosition(37.57, 126.99));
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(
+      getLastKnownPositionAsync({ maximumAge: 30_000 })
+    ).resolves.toMatchObject({
+      coords: { latitude: 37.57, longitude: 126.99 }
+    });
+    expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
+      maximumAge: 30_000,
+      timeout: 0
+    });
+    expect(getLastKnownPosition()).toMatchObject({
+      coords: { latitude: 37.57, longitude: 126.99 }
+    });
+  });
+
+  it("preserves permission errors from async browser cache queries", async () => {
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn((_success, error) => {
+          error({ code: 1, message: "denied" });
+        }),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+
+    await expect(getLastKnownPositionAsync()).rejects.toEqual({
+      code: 1,
+      message: "denied"
+    });
+    expect(getLastKnownPosition()).toBeUndefined();
   });
 
   it("uses permissions.query when checkPermission can read geolocation state", async () => {

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -172,10 +172,8 @@ describe("web Modern API", () => {
     });
   });
 
-  it("maps an async browser cache miss to undefined", async () => {
-    const getCurrentPositionMock = vi.fn((_success, error) => {
-      error({ code: 3, message: "Timeout expired" });
-    });
+  it("returns an async cache miss without querying or requiring browser geolocation", async () => {
+    const getCurrentPositionMock = vi.fn();
     setNavigator({
       geolocation: {
         getCurrentPosition: getCurrentPositionMock,
@@ -185,15 +183,16 @@ describe("web Modern API", () => {
     });
 
     await expect(getLastKnownPositionAsync()).resolves.toBeUndefined();
-    expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
-      maximumAge: Number.POSITIVE_INFINITY,
-      timeout: 0
-    });
+    expect(getCurrentPositionMock).not.toHaveBeenCalled();
+
+    setNavigator(undefined);
+    await expect(getLastKnownPositionAsync()).resolves.toBeUndefined();
   });
 
-  it("queries the browser cache asynchronously and updates the sync module cache", async () => {
+  it("reads the observed module cache asynchronously without another browser request", async () => {
+    const timestamp = Date.now();
     const getCurrentPositionMock = vi.fn((success) => {
-      success(createPosition(37.57, 126.99));
+      success({ ...createPosition(37.57, 126.99), timestamp });
     });
     setNavigator({
       geolocation: {
@@ -203,36 +202,36 @@ describe("web Modern API", () => {
       }
     });
 
+    await getCurrentPosition();
     await expect(
       getLastKnownPositionAsync({ maximumAge: 30_000 })
     ).resolves.toMatchObject({
-      coords: { latitude: 37.57, longitude: 126.99 }
+      coords: { latitude: 37.57, longitude: 126.99 },
+      timestamp
     });
-    expect(getCurrentPositionMock.mock.calls[0][2]).toMatchObject({
-      maximumAge: 30_000,
-      timeout: 0
-    });
+    expect(getCurrentPositionMock).toHaveBeenCalledTimes(1);
     expect(getLastKnownPosition()).toMatchObject({
       coords: { latitude: 37.57, longitude: 126.99 }
     });
   });
 
-  it("preserves permission errors from async browser cache queries", async () => {
+  it("filters stale observed positions without querying the browser again", async () => {
+    const getCurrentPositionMock = vi.fn((success) => {
+      success({ ...createPosition(), timestamp: Date.now() - 60_000 });
+    });
     setNavigator({
       geolocation: {
-        getCurrentPosition: vi.fn((_success, error) => {
-          error({ code: 1, message: "denied" });
-        }),
+        getCurrentPosition: getCurrentPositionMock,
         watchPosition: vi.fn(),
         clearWatch: vi.fn()
       }
     });
 
-    await expect(getLastKnownPositionAsync()).rejects.toEqual({
-      code: 1,
-      message: "denied"
-    });
-    expect(getLastKnownPosition()).toBeUndefined();
+    await getCurrentPosition();
+    await expect(
+      getLastKnownPositionAsync({ maximumAge: 1_000 })
+    ).resolves.toBeUndefined();
+    expect(getCurrentPositionMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses permissions.query when checkPermission can read geolocation state", async () => {

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -4,7 +4,11 @@ import type {
   LocationSettingsOptions,
   PermissionStatus
 } from "../NitroGeolocation.nitro";
-import { readLastKnownPosition, rememberPosition } from "../api/positionCache";
+import {
+  readLastKnownPosition,
+  rememberPosition,
+  selectCachedPosition
+} from "../api/positionCache";
 import type {
   AccuracyAuthorization,
   GeocodedLocation,
@@ -16,7 +20,6 @@ import type {
   LocationProviderStatus,
   ReverseGeocodedAddress
 } from "../publicTypes";
-import { LocationErrorCode } from "../utils/errors";
 import {
   createUnsupportedError,
   getGeolocation,
@@ -144,17 +147,8 @@ export function getLastKnownPositionAsync(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse | undefined> {
   const maximumAge = options?.maximumAge ?? Number.POSITIVE_INFINITY;
-  return getCurrentPosition({ ...options, maximumAge, timeout: 0 }).catch(
-    (error) => {
-      const code = (error as LocationError).code;
-      if (
-        code === LocationErrorCode.POSITION_UNAVAILABLE ||
-        code === LocationErrorCode.TIMEOUT
-      ) {
-        return undefined;
-      }
-      throw error;
-    }
+  return Promise.resolve(
+    selectCachedPosition(readLastKnownPosition(), maximumAge)
   );
 }
 

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -4,6 +4,7 @@ import type {
   LocationSettingsOptions,
   PermissionStatus
 } from "../NitroGeolocation.nitro";
+import { readLastKnownPosition, rememberPosition } from "../api/positionCache";
 import type {
   AccuracyAuthorization,
   GeocodedLocation,
@@ -15,7 +16,7 @@ import type {
   LocationProviderStatus,
   ReverseGeocodedAddress
 } from "../publicTypes";
-import { LocationErrorCode, createLocationError } from "../utils/errors";
+import { LocationErrorCode } from "../utils/errors";
 import {
   createUnsupportedError,
   getGeolocation,
@@ -128,24 +129,29 @@ export function getCurrentPosition(
 
   return new Promise((resolve, reject) => {
     geolocation.getCurrentPosition(
-      (position) => resolve(normalizePosition(position)),
+      (position) => resolve(rememberPosition(normalizePosition(position))),
       (error) => reject(mapBrowserError(error)),
       toPositionOptions(options)
     );
   });
 }
 
-export function getLastKnownPosition(
+export function getLastKnownPosition(): GeolocationResponse | undefined {
+  return readLastKnownPosition();
+}
+
+export function getLastKnownPositionAsync(
   options?: LocationRequestOptions
-): Promise<GeolocationResponse> {
+): Promise<GeolocationResponse | undefined> {
   const maximumAge = options?.maximumAge ?? Number.POSITIVE_INFINITY;
   return getCurrentPosition({ ...options, maximumAge, timeout: 0 }).catch(
     (error) => {
-      if ((error as LocationError).code === LocationErrorCode.TIMEOUT) {
-        throw createLocationError(
-          LocationErrorCode.POSITION_UNAVAILABLE,
-          "No cached browser location is available."
-        );
+      const code = (error as LocationError).code;
+      if (
+        code === LocationErrorCode.POSITION_UNAVAILABLE ||
+        code === LocationErrorCode.TIMEOUT
+      ) {
+        return undefined;
       }
       throw error;
     }

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -20,6 +20,7 @@ import type {
   LocationProviderStatus,
   ReverseGeocodedAddress
 } from "../publicTypes";
+import { LocationErrorCode } from "../utils/errors";
 import {
   createUnsupportedError,
   getGeolocation,

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -2,6 +2,7 @@ import type {
   LocationError,
   LocationRequestOptions
 } from "../NitroGeolocation.nitro";
+import { rememberPosition } from "../api/positionCache";
 import type {
   GeolocationResponse,
   Heading,
@@ -52,8 +53,8 @@ export function watchPosition(
         !lastEmitted ||
         distanceMeters(lastEmitted, normalizedPosition) >= filter
       ) {
-        lastEmitted = normalizedPosition;
-        success(normalizedPosition);
+        lastEmitted = rememberPosition(normalizedPosition);
+        success(lastEmitted);
       }
     },
     (browserError) => error?.(mapBrowserError(browserError)),


### PR DESCRIPTION
## Roadmap checkbox

Implements the v2 roadmap item in #98 that separates synchronous module-cache reads from asynchronous cache-only reads.

## Red -> green

Initial red evidence:
- the consumer type contract failed because `getLastKnownPositionAsync` did not exist
- assigning `getLastKnownPosition()` to a synchronous optional position failed because the old API returned a Promise
- the no-options `@ts-expect-error` was unused
- Web unit tests failed because the module cache did not exist

Adversarial-review red evidence:
- DevTools cache miss had no cache-only helper and rejected instead of resolving `undefined`
- Web async cold read timed out because it called browser geolocation
- a stale observed Web position was returned despite `maximumAge`

Green implementation:
- `getLastKnownPosition()` synchronously returns the latest Modern position observed by this JS module, or `undefined`
- native `getLastKnownPositionAsync(options?)` queries native/GMS cache-only sources without starting a fresh request
- Web filters the observed module cache because the browser Geolocation API cannot guarantee a prompt-free, acquisition-free cache query
- DevTools filters its configured mock cache, including `maximumAge` and `maxUpdateAge`
- cache misses resolve `undefined`; native permission and operational errors remain errors
- current-position and accepted watch emissions populate the module cache on native, Web, and DevTools paths
- natural test pages cover cold sync/async cache, stale/empty cache, native platform cache success, seeded sync cache, and permission denial

## Verification

- 68 unit tests across 8 files
- example consumer TypeScript contract with unused-symbol checks
- format, lint, dead-code, production dead-code, source-line, package dry-run, and build checks
- Android Release build + native E2E: `last-known-position.yaml`, `android-request-options.yaml`
- iOS Release build + native E2E: `last-known-position.yaml`, `ios-release-options-bridge.yaml`
- Android WebView E2E: affected success and permission-denied contracts
- iOS WebView E2E: affected success and permission-denied contracts
- Changesets v3 pre mode resolves the package to `2.0.0-rc.0`

## Release note

The breaking API surface is represented by the major changeset; the commit and PR title intentionally do not use Conventional Commit `!` syntax.