### PR TITLE
feat: add cancellable current position requests

### DIFF
--- a/.changeset/calm-pandas-cancel.md
+++ b/.changeset/calm-pandas-cancel.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add request-scoped `AbortSignal` cancellation to the Modern API `getCurrentPosition()` call on Android, iOS, and web.

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -248,7 +248,9 @@ Supported on web:
   Permissions API is available.
 - `requestPermission()` performs a one-shot browser geolocation request because
   browsers do not expose a standalone geolocation permission request API.
-- `getCurrentPosition()` wraps `navigator.geolocation.getCurrentPosition()`.
+- `getCurrentPosition()` uses `navigator.geolocation.getCurrentPosition()` for
+  ordinary requests. When `signal` is provided, it uses a one-shot browser
+  watch so aborting can call `clearWatch()` immediately.
 - `watchPosition()` wraps `navigator.geolocation.watchPosition()` and returns a
   string token.
 - `unwatch()` and `stopObserving()` clear browser watch IDs.
@@ -321,12 +323,16 @@ function LocationButton() {
 }
 ```
 
-**Parameters**: `options?: LocationRequestOptions`
+**Parameters**: `options?: CurrentPositionOptions`
 
 **Options**:
 
 - `timeout?: number` - Request timeout in ms (default: 600000 / 10 min)
 - `maximumAge?: number` - Max age of cached location in ms (default: 0)
+- `signal?: AbortSignal` - Cancels only this request. A signal that is already
+  aborted prevents native or browser location work from starting. The promise
+  rejects with the exact `signal.reason`; runtimes without a reason receive an
+  `AbortError` fallback.
 - `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
 - `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
@@ -351,6 +357,28 @@ await getCurrentPosition({
   timeout: 15000
 });
 ```
+
+Use an `AbortController` when the screen or operation that owns a one-shot
+request can end before location arrives:
+
+```tsx
+const controller = new AbortController();
+
+const request = getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  maximumAge: 0,
+  timeout: 30000,
+  signal: controller.signal
+});
+
+controller.abort(new Error('Screen closed'));
+await request;
+```
+
+Cancellation is isolated by request ID: aborting one concurrent request does
+not cancel another request or an active watch. Omitting `signal` keeps the
+existing one-shot native/browser path. The callback-based `/compat` API is
+unchanged.
 
 Android maps the presets to native accuracy/priority intent. With `auto` or
 `playServices`, requests prefer Google Play Services fused location and use the
@@ -880,6 +908,7 @@ All Modern API exports are fully typed:
 ```typescript
 import type {
   PermissionStatus,
+  CurrentPositionOptions,
   LocationRequestOptions,
   LocationErrorCode,
   LocationError,

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -64,6 +64,7 @@ appId: nitrogeolocation.example
       platform: Android
     file: gps-only-recipe-coarse.yaml
 - runFlow: current-position.yaml
+- runFlow: cancellable-current-position.yaml
 - runFlow: watch-position.yaml
 - runFlow: location-simulation.yaml
 - runFlow: accuracy-presets.yaml

--- a/examples/v0.81.1/.maestro/cancellable-current-position.yaml
+++ b/examples/v0.81.1/.maestro/cancellable-current-position.yaml
@@ -61,6 +61,29 @@ appId: nitrogeolocation.example
     text: ".*preserved the (exact reason|AbortError fallback).*"
 
 - setLocation:
+    latitude: 37.5
+    longitude: 126.9
+
+- tapOn:
+    id: "e2e-action-cancellable-current-position-run-cache-isolation-button"
+
+- extendedWaitUntil:
+    visible: "Cache read completed; move location for the active watch."
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.6123
+    longitude: 127.0456
+
+- extendedWaitUntil:
+    visible: "Cache read isolation: passed"
+    timeout: 60000
+- assertVisible:
+    id: "cancellable-current-position-cache-isolation-result"
+- assertVisible:
+    text: ".*Cache read kept watch active at 37.612300, 127.045600.*"
+
+- setLocation:
     latitude: 37.5665
     longitude: 126.978
 
@@ -79,16 +102,20 @@ appId: nitrogeolocation.example
 - assertVisible:
     text: ".*cancelled first only.*survivor 37.566500, 126.978000.*"
 
+- setLocation:
+    latitude: 37.5
+    longitude: 126.9
+
 - tapOn:
     id: "e2e-action-cancellable-current-position-run-watch-isolation-button"
 
 - extendedWaitUntil:
-    visible: ".*(One-shot cancelled; move location for the active watch.|Watch isolation: passed).*"
-    timeout: 10000
+    visible: "One-shot cancelled; move location for the active watch."
+    timeout: 60000
 
 - setLocation:
-    latitude: 37.5665
-    longitude: 126.978
+    latitude: 37.6123
+    longitude: 127.0456
 
 - extendedWaitUntil:
     visible: "Watch isolation: passed"
@@ -96,4 +123,4 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "cancellable-current-position-watch-isolation-result"
 - assertVisible:
-    text: ".*One-shot cancellation kept watch active at 37.566500, 126.978000.*"
+    text: ".*One-shot cancellation kept watch active at 37.612300, 127.045600.*"

--- a/examples/v0.81.1/.maestro/cancellable-current-position.yaml
+++ b/examples/v0.81.1/.maestro/cancellable-current-position.yaml
@@ -1,0 +1,80 @@
+appId: nitrogeolocation.example
+---
+# AbortSignal contract: pre-aborted requests preserve their reason, and
+# cancelling one active request does not cancel a concurrent survivor.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/cancellable-current-position
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/cancellable-current-position
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "AbortSignal cancellation without cross-request interference"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-cancellable-current-position-run-pre-aborted-button"
+
+- extendedWaitUntil:
+    visible: "Pre-aborted request: passed"
+    timeout: 10000
+- assertVisible:
+    id: "cancellable-current-position-pre-aborted-result"
+- assertVisible:
+    text: ".*preserved the (exact reason|AbortError fallback).*"
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- tapOn:
+    id: "e2e-action-cancellable-current-position-run-isolation-button"
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- extendedWaitUntil:
+    visible: "Isolated cancellation: passed"
+    timeout: 60000
+- assertVisible:
+    id: "cancellable-current-position-isolation-result"
+- assertVisible:
+    text: ".*cancelled first only.*survivor 37.566500, 126.978000.*"

--- a/examples/v0.81.1/.maestro/cancellable-current-position.yaml
+++ b/examples/v0.81.1/.maestro/cancellable-current-position.yaml
@@ -1,7 +1,7 @@
 appId: nitrogeolocation.example
 ---
 # AbortSignal contract: pre-aborted requests preserve their reason, and
-# cancelling one active request does not cancel a concurrent survivor.
+# cancelling one active request does not cancel concurrent one-shot or watch survivors.
 
 - launchApp:
     clearState: true
@@ -78,3 +78,22 @@ appId: nitrogeolocation.example
     id: "cancellable-current-position-isolation-result"
 - assertVisible:
     text: ".*cancelled first only.*survivor 37.566500, 126.978000.*"
+
+- tapOn:
+    id: "e2e-action-cancellable-current-position-run-watch-isolation-button"
+
+- extendedWaitUntil:
+    visible: ".*(One-shot cancelled; move location for the active watch.|Watch isolation: passed).*"
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- extendedWaitUntil:
+    visible: "Watch isolation: passed"
+    timeout: 60000
+- assertVisible:
+    id: "cancellable-current-position-watch-isolation-result"
+- assertVisible:
+    text: ".*One-shot cancellation kept watch active at 37.566500, 126.978000.*"

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -14,6 +14,7 @@ import AndroidRequestOptionsScreen, {
 } from "./screens/AndroidRequestOptionsScreen";
 import ApiErrorsScreen from "./screens/ApiErrorsScreen";
 import BackgroundE2EScreen from "./screens/BackgroundE2EScreen";
+import CancellableCurrentPositionScreen from "./screens/CancellableCurrentPositionScreen";
 import CompatScreen from "./screens/CompatScreen";
 import CurrentPositionScreen from "./screens/CurrentPositionScreen";
 import DefaultScreen from "./screens/DefaultScreen";
@@ -49,6 +50,7 @@ const linking = {
       Compat: "compat",
       PermissionCheck: "permission-check",
       CurrentPosition: "current-position",
+      CancellableCurrentPosition: "cancellable-current-position",
       WatchPosition: "watch-position",
       LocationSimulation: "location-simulation",
       MockedMetadata: "mocked-metadata",
@@ -130,6 +132,11 @@ export default function App() {
           <Tab.Screen
             name="CurrentPosition"
             component={CurrentPositionScreen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="CancellableCurrentPosition"
+            component={CancellableCurrentPositionScreen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { getCurrentPosition } from "react-native-nitro-geolocation";
+import {
+  getCurrentPosition,
+  unwatch,
+  watchPosition
+} from "react-native-nitro-geolocation";
+import type { GeolocationResponse } from "react-native-nitro-geolocation";
 import {
   PermissionStatusBlock,
   ResultBlock,
@@ -18,7 +23,8 @@ const PREFIX = "cancellable-current-position";
 
 const initialResults = createScenarioResults([
   "preAborted",
-  "isolation"
+  "isolation",
+  "watchIsolation"
 ] as const);
 
 function abortWithReason(controller: AbortController, reason: unknown) {
@@ -150,6 +156,110 @@ export default function CancellableCurrentPositionScreen() {
     }
   };
 
+  const runWatchIsolationScenario = async () => {
+    setResult("watchIsolation", {
+      status: "running",
+      message: "Starting a watch and cancelling a one-shot request"
+    });
+
+    const controller = new AbortController();
+    const cancellationReason = new Error("cancel one-shot, keep watch");
+
+    try {
+      const permission = await requestLocationPermission();
+      if (permission !== "granted") {
+        throw new Error(`Permission was not granted: ${permission}`);
+      }
+
+      const watchedPosition = await runWithNativeGeolocation(
+        () =>
+          new Promise<GeolocationResponse>((resolve, reject) => {
+            let token = "";
+            let didFinish = false;
+            let cancelledAt = Number.POSITIVE_INFINITY;
+            const timeout = setTimeout(() => {
+              finish(() =>
+                reject(
+                  new Error(
+                    "Watch did not deliver after the one-shot request was cancelled."
+                  )
+                )
+              );
+            }, 30000);
+            const finish = (callback: () => void) => {
+              if (didFinish) return;
+              didFinish = true;
+              clearTimeout(timeout);
+              if (token) unwatch(token);
+              callback();
+            };
+            const requestOptions = {
+              accuracy: { android: "high" as const, ios: "best" as const },
+              maximumAge: 0,
+              timeout: 30000
+            };
+
+            token = watchPosition(
+              (position) => {
+                if (position.timestamp < cancelledAt) return;
+                finish(() => resolve(position));
+              },
+              (error) => finish(() => reject(error)),
+              requestOptions
+            );
+
+            const cancelledRequest = getCurrentPosition({
+              ...requestOptions,
+              signal: controller.signal
+            });
+            abortWithReason(controller, cancellationReason);
+
+            cancelledRequest.then(
+              () =>
+                finish(() =>
+                  reject(
+                    new Error(
+                      "Cancelled one-shot request unexpectedly resolved."
+                    )
+                  )
+                ),
+              (error) => {
+                try {
+                  assertAbortOutcome(
+                    error,
+                    controller.signal,
+                    cancellationReason
+                  );
+                  cancelledAt = Date.now();
+                  setResult("watchIsolation", {
+                    status: "running",
+                    message:
+                      "One-shot cancelled; move location for the active watch."
+                  });
+                } catch (assertionError) {
+                  finish(() => reject(assertionError));
+                }
+              }
+            );
+          })
+      );
+
+      const coordinates = assertFixtureCoordinates(watchedPosition);
+      setResult("watchIsolation", {
+        status: "passed",
+        message: `One-shot cancellation kept watch active at ${coordinates}.`
+      });
+    } catch (error) {
+      setResult("watchIsolation", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      controller.abort();
+      await refreshPermission();
+    }
+  };
+
   return (
     <ScenarioScreen
       prefix={PREFIX}
@@ -186,6 +296,21 @@ export default function CancellableCurrentPositionScreen() {
           id="isolation"
           label="Isolated cancellation"
           result={results.isolation}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={4} title="Active Watch" divided>
+        <ScenarioButton
+          title="Cancel One-shot While Watching"
+          onPress={runWatchIsolationScenario}
+          color="#00695C"
+          testID={`${PREFIX}-run-watch-isolation-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="watch-isolation"
+          label="Watch isolation"
+          result={results.watchIsolation}
         />
       </ScenarioSection>
     </ScenarioScreen>

--- a/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   getCurrentPosition,
+  getLastKnownPositionAsync,
   unwatch,
   watchPosition
 } from "react-native-nitro-geolocation";
@@ -20,12 +21,33 @@ import {
 } from "./scenario";
 
 const PREFIX = "cancellable-current-position";
+const CONCURRENCY_FIXTURE = {
+  latitude: 37.6123,
+  longitude: 127.0456
+};
+const COORDINATE_TOLERANCE = 0.0001;
 
 const initialResults = createScenarioResults([
   "preAborted",
+  "cacheIsolation",
   "isolation",
   "watchIsolation"
 ] as const);
+
+function isConcurrencyFixture(position: GeolocationResponse) {
+  return (
+    Math.abs(position.coords.latitude - CONCURRENCY_FIXTURE.latitude) <=
+      COORDINATE_TOLERANCE &&
+    Math.abs(position.coords.longitude - CONCURRENCY_FIXTURE.longitude) <=
+      COORDINATE_TOLERANCE
+  );
+}
+
+function formatCoordinates(position: GeolocationResponse) {
+  return `${position.coords.latitude.toFixed(
+    6
+  )}, ${position.coords.longitude.toFixed(6)}`;
+}
 
 function abortWithReason(controller: AbortController, reason: unknown) {
   (controller.abort as (reason?: unknown) => void)(reason);
@@ -156,6 +178,81 @@ export default function CancellableCurrentPositionScreen() {
     }
   };
 
+  const runCacheIsolationScenario = async () => {
+    setResult("cacheIsolation", {
+      status: "running",
+      message: "Starting a watch and an immediate cache read"
+    });
+
+    try {
+      const watchedPosition = await runWithNativeGeolocation(
+        () =>
+          new Promise<GeolocationResponse>((resolve, reject) => {
+            let token = "";
+            let didFinish = false;
+            let cacheReadFinished = false;
+            const timeout = setTimeout(() => {
+              finish(() =>
+                reject(
+                  new Error(
+                    "Watch did not deliver after the concurrent cache read."
+                  )
+                )
+              );
+            }, 30000);
+            const finish = (callback: () => void) => {
+              if (didFinish) return;
+              didFinish = true;
+              clearTimeout(timeout);
+              if (token) unwatch(token);
+              callback();
+            };
+
+            token = watchPosition(
+              (position) => {
+                if (!cacheReadFinished || !isConcurrencyFixture(position)) {
+                  return;
+                }
+                finish(() => resolve(position));
+              },
+              (error) => finish(() => reject(error)),
+              {
+                accuracy: { android: "high", ios: "best" },
+                maximumAge: 0,
+                timeout: 30000
+              }
+            );
+
+            getLastKnownPositionAsync({ maximumAge: 0 }).then(
+              () => {
+                cacheReadFinished = true;
+                setResult("cacheIsolation", {
+                  status: "running",
+                  message:
+                    "Cache read completed; move location for the active watch."
+                });
+              },
+              (error) => finish(() => reject(error))
+            );
+          })
+      );
+
+      setResult("cacheIsolation", {
+        status: "passed",
+        message: `Cache read kept watch active at ${formatCoordinates(
+          watchedPosition
+        )}.`
+      });
+    } catch (error) {
+      setResult("cacheIsolation", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      await refreshPermission();
+    }
+  };
+
   const runWatchIsolationScenario = async () => {
     setResult("watchIsolation", {
       status: "running",
@@ -176,7 +273,8 @@ export default function CancellableCurrentPositionScreen() {
           new Promise<GeolocationResponse>((resolve, reject) => {
             let token = "";
             let didFinish = false;
-            let cancelledAt = Number.POSITIVE_INFINITY;
+            let oneShotStarted = false;
+            let cancellationConfirmed = false;
             const timeout = setTimeout(() => {
               finish(() =>
                 reject(
@@ -201,50 +299,56 @@ export default function CancellableCurrentPositionScreen() {
 
             token = watchPosition(
               (position) => {
-                if (position.timestamp < cancelledAt) return;
+                if (!oneShotStarted) {
+                  oneShotStarted = true;
+                  const cancelledRequest = getCurrentPosition({
+                    ...requestOptions,
+                    signal: controller.signal
+                  });
+                  abortWithReason(controller, cancellationReason);
+
+                  cancelledRequest.then(
+                    () =>
+                      finish(() =>
+                        reject(
+                          new Error(
+                            "Cancelled one-shot request unexpectedly resolved."
+                          )
+                        )
+                      ),
+                    (error) => {
+                      try {
+                        assertAbortOutcome(
+                          error,
+                          controller.signal,
+                          cancellationReason
+                        );
+                        cancellationConfirmed = true;
+                        setResult("watchIsolation", {
+                          status: "running",
+                          message:
+                            "One-shot cancelled; move location for the active watch."
+                        });
+                      } catch (assertionError) {
+                        finish(() => reject(assertionError));
+                      }
+                    }
+                  );
+                  return;
+                }
+
+                if (!cancellationConfirmed || !isConcurrencyFixture(position)) {
+                  return;
+                }
                 finish(() => resolve(position));
               },
               (error) => finish(() => reject(error)),
               requestOptions
             );
-
-            const cancelledRequest = getCurrentPosition({
-              ...requestOptions,
-              signal: controller.signal
-            });
-            abortWithReason(controller, cancellationReason);
-
-            cancelledRequest.then(
-              () =>
-                finish(() =>
-                  reject(
-                    new Error(
-                      "Cancelled one-shot request unexpectedly resolved."
-                    )
-                  )
-                ),
-              (error) => {
-                try {
-                  assertAbortOutcome(
-                    error,
-                    controller.signal,
-                    cancellationReason
-                  );
-                  cancelledAt = Date.now();
-                  setResult("watchIsolation", {
-                    status: "running",
-                    message:
-                      "One-shot cancelled; move location for the active watch."
-                  });
-                } catch (assertionError) {
-                  finish(() => reject(assertionError));
-                }
-              }
-            );
           })
       );
 
-      const coordinates = assertFixtureCoordinates(watchedPosition);
+      const coordinates = formatCoordinates(watchedPosition);
       setResult("watchIsolation", {
         status: "passed",
         message: `One-shot cancellation kept watch active at ${coordinates}.`
@@ -284,7 +388,22 @@ export default function CancellableCurrentPositionScreen() {
         />
       </ScenarioSection>
 
-      <ScenarioSection index={3} title="Concurrent Requests" divided>
+      <ScenarioSection index={3} title="Concurrent Cache Read" divided>
+        <ScenarioButton
+          title="Read Cache While Starting Watch"
+          onPress={runCacheIsolationScenario}
+          color="#455A64"
+          testID={`${PREFIX}-run-cache-isolation-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="cache-isolation"
+          label="Cache read isolation"
+          result={results.cacheIsolation}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={4} title="Concurrent Requests" divided>
         <ScenarioButton
           title="Run Isolated Cancellation"
           onPress={runIsolationScenario}
@@ -299,7 +418,7 @@ export default function CancellableCurrentPositionScreen() {
         />
       </ScenarioSection>
 
-      <ScenarioSection index={4} title="Active Watch" divided>
+      <ScenarioSection index={5} title="Active Watch" divided>
         <ScenarioButton
           title="Cancel One-shot While Watching"
           onPress={runWatchIsolationScenario}

--- a/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/CancellableCurrentPositionScreen.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { getCurrentPosition } from "react-native-nitro-geolocation";
+import {
+  PermissionStatusBlock,
+  ResultBlock,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  assertFixtureCoordinates,
+  createScenarioResults,
+  getDisplayErrorMessage,
+  runWithNativeGeolocation,
+  usePermissionStatus,
+  useScenarioResults
+} from "./scenario";
+
+const PREFIX = "cancellable-current-position";
+
+const initialResults = createScenarioResults([
+  "preAborted",
+  "isolation"
+] as const);
+
+function abortWithReason(controller: AbortController, reason: unknown) {
+  (controller.abort as (reason?: unknown) => void)(reason);
+}
+
+function assertAbortOutcome(
+  error: unknown,
+  signal: AbortSignal,
+  requestedReason: unknown
+): "exact reason" | "AbortError fallback" {
+  const runtimeReason = (signal as AbortSignal & { reason?: unknown }).reason;
+  if (runtimeReason !== undefined) {
+    if (error !== runtimeReason || runtimeReason !== requestedReason) {
+      throw new Error("Cancelled request did not preserve signal.reason.");
+    }
+    return "exact reason";
+  }
+
+  if (!(error instanceof Error) || error.name !== "AbortError") {
+    throw new Error("Cancelled request did not use an AbortError fallback.");
+  }
+  return "AbortError fallback";
+}
+
+export default function CancellableCurrentPositionScreen() {
+  const { permissionStatus, refreshPermission, requestLocationPermission } =
+    usePermissionStatus();
+  const { results, setResult } = useScenarioResults(initialResults);
+
+  const runPreAbortedScenario = async () => {
+    setResult("preAborted", {
+      status: "running",
+      message: "Rejecting a request whose signal is already aborted"
+    });
+
+    const controller = new AbortController();
+    const reason = new Error("cancelled before native work");
+    abortWithReason(controller, reason);
+
+    try {
+      await runWithNativeGeolocation(() =>
+        getCurrentPosition({ signal: controller.signal })
+      );
+      throw new Error("Pre-aborted getCurrentPosition unexpectedly resolved.");
+    } catch (error) {
+      try {
+        const outcome = assertAbortOutcome(error, controller.signal, reason);
+        setResult("preAborted", {
+          status: "passed",
+          message: `Pre-aborted request preserved the ${outcome}.`
+        });
+      } catch (assertionError) {
+        setResult("preAborted", {
+          status: "failed",
+          message: getDisplayErrorMessage(assertionError)
+        });
+      }
+    } finally {
+      await refreshPermission();
+    }
+  };
+
+  const runIsolationScenario = async () => {
+    setResult("isolation", {
+      status: "running",
+      message: "Starting two native requests and cancelling the first"
+    });
+
+    const cancelledController = new AbortController();
+    const survivorController = new AbortController();
+    const cancellationReason = new Error("cancel only the first request");
+
+    try {
+      const permission = await requestLocationPermission();
+      if (permission !== "granted") {
+        throw new Error(`Permission was not granted: ${permission}`);
+      }
+
+      const survivor = await runWithNativeGeolocation(async () => {
+        const requestOptions = {
+          accuracy: { android: "high" as const, ios: "best" as const },
+          maximumAge: 0,
+          timeout: 30000
+        };
+        const cancelledRequest = getCurrentPosition({
+          ...requestOptions,
+          signal: cancelledController.signal
+        });
+        const survivingRequest = getCurrentPosition({
+          ...requestOptions,
+          signal: survivorController.signal
+        });
+
+        abortWithReason(cancelledController, cancellationReason);
+
+        try {
+          await cancelledRequest;
+          throw new Error("Cancelled request unexpectedly resolved.");
+        } catch (error) {
+          assertAbortOutcome(
+            error,
+            cancelledController.signal,
+            cancellationReason
+          );
+        }
+
+        setResult("isolation", {
+          status: "running",
+          message:
+            "Cancelled request rejected; move location for surviving request."
+        });
+        return survivingRequest;
+      });
+
+      const coordinates = assertFixtureCoordinates(survivor);
+      setResult("isolation", {
+        status: "passed",
+        message: `Native cancellation cancelled first only; survivor ${coordinates}.`
+      });
+    } catch (error) {
+      setResult("isolation", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      survivorController.abort();
+      await refreshPermission();
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix={PREFIX}
+      title="Cancellable Current Position"
+      subtitle="AbortSignal cancellation without cross-request interference"
+    >
+      <ScenarioSection index={1} title="Permission">
+        <PermissionStatusBlock prefix={PREFIX} status={permissionStatus} />
+      </ScenarioSection>
+
+      <ScenarioSection index={2} title="Pre-aborted Signal" divided>
+        <ScenarioButton
+          title="Run Pre-aborted Request"
+          onPress={runPreAbortedScenario}
+          testID={`${PREFIX}-run-pre-aborted-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="pre-aborted"
+          label="Pre-aborted request"
+          result={results.preAborted}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={3} title="Concurrent Requests" divided>
+        <ScenarioButton
+          title="Run Isolated Cancellation"
+          onPress={runIsolationScenario}
+          color="#7B1FA2"
+          testID={`${PREFIX}-run-isolation-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="isolation"
+          label="Isolated cancellation"
+          result={results.isolation}
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}

--- a/examples/web-e2e/src/currentPositionCancellation.ts
+++ b/examples/web-e2e/src/currentPositionCancellation.ts
@@ -1,0 +1,38 @@
+import { getCurrentPosition } from "react-native-nitro-geolocation";
+
+export async function runPreAbortedCurrentPosition() {
+  const controller = new AbortController();
+  const reason = new Error("web pre-aborted request");
+  controller.abort(reason);
+
+  try {
+    await getCurrentPosition({ signal: controller.signal });
+    throw new Error("Pre-aborted request unexpectedly resolved.");
+  } catch (error) {
+    if (error !== reason) {
+      throw new Error("Pre-aborted request did not preserve signal.reason.");
+    }
+    return { sameReason: true };
+  }
+}
+
+export async function runCancelledCurrentPosition() {
+  const controller = new AbortController();
+  const reason = new Error("web in-flight cancellation");
+  const request = getCurrentPosition({
+    maximumAge: 0,
+    signal: controller.signal,
+    timeout: 15000
+  });
+  controller.abort(reason);
+
+  try {
+    await request;
+    throw new Error("Cancelled request unexpectedly resolved.");
+  } catch (error) {
+    if (error !== reason) {
+      throw new Error("In-flight request did not preserve signal.reason.");
+    }
+    return { sameReason: true };
+  }
+}

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -20,6 +20,10 @@ import {
   runCompatApiAvailabilityCheck,
   runCompatScenarios
 } from "./compatRunner";
+import {
+  runCancelledCurrentPosition,
+  runPreAbortedCurrentPosition
+} from "./currentPositionCancellation";
 import { setScenario } from "./dom";
 import {
   expectCacheMiss,
@@ -34,27 +38,11 @@ import {
   isNearExpected
 } from "./locationAssertions";
 import { postNativeStatus } from "./nativeBridge";
+import { runStep } from "./scenarioRunner";
 import { scenarios } from "./scenarios";
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function runStep<T>(
-  id: string,
-  action: () => Promise<T>,
-  validate: (value: T) => void = () => undefined
-) {
-  setScenario(id, "running");
-  try {
-    const result = await action();
-    validate(result);
-    setScenario(id, "pass", result);
-    return result;
-  } catch (error) {
-    setScenario(id, "fail", error);
-    throw error;
-  }
 }
 
 async function watchUntilFirstEvent({
@@ -271,6 +259,13 @@ export async function runSuccessSuite() {
       }
     }
   );
+
+  await runStep(
+    "get-current-position-pre-aborted",
+    runPreAbortedCurrentPosition
+  );
+
+  await runStep("get-current-position-cancelled", runCancelledCurrentPosition);
 
   const position = await runStep(
     "get-current-position",
@@ -501,6 +496,8 @@ export async function runSuccessSuite() {
         "request-location-settings",
         "check-permission",
         "request-permission",
+        "get-current-position-pre-aborted",
+        "get-current-position-cancelled",
         "get-current-position",
         "last-known-cold-cache",
         "last-known-async-cold-cache",

--- a/examples/web-e2e/src/scenarioRunner.ts
+++ b/examples/web-e2e/src/scenarioRunner.ts
@@ -1,0 +1,18 @@
+import { setScenario } from "./dom";
+
+export async function runStep<T>(
+  id: string,
+  action: () => Promise<T>,
+  validate: (value: T) => void = () => undefined
+) {
+  setScenario(id, "running");
+  try {
+    const result = await action();
+    validate(result);
+    setScenario(id, "pass", result);
+    return result;
+  } catch (error) {
+    setScenario(id, "fail", error);
+    throw error;
+  }
+}

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -46,6 +46,18 @@ export const scenarios: Scenario[] = [
     status: "idle"
   },
   {
+    id: "get-current-position-pre-aborted",
+    title: "getCurrentPosition pre-aborted",
+    detail: "Rejects with the exact abort reason without starting a request.",
+    status: "idle"
+  },
+  {
+    id: "get-current-position-cancelled",
+    title: "getCurrentPosition in-flight cancellation",
+    detail: "Cancels an active one-shot request with AbortSignal.",
+    status: "idle"
+  },
+  {
     id: "last-known-cold-cache",
     title: "getLastKnownPosition cold cache",
     detail:

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidFusedLocationProvider.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidFusedLocationProvider.kt
@@ -8,7 +8,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.tasks.CancellationTokenSource
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 private const val FUSED_ATTEMPT_TIMEOUT_MS = 15_000L
 private const val FUSED_FALLBACK_RESERVED_TIMEOUT_MS = 10_000L
@@ -23,25 +23,45 @@ internal class AndroidFusedLocationProvider(
         success: (GeolocationResponse) -> Unit,
         error: ((LocationError) -> Unit)?,
         options: ParsedOptions,
-        deadlineElapsedRealtime: Long
+        deadlineElapsedRealtime: Long,
+        onCancellationReady: ((() -> Unit) -> Unit)? = null
     ) {
+        val cancellationState = CurrentPositionCancellationState()
+        onCancellationReady?.invoke(cancellationState::cancel)
+
         if (effectiveMaximumAge(options) > 0.0) {
             getCachedLocation(options) { cachedLocation, fusedError ->
                 if (cachedLocation != null) {
-                    success(locationToPosition(cachedLocation, LocationProviderUsed.FUSED))
+                    if (cancellationState.finish()) {
+                        success(locationToPosition(cachedLocation, LocationProviderUsed.FUSED))
+                    }
                     return@getCachedLocation
                 }
                 if (fusedError != null) {
-                    error?.invoke(fusedError)
+                    if (cancellationState.finish()) error?.invoke(fusedError)
                     return@getCachedLocation
                 }
 
-                requestFreshLocation(success, error, options, deadlineElapsedRealtime)
+                if (cancellationState.isActive()) {
+                    requestFreshLocation(
+                        success,
+                        error,
+                        options,
+                        deadlineElapsedRealtime,
+                        cancellationState
+                    )
+                }
             }
             return
         }
 
-        requestFreshLocation(success, error, options, deadlineElapsedRealtime)
+        requestFreshLocation(
+            success,
+            error,
+            options,
+            deadlineElapsedRealtime,
+            cancellationState
+        )
     }
 
     fun getLastKnownPosition(
@@ -125,37 +145,43 @@ internal class AndroidFusedLocationProvider(
         success: (GeolocationResponse) -> Unit,
         error: ((LocationError) -> Unit)?,
         options: ParsedOptions,
-        deadlineElapsedRealtime: Long
+        deadlineElapsedRealtime: Long,
+        cancellationState: CurrentPositionCancellationState
     ) {
         val handler = Handler(Looper.getMainLooper())
-        val didComplete = AtomicBoolean(false)
         val remainingTimeoutMillis = remainingTimeoutMillis(deadlineElapsedRealtime)
 
         if (remainingTimeoutMillis <= 0L) {
-            error?.invoke(createPositionTimeoutError(options))
+            if (cancellationState.finish()) error?.invoke(createPositionTimeoutError(options))
             return
         }
         val fusedAttemptTimeoutMillis = fusedAttemptTimeoutMillis(remainingTimeoutMillis)
         val cancellationTokenSource = CancellationTokenSource()
-        var locationUpdateCallback: LocationCallback? = null
+        val locationUpdateCallback = AtomicReference<LocationCallback?>(null)
 
-        fun complete(result: PositionResult) {
-            if (!didComplete.compareAndSet(false, true)) return
-
+        fun cleanup() {
             handler.removeCallbacksAndMessages(null)
-            locationUpdateCallback?.let { callback ->
+            locationUpdateCallback.getAndSet(null)?.let { callback ->
                 try {
                     fusedLocationClient.removeLocationUpdates(callback)
                 } catch (_: Exception) {
                     // Ignore cleanup races.
                 }
             }
-            locationUpdateCallback = null
             try {
                 cancellationTokenSource.cancel()
             } catch (_: Exception) {
                 // Ignore cleanup races.
             }
+        }
+
+        cancellationState.setCancellationAction(::cleanup)
+        if (!cancellationState.isActive()) return
+
+        fun complete(result: PositionResult) {
+            if (!cancellationState.finish()) return
+
+            cleanup()
 
             when (result) {
                 is PositionResult.Success -> success(result.position)
@@ -165,6 +191,11 @@ internal class AndroidFusedLocationProvider(
 
         val timeoutRunnable = Runnable {
             complete(PositionResult.Failure(createPositionTimeoutError(options)))
+        }
+        handler.postDelayed(timeoutRunnable, fusedAttemptTimeoutMillis)
+        if (!cancellationState.isActive()) {
+            handler.removeCallbacks(timeoutRunnable)
+            return
         }
 
         try {
@@ -193,23 +224,30 @@ internal class AndroidFusedLocationProvider(
                         }
                     }
                 }
-                locationUpdateCallback = callback
+                locationUpdateCallback.set(callback)
 
-                fusedLocationClient.requestLocationUpdates(
+                val requestTask = fusedLocationClient.requestLocationUpdates(
                     request,
                     callback,
                     Looper.getMainLooper()
                 )
-                    .addOnFailureListener { exception ->
-                        complete(PositionResult.Failure(
-                            createFusedRequestFailureError(exception)
-                        ))
+                if (!cancellationState.isActive()) {
+                    try {
+                        fusedLocationClient.removeLocationUpdates(callback)
+                    } catch (_: Exception) {
+                        // Ignore a cancellation race before registration completed.
                     }
+                    return
+                }
+                requestTask.addOnFailureListener { exception ->
+                    complete(PositionResult.Failure(
+                        createFusedRequestFailureError(exception)
+                    ))
+                }
                     .addOnCanceledListener {
                         complete(PositionResult.Failure(createPositionTimeoutError(options)))
                     }
 
-                handler.postDelayed(timeoutRunnable, fusedAttemptTimeoutMillis)
                 return
             }
 
@@ -248,8 +286,6 @@ internal class AndroidFusedLocationProvider(
                 .addOnCanceledListener {
                     complete(PositionResult.Failure(createPositionTimeoutError(options)))
                 }
-
-            handler.postDelayed(timeoutRunnable, fusedAttemptTimeoutMillis)
         } catch (e: SecurityException) {
             complete(PositionResult.Failure(createFusedSecurityError(e.message)))
         } catch (e: Exception) {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
@@ -1,9 +1,7 @@
 package com.margelo.nitro.nitrogeolocation
 
-import android.os.CancellationSignal
 import android.os.Handler
 import android.os.SystemClock
-import java.util.UUID
 
 internal data class ParsedOptions(
     val timeout: Double,
@@ -76,16 +74,54 @@ internal sealed interface PositionResult {
 }
 
 internal data class PositionRequest(
-    val id: UUID,
+    val id: String,
     val resolver: (PositionResult) -> Unit,
     val options: ParsedOptions,
     val handler: Handler,
     val providers: List<String>,
     val deadlineElapsedRealtime: Long,
     var providerIndex: Int = 0,
-    var cancellationSignal: CancellationSignal? = null
+    @Volatile
+    var cancellationAction: (() -> Unit)? = null
 ) {
     fun remainingTimeoutMillis(): Long {
         return (deadlineElapsedRealtime - SystemClock.elapsedRealtime()).coerceAtLeast(0L)
+    }
+}
+
+internal class CurrentPositionCancellationState {
+    private val lock = Any()
+    private var active = true
+    private var cancellationAction: (() -> Unit)? = null
+
+    fun isActive(): Boolean = synchronized(lock) { active }
+
+    fun setCancellationAction(action: () -> Unit) {
+        val shouldCancel = synchronized(lock) {
+            if (active) {
+                cancellationAction = action
+                false
+            } else {
+                true
+            }
+        }
+
+        if (shouldCancel) action()
+    }
+
+    fun finish(): Boolean = synchronized(lock) {
+        if (!active) return@synchronized false
+        active = false
+        cancellationAction = null
+        true
+    }
+
+    fun cancel() {
+        val action = synchronized(lock) {
+            if (!active) return@synchronized null
+            active = false
+            cancellationAction.also { cancellationAction = null }
+        }
+        action?.invoke()
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationRequestHelpers.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidLocationRequestHelpers.kt
@@ -1,0 +1,107 @@
+package com.margelo.nitro.nitrogeolocation
+
+import android.location.Location
+
+private const val TWO_MINUTES_MS = 2 * 60 * 1000L
+
+internal fun validateParsedOptions(options: ParsedOptions): LocationError? {
+    if (!options.timeout.isFinite() || options.timeout < 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "timeout must be a finite number greater than or equal to 0."
+        )
+    }
+
+    if (!options.maximumAge.isFinite() && options.maximumAge != Double.POSITIVE_INFINITY) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "maximumAge must be a finite number greater than or equal to 0."
+        )
+    }
+
+    if (options.maximumAge < 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "maximumAge must be greater than or equal to 0."
+        )
+    }
+
+    if (!options.interval.isFinite() || options.interval <= 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "interval must be a finite number greater than 0."
+        )
+    }
+
+    if (!options.fastestInterval.isFinite() || options.fastestInterval <= 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "fastestInterval must be a finite number greater than 0."
+        )
+    }
+
+    if (!options.distanceFilter.isFinite() || options.distanceFilter < 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "distanceFilter must be a finite number greater than or equal to 0."
+        )
+    }
+
+    val maxUpdateAge = options.maxUpdateAge
+    if (maxUpdateAge != null && (!maxUpdateAge.isFinite() || maxUpdateAge < 0.0)) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "maxUpdateAge must be a finite number greater than or equal to 0."
+        )
+    }
+
+    if (!options.maxUpdateDelay.isFinite() || options.maxUpdateDelay < 0.0) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "maxUpdateDelay must be a finite number greater than or equal to 0."
+        )
+    }
+
+    val maxUpdates = options.maxUpdates
+    if (maxUpdates != null && maxUpdates < 1) {
+        return createLocationError(
+            INTERNAL_ERROR,
+            "maxUpdates must be greater than or equal to 1."
+        )
+    }
+
+    return null
+}
+
+internal fun selectBestLocation(newLocation: Location, currentBest: Location?): Location {
+    if (currentBest == null) return newLocation
+
+    val timeDelta = newLocation.time - currentBest.time
+    val isSignificantlyNewer = timeDelta > TWO_MINUTES_MS
+    val isSignificantlyOlder = timeDelta < -TWO_MINUTES_MS
+
+    if (isSignificantlyNewer) return newLocation
+    if (isSignificantlyOlder) return currentBest
+
+    val accuracyDelta = (newLocation.accuracy - currentBest.accuracy).toInt()
+    val isMoreAccurate = accuracyDelta < 0
+    val isSignificantlyLessAccurate = accuracyDelta > 200
+    val isNewer = timeDelta > 0
+    val isLessAccurate = accuracyDelta > 0
+    val isFromSameProvider = newLocation.provider == currentBest.provider
+
+    return when {
+        isMoreAccurate -> newLocation
+        isNewer && !isLessAccurate -> newLocation
+        isNewer && !isSignificantlyLessAccurate && isFromSameProvider -> newLocation
+        else -> currentBest
+    }
+}
+
+internal fun mergeNullableMinimum(current: Double?, next: Double?): Double? {
+    return when {
+        current == null -> next
+        next == null -> current
+        else -> minOf(current, next)
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -86,7 +86,9 @@ class NitroGeolocation(
     private val pendingPermissionResolvers = mutableListOf<(PermissionStatus) -> Unit>()
 
     // getCurrentPosition requests
-    private val pendingPositionRequests = ConcurrentHashMap<UUID, PositionRequest>()
+    private val pendingPositionRequests = ConcurrentHashMap<String, PositionRequest>()
+    private val cancellablePositionRequests =
+        ConcurrentHashMap<String, CurrentPositionCancellationState>()
 
     // Watch subscriptions (token -> callback)
     private val watchSubscriptions = ConcurrentHashMap<String, WatchSubscription>()
@@ -247,6 +249,53 @@ class NitroGeolocation(
         options: LocationRequestOptions,
         error: ((LocationError) -> Unit)?
     ): Unit {
+        getCurrentPositionInternal(success, options, error, null, null)
+    }
+
+    override fun getCurrentPositionCancellable(
+        requestId: String,
+        success: (GeolocationResponse) -> Unit,
+        options: LocationRequestOptions,
+        error: ((LocationError) -> Unit)?
+    ) {
+        val cancellationState = CurrentPositionCancellationState()
+        cancellablePositionRequests.put(requestId, cancellationState)?.cancel()
+
+        val finishRequest = {
+            cancellablePositionRequests.remove(requestId)
+        }
+        getCurrentPositionInternal(
+            success = { position ->
+                if (cancellationState.finish()) {
+                    finishRequest()
+                    success(position)
+                }
+            },
+            options = options,
+            error = { locationError ->
+                if (cancellationState.finish()) {
+                    finishRequest()
+                    error?.invoke(locationError)
+                }
+            },
+            requestId = requestId,
+            cancellationState = cancellationState
+        )
+    }
+
+    override fun cancelCurrentPositionRequest(requestId: String) {
+        cancellablePositionRequests.remove(requestId)?.cancel()
+    }
+
+    private fun getCurrentPositionInternal(
+        success: (GeolocationResponse) -> Unit,
+        options: LocationRequestOptions,
+        error: ((LocationError) -> Unit)?,
+        requestId: String?,
+        cancellationState: CurrentPositionCancellationState?
+    ) {
+        if (cancellationState?.isActive() == false) return
+
         // Check permission
         if (!hasLocationPermission()) {
             error?.invoke(createLocationError(
@@ -272,6 +321,7 @@ class NitroGeolocation(
             fusedLocationProvider.getCurrentPosition(
                 success,
                 { fusedError ->
+                    if (cancellationState?.isActive() == false) return@getCurrentPosition
                     runAndroidCurrentPositionFallbackAfterFusedFailure(
                         locationProvider = configuration?.locationProvider,
                         runPlatformFallback = {
@@ -279,7 +329,9 @@ class NitroGeolocation(
                                 success,
                                 error,
                                 parsedOptions,
-                                deadlineElapsedRealtime
+                                deadlineElapsedRealtime,
+                                requestId,
+                                cancellationState
                             )
                         },
                         failWithoutFallback = {
@@ -288,20 +340,34 @@ class NitroGeolocation(
                     )
                 },
                 parsedOptions,
-                deadlineElapsedRealtime
+                deadlineElapsedRealtime,
+                onCancellationReady = { action ->
+                    cancellationState?.setCancellationAction(action)
+                }
             )
             return
         }
 
-        getCurrentPositionWithPlatform(success, error, parsedOptions, deadlineElapsedRealtime)
+        getCurrentPositionWithPlatform(
+            success,
+            error,
+            parsedOptions,
+            deadlineElapsedRealtime,
+            requestId,
+            cancellationState
+        )
     }
 
     private fun getCurrentPositionWithPlatform(
         success: (GeolocationResponse) -> Unit,
         error: ((LocationError) -> Unit)?,
         parsedOptions: ParsedOptions,
-        deadlineElapsedRealtime: Long = createRequestDeadlineElapsedRealtime(parsedOptions.timeout)
+        deadlineElapsedRealtime: Long = createRequestDeadlineElapsedRealtime(parsedOptions.timeout),
+        requestId: String? = null,
+        cancellationState: CurrentPositionCancellationState? = null
     ) {
+        if (cancellationState?.isActive() == false) return
+
         val providers = getValidProviders(parsedOptions)
         if (providers.isEmpty()) {
             error?.invoke(createNoLocationProviderError(parsedOptions))
@@ -320,12 +386,21 @@ class NitroGeolocation(
         }
 
         // Request fresh location
-        requestFreshLocation(providers, parsedOptions, deadlineElapsedRealtime) { result ->
-            when (result) {
-                is PositionResult.Success -> success(result.position)
-                is PositionResult.Failure -> error?.invoke(result.error)
+        requestFreshLocation(
+            providers,
+            parsedOptions,
+            deadlineElapsedRealtime,
+            { result ->
+                when (result) {
+                    is PositionResult.Success -> success(result.position)
+                    is PositionResult.Failure -> error?.invoke(result.error)
+                }
+            },
+            requestId,
+            onCancellationReady = { action ->
+                cancellationState?.setCancellationAction(action)
             }
-        }
+        )
     }
 
     override fun getLastKnownPosition(
@@ -602,75 +677,6 @@ class NitroGeolocation(
         }
     }
 
-    private fun validateParsedOptions(options: ParsedOptions): LocationError? {
-        if (!options.timeout.isFinite() || options.timeout < 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "timeout must be a finite number greater than or equal to 0."
-            )
-        }
-
-        if (!options.maximumAge.isFinite() && options.maximumAge != Double.POSITIVE_INFINITY) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "maximumAge must be a finite number greater than or equal to 0."
-            )
-        }
-
-        if (options.maximumAge < 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "maximumAge must be greater than or equal to 0."
-            )
-        }
-
-        if (!options.interval.isFinite() || options.interval <= 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "interval must be a finite number greater than 0."
-            )
-        }
-
-        if (!options.fastestInterval.isFinite() || options.fastestInterval <= 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "fastestInterval must be a finite number greater than 0."
-            )
-        }
-
-        if (!options.distanceFilter.isFinite() || options.distanceFilter < 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "distanceFilter must be a finite number greater than or equal to 0."
-            )
-        }
-
-        val maxUpdateAge = options.maxUpdateAge
-        if (maxUpdateAge != null && (!maxUpdateAge.isFinite() || maxUpdateAge < 0.0)) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "maxUpdateAge must be a finite number greater than or equal to 0."
-            )
-        }
-
-        if (!options.maxUpdateDelay.isFinite() || options.maxUpdateDelay < 0.0) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "maxUpdateDelay must be a finite number greater than or equal to 0."
-            )
-        }
-
-        val maxUpdates = options.maxUpdates
-        if (maxUpdates != null && maxUpdates < 1) {
-            return createLocationError(
-                INTERNAL_ERROR,
-                "maxUpdates must be greater than or equal to 1."
-            )
-        }
-
-        return null
-    }
-
     private fun validateRequestPermission(options: ParsedOptions): LocationError? {
         if (options.granularity == AndroidGranularity.FINE && !hasFineLocationPermission()) {
             return createLocationError(
@@ -840,9 +846,11 @@ class NitroGeolocation(
         providers: List<String>,
         options: ParsedOptions,
         deadlineElapsedRealtime: Long = createRequestDeadlineElapsedRealtime(options.timeout),
-        resolver: (PositionResult) -> Unit
+        resolver: (PositionResult) -> Unit,
+        requestId: String? = null,
+        onCancellationReady: ((() -> Unit) -> Unit)? = null
     ) {
-        val id = UUID.randomUUID()
+        val id = requestId ?: UUID.randomUUID().toString()
         val handler = Handler(Looper.getMainLooper())
 
         val request = PositionRequest(
@@ -855,10 +863,18 @@ class NitroGeolocation(
         )
 
         pendingPositionRequests[id] = request
+        onCancellationReady?.invoke { cancelPlatformCurrentPositionRequest(id) }
         requestFreshLocationForCurrentProvider(id)
     }
 
-    private fun requestFreshLocationForCurrentProvider(requestId: UUID) {
+    private fun cancelPlatformCurrentPositionRequest(requestId: String) {
+        val request = pendingPositionRequests.remove(requestId) ?: return
+        request.handler.removeCallbacksAndMessages(null)
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+    }
+
+    private fun requestFreshLocationForCurrentProvider(requestId: String) {
         val request = pendingPositionRequests[requestId] ?: return
         val provider = request.providers.getOrNull(request.providerIndex)
         val remainingTimeoutMillis = request.remainingTimeoutMillis()
@@ -889,7 +905,7 @@ class NitroGeolocation(
     @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
     private fun requestCurrentLocationModern(
         provider: String,
-        requestId: UUID,
+        requestId: String,
         handler: Handler,
         timeoutMillis: Long
     ) {
@@ -932,7 +948,17 @@ class NitroGeolocation(
 
             handler.postDelayed(timeoutRunnable, timeoutMillis)
 
-            pendingPositionRequests[requestId]?.cancellationSignal = cancellationSignal
+            val cleanup = {
+                handler.removeCallbacksAndMessages(null)
+                cancellationSignal.cancel()
+            }
+            val request = pendingPositionRequests[requestId]
+            if (request != null) {
+                request.cancellationAction = cleanup
+                if (pendingPositionRequests[requestId] !== request) cleanup()
+            } else {
+                cleanup()
+            }
 
         } catch (e: SecurityException) {
             handler.removeCallbacks(timeoutRunnable)
@@ -945,12 +971,12 @@ class NitroGeolocation(
 
     private fun retryCurrentLocationLegacyAfterStaleModern(
         provider: String,
-        requestId: UUID,
+        requestId: String,
         handler: Handler,
         request: PositionRequest
     ) {
-        request.cancellationSignal?.cancel()
-        request.cancellationSignal = null
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
 
         val remainingTimeoutMillis = request.remainingTimeoutMillis()
         if (remainingTimeoutMillis <= 0L) {
@@ -963,7 +989,7 @@ class NitroGeolocation(
 
     private fun requestCurrentLocationLegacy(
         provider: String,
-        requestId: UUID,
+        requestId: String,
         handler: Handler,
         timeoutMillis: Long
     ) {
@@ -1028,6 +1054,25 @@ class NitroGeolocation(
 
             handler.postDelayed(timeoutRunnable, timeoutMillis)
 
+            val cleanup = {
+                synchronized(listener) {
+                    isResolved = true
+                    handler.removeCallbacksAndMessages(null)
+                    try {
+                        locationManager.removeUpdates(listener)
+                    } catch (_: Exception) {
+                        // Ignore cleanup races.
+                    }
+                }
+            }
+            val request = pendingPositionRequests[requestId]
+            if (request != null) {
+                request.cancellationAction = cleanup
+                if (pendingPositionRequests[requestId] !== request) cleanup()
+            } else {
+                cleanup()
+            }
+
         } catch (e: SecurityException) {
             handleProviderFailure(requestId, createLocationError(
                 PERMISSION_DENIED,
@@ -1036,11 +1081,11 @@ class NitroGeolocation(
         }
     }
 
-    private fun handleProviderFailure(requestId: UUID, error: LocationError) {
+    private fun handleProviderFailure(requestId: String, error: LocationError) {
         val request = pendingPositionRequests[requestId] ?: return
 
-        request.cancellationSignal?.cancel()
-        request.cancellationSignal = null
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
         request.providerIndex += 1
 
         if (request.providerIndex < request.providers.size) {
@@ -1058,42 +1103,12 @@ class NitroGeolocation(
         pendingPositionRequests.remove(requestId)?.resolver(PositionResult.Failure(error))
     }
 
-    private fun selectBestLocation(newLocation: Location, currentBest: Location?): Location {
-        if (currentBest == null) return newLocation
-
-        val timeDelta = newLocation.time - currentBest.time
-        val isSignificantlyNewer = timeDelta > TWO_MINUTES_MS
-        val isSignificantlyOlder = timeDelta < -TWO_MINUTES_MS
-
-        if (isSignificantlyNewer) return newLocation
-        if (isSignificantlyOlder) return currentBest
-
-        val accuracyDelta = (newLocation.accuracy - currentBest.accuracy).toInt()
-        val isMoreAccurate = accuracyDelta < 0
-        val isSignificantlyLessAccurate = accuracyDelta > 200
-        val isNewer = timeDelta > 0
-        val isLessAccurate = accuracyDelta > 0
-        val isFromSameProvider = newLocation.provider == currentBest.provider
-
-        return when {
-            isMoreAccurate -> newLocation
-            isNewer && !isLessAccurate -> newLocation
-            isNewer && !isSignificantlyLessAccurate && isFromSameProvider -> newLocation
-            else -> currentBest
-        }
-    }
-
-    private fun handlePositionTimeout(requestId: UUID) {
-        val request = pendingPositionRequests[requestId]
-        if (request != null) {
-            request.handler.removeCallbacksAndMessages(null)
-            request.cancellationSignal?.cancel()
-            request.cancellationSignal = null
-
-            pendingPositionRequests.remove(requestId)?.resolver(
-                PositionResult.Failure(createPositionTimeoutError(request.options))
-            )
-        }
+    private fun handlePositionTimeout(requestId: String) {
+        val request = pendingPositionRequests.remove(requestId) ?: return
+        request.handler.removeCallbacksAndMessages(null)
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+        request.resolver(PositionResult.Failure(createPositionTimeoutError(request.options)))
     }
 
     // MARK: - Helper Functions - Watch Position
@@ -1326,14 +1341,6 @@ class NitroGeolocation(
         }
     }
 
-    private fun mergeNullableMinimum(current: Double?, next: Double?): Double? {
-        return when {
-            current == null -> next
-            next == null -> current
-            else -> minOf(current, next)
-        }
-    }
-
     private fun stopWatchingLocation() {
         watchLocationGeneration.incrementAndGet()
         removePlatformWatchLocationListener()
@@ -1437,6 +1444,5 @@ class NitroGeolocation(
     companion object {
         private const val PERMISSION_REQUEST_CODE = 8947
         private const val GEOCODER_MAX_RESULTS = 5
-        private const val TWO_MINUTES_MS = 2 * 60 * 1000L
     }
 }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -7,7 +7,7 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        runCurrentPositionOperationOnMain {
+        runLocationOperationOnMain {
             self.getCurrentPositionInternal(
                 requestId: UUID().uuidString,
                 success: success,
@@ -23,7 +23,7 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        runCurrentPositionOperationOnMain {
+        runLocationOperationOnMain {
             self.cancelCurrentPositionRequestOnMain(requestId: requestId)
             self.getCurrentPositionInternal(
                 requestId: requestId,
@@ -35,9 +35,31 @@ extension NitroGeolocation {
     }
 
     func cancelCurrentPositionRequest(requestId: String) {
-        runCurrentPositionOperationOnMain {
+        runLocationOperationOnMain {
             self.cancelCurrentPositionRequestOnMain(requestId: requestId)
         }
+    }
+
+    func watchPosition(
+        success: @escaping (GeolocationResponse) -> Void,
+        options: LocationRequestOptions,
+        error: ((LocationError) -> Void)?
+    ) -> String {
+        let token = UUID().uuidString
+        let subscription = WatchSubscription(
+            success: success,
+            error: error,
+            options: ParsedOptions.parse(from: options)
+        )
+
+        runLocationOperationOnMain {
+            self.watchSubscriptions[token] = subscription
+            self.initializeLocationManagerIfNeeded()
+            self.updateLocationManagerConfiguration()
+            self.startMonitoring()
+        }
+
+        return token
     }
 
     private func cancelCurrentPositionRequestOnMain(requestId: String) {
@@ -49,7 +71,7 @@ extension NitroGeolocation {
         updateMonitoringAfterPositionRequestRemoval()
     }
 
-    private func runCurrentPositionOperationOnMain(_ operation: @escaping () -> Void) {
+    internal func runLocationOperationOnMain(_ operation: @escaping () -> Void) {
         if Thread.isMainThread {
             operation()
         } else {

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -7,11 +7,13 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
         runLocationOperationOnMain {
             self.getCurrentPositionInternal(
                 requestId: UUID().uuidString,
                 success: success,
                 options: options,
+                locationServicesEnabled: locationServicesEnabled,
                 error: error
             )
         }
@@ -23,12 +25,14 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
         runLocationOperationOnMain {
             self.cancelCurrentPositionRequestOnMain(requestId: requestId)
             self.getCurrentPositionInternal(
                 requestId: requestId,
                 success: success,
                 options: options,
+                locationServicesEnabled: locationServicesEnabled,
                 error: error
             )
         }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -7,12 +7,14 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        getCurrentPositionInternal(
-            requestId: UUID().uuidString,
-            success: success,
-            options: options,
-            error: error
-        )
+        runCurrentPositionOperationOnMain {
+            self.getCurrentPositionInternal(
+                requestId: UUID().uuidString,
+                success: success,
+                options: options,
+                error: error
+            )
+        }
     }
 
     func getCurrentPositionCancellable(
@@ -21,22 +23,38 @@ extension NitroGeolocation {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        cancelCurrentPositionRequest(requestId: requestId)
-        getCurrentPositionInternal(
-            requestId: requestId,
-            success: success,
-            options: options,
-            error: error
-        )
+        runCurrentPositionOperationOnMain {
+            self.cancelCurrentPositionRequestOnMain(requestId: requestId)
+            self.getCurrentPositionInternal(
+                requestId: requestId,
+                success: success,
+                options: options,
+                error: error
+            )
+        }
     }
 
     func cancelCurrentPositionRequest(requestId: String) {
+        runCurrentPositionOperationOnMain {
+            self.cancelCurrentPositionRequestOnMain(requestId: requestId)
+        }
+    }
+
+    private func cancelCurrentPositionRequestOnMain(requestId: String) {
         guard let request = pendingPositionRequests.removeValue(forKey: requestId) else {
             return
         }
 
         request.timer?.cancel()
         updateMonitoringAfterPositionRequestRemoval()
+    }
+
+    private func runCurrentPositionOperationOnMain(_ operation: @escaping () -> Void) {
+        if Thread.isMainThread {
+            operation()
+        } else {
+            DispatchQueue.main.async(execute: operation)
+        }
     }
 }
 

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -1,0 +1,50 @@
+import Foundation
+import CoreLocation
+
+extension NitroGeolocation {
+    func getCurrentPosition(
+        success: @escaping (GeolocationResponse) -> Void,
+        options: LocationRequestOptions,
+        error: ((LocationError) -> Void)?
+    ) throws -> Void {
+        getCurrentPositionInternal(
+            requestId: UUID().uuidString,
+            success: success,
+            options: options,
+            error: error
+        )
+    }
+
+    func getCurrentPositionCancellable(
+        requestId: String,
+        success: @escaping (GeolocationResponse) -> Void,
+        options: LocationRequestOptions,
+        error: ((LocationError) -> Void)?
+    ) throws -> Void {
+        cancelCurrentPositionRequest(requestId: requestId)
+        getCurrentPositionInternal(
+            requestId: requestId,
+            success: success,
+            options: options,
+            error: error
+        )
+    }
+
+    func cancelCurrentPositionRequest(requestId: String) {
+        guard let request = pendingPositionRequests.removeValue(forKey: requestId) else {
+            return
+        }
+
+        request.timer?.cancel()
+        updateMonitoringAfterPositionRequestRemoval()
+    }
+}
+
+internal func isCachedLocationValid(_ location: CLLocation, options: ParsedOptions) -> Bool {
+    if options.maximumAge.isInfinite {
+        return true
+    }
+
+    let age = Date().timeIntervalSince(location.timestamp) * 1000
+    return age < options.maximumAge
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -184,6 +184,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         requestId: String,
         success: @escaping (GeolocationResponse) -> Void,
         options: LocationRequestOptions,
+        locationServicesEnabled: Bool,
         error: ((LocationError) -> Void)?
     ) {
         dispatchPrecondition(condition: .onQueue(.main))
@@ -201,7 +202,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return
         }
 
-        if !CLLocationManager.locationServicesEnabled() {
+        if !locationServicesEnabled {
             error?(createLocationError(
                 code: SETTINGS_NOT_SATISFIED,
                 message: "Location services disabled."
@@ -379,8 +380,12 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         success: @escaping (Heading) -> Void,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
         runLocationOperationOnMain {
-            guard self.validateHeadingAvailability(error: error) else { return }
+            guard self.validateHeadingAvailability(
+                locationServicesEnabled: locationServicesEnabled,
+                error: error
+            ) else { return }
             self.initializeLocationManagerIfNeeded()
 
             let id = UUID()
@@ -419,6 +424,8 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return token
         }
 
+        let locationServicesEnabled = CLLocationManager.locationServicesEnabled()
+
         let subscription = HeadingSubscription(
             success: success,
             error: error,
@@ -427,7 +434,10 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         )
 
         runLocationOperationOnMain {
-            guard self.validateHeadingAvailability(error: error) else { return }
+            guard self.validateHeadingAvailability(
+                locationServicesEnabled: locationServicesEnabled,
+                error: error
+            ) else { return }
             self.headingSubscriptions[token] = subscription
             self.initializeLocationManagerIfNeeded()
             self.updateHeadingConfiguration()
@@ -619,6 +629,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     }
 
     private func validateHeadingAvailability(
+        locationServicesEnabled: Bool,
         error: ((LocationError) -> Void)?
     ) -> Bool {
         let status = CLLocationManager.authorizationStatus()
@@ -633,7 +644,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return false
         }
 
-        if !CLLocationManager.locationServicesEnabled() {
+        if !locationServicesEnabled {
             error?(createLocationError(
                 code: SETTINGS_NOT_SATISFIED,
                 message: "Location services disabled."

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -188,6 +188,8 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) {
+        dispatchPrecondition(condition: .onQueue(.main))
+
         // Check permission
         let status = CLLocationManager.authorizationStatus()
         if status == .denied || status == .restricted {

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -27,7 +27,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     internal var pendingPositionRequests: [String: PositionRequest] = [:]
 
     // Watch subscriptions (token -> callback)
-    private var watchSubscriptions: [String: WatchSubscription] = [:]
+    internal var watchSubscriptions: [String: WatchSubscription] = [:]
 
     // Heading requests/subscriptions
     private var pendingHeadingRequests: [UUID: HeadingRequest] = [:]
@@ -444,42 +444,17 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         return token
     }
 
-    // MARK: - Watch Position (Callback-based with tokens)
-
-    func watchPosition(
-        success: @escaping (GeolocationResponse) -> Void,
-        options: LocationRequestOptions,
-        error: ((LocationError) -> Void)?
-    ) -> String {
-        let token = UUID().uuidString
-        let parsedOptions = ParsedOptions.parse(from: options)
-
-        let subscription = WatchSubscription(
-            success: success,
-            error: error,
-            options: parsedOptions
-        )
-
-        watchSubscriptions[token] = subscription
-
-        initializeLocationManagerIfNeeded()
-        updateLocationManagerConfiguration()
-        startMonitoring()
-
-        return token
-    }
-
     func unwatch(token: String) {
-        watchSubscriptions.removeValue(forKey: token)
-        headingSubscriptions.removeValue(forKey: token)
-
-        // Stop monitoring if no more subscriptions or pending requests
-        if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
-            stopMonitoring()
-        } else {
-            updateLocationManagerConfiguration()
+        runLocationOperationOnMain {
+            self.watchSubscriptions.removeValue(forKey: token)
+            if self.watchSubscriptions.isEmpty && self.pendingPositionRequests.isEmpty {
+                self.stopMonitoring()
+            } else {
+                self.updateLocationManagerConfiguration()
+            }
         }
 
+        headingSubscriptions.removeValue(forKey: token)
         if headingSubscriptions.isEmpty && pendingHeadingRequests.isEmpty {
             stopHeadingMonitoring()
         } else {
@@ -488,16 +463,16 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     }
 
     func stopObserving() {
-        watchSubscriptions.removeAll()
-        headingSubscriptions.removeAll()
-
-        // Stop monitoring if no pending requests
-        if pendingPositionRequests.isEmpty {
-            stopMonitoring()
-        } else {
-            updateLocationManagerConfiguration()
+        runLocationOperationOnMain {
+            self.watchSubscriptions.removeAll()
+            if self.pendingPositionRequests.isEmpty {
+                self.stopMonitoring()
+            } else {
+                self.updateLocationManagerConfiguration()
+            }
         }
 
+        headingSubscriptions.removeAll()
         if pendingHeadingRequests.isEmpty {
             stopHeadingMonitoring()
         } else {
@@ -630,7 +605,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     // MARK: - Helper Functions
 
-    private func initializeLocationManagerIfNeeded() {
+    internal func initializeLocationManagerIfNeeded() {
         guard locationManager == nil else { return }
 
         if Thread.isMainThread {
@@ -753,7 +728,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         stopHeadingMonitoring()
     }
 
-    private func updateLocationManagerConfiguration() {
+    internal func updateLocationManagerConfiguration() {
         guard let manager = locationManager else { return }
 
         // Merge configurations from all pending requests and watches
@@ -886,7 +861,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         return min(current, next)
     }
 
-    private func startMonitoring() {
+    internal func startMonitoring() {
         if usingSignificantChanges {
             locationManager?.startMonitoringSignificantLocationChanges()
         } else {

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -24,7 +24,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     private var pendingPermissionResolvers: [(PermissionStatus) -> Void] = []
 
     // getCurrentPosition promise resolvers with timeout
-    private var pendingPositionRequests: [UUID: PositionRequest] = [:]
+    internal var pendingPositionRequests: [String: PositionRequest] = [:]
 
     // Watch subscriptions (token -> callback)
     private var watchSubscriptions: [String: WatchSubscription] = [:]
@@ -182,11 +182,12 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     // MARK: - Get Current Position
 
-    func getCurrentPosition(
+    internal func getCurrentPositionInternal(
+        requestId: String,
         success: @escaping (GeolocationResponse) -> Void,
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
-    ) throws -> Void {
+    ) {
         // Check permission
         let status = CLLocationManager.authorizationStatus()
         if status == .denied || status == .restricted {
@@ -221,7 +222,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         }
 
         // Create position request
-        let id = UUID()
         var request = PositionRequest(
             success: success,
             error: { locationError in
@@ -235,12 +235,12 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.schedule(deadline: .now() + parsedOptions.timeout / 1000.0)
         timer.setEventHandler { [weak self] in
-            self?.handlePositionTimeout(requestId: id)
+            self?.handlePositionTimeout(requestId: requestId)
         }
         timer.resume()
         request.timer = timer
 
-        self.pendingPositionRequests[id] = request
+        self.pendingPositionRequests[requestId] = request
 
         // Update configuration and start monitoring
         self.updateLocationManagerConfiguration()
@@ -530,7 +530,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         let position = locationToPosition(location)
 
         // 1. Resolve all pending getCurrentPosition requests
-        for (id, request) in pendingPositionRequests {
+        for (_, request) in pendingPositionRequests {
             request.timer?.cancel()
             request.success(position)
         }
@@ -900,17 +900,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         }
     }
 
-    private func isCachedLocationValid(_ location: CLLocation, options: ParsedOptions) -> Bool {
-        // maximumAge is infinity
-        if options.maximumAge.isInfinite {
-            return true
-        }
-
-        // Check age
-        let age = Date().timeIntervalSince(location.timestamp) * 1000  // ms
-        return age < options.maximumAge
-    }
-
     private func getBestCachedLocation(options: ParsedOptions) -> CLLocation? {
         initializeLocationManagerIfNeeded()
 
@@ -920,7 +909,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             .max { $0.timestamp < $1.timestamp }
     }
 
-    private func handlePositionTimeout(requestId: UUID) {
+    private func handlePositionTimeout(requestId: String) {
         guard let request = pendingPositionRequests.removeValue(forKey: requestId) else {
             return
         }
@@ -933,6 +922,10 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
         request.error(error)
 
+        updateMonitoringAfterPositionRequestRemoval()
+    }
+
+    internal func updateMonitoringAfterPositionRequestRemoval() {
         // Stop monitoring if no more watches or pending requests
         if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
             stopMonitoring()

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -37,7 +37,9 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     // MARK: - Configuration
 
     func setConfiguration(config: GeolocationConfiguration) {
-        self.configuration = config
+        runLocationOperationOnMain {
+            self.configuration = config
+        }
     }
 
     // MARK: - Permission API
@@ -53,23 +55,18 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         success: @escaping (PermissionStatus) -> Void,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        self.initializeLocationManagerIfNeeded()
+        runLocationOperationOnMain {
+            self.initializeLocationManagerIfNeeded()
 
-        let currentStatus = CLLocationManager.authorizationStatus()
+            let currentStatus = CLLocationManager.authorizationStatus()
+            if currentStatus != .notDetermined {
+                success(self.mapCLAuthorizationStatus(currentStatus))
+                return
+            }
 
-        // Already determined
-        if currentStatus != .notDetermined {
-            let status = self.mapCLAuthorizationStatus(currentStatus)
-            success(status)
-            return
+            self.pendingPermissionResolvers.append(success)
+            self.requestSystemPermission(for: self.determineAuthorizationLevel())
         }
-
-        // Queue resolver
-        self.pendingPermissionResolvers.append(success)
-
-        // Request permission
-        let authLevel = self.determineAuthorizationLevel()
-        self.requestSystemPermission(for: authLevel)
     }
 
     // MARK: - Provider/Settings API
@@ -151,9 +148,8 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return
         }
 
-        initializeLocationManagerIfNeeded()
-
-        DispatchQueue.main.async {
+        runLocationOperationOnMain {
+            self.initializeLocationManagerIfNeeded()
             guard #available(iOS 14.0, *), let manager = self.locationManager else {
                 success(.unknown)
                 return
@@ -167,15 +163,17 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             manager.requestTemporaryFullAccuracyAuthorization(
                 withPurposeKey: trimmedPurposeKey
             ) { requestError in
-                if let requestError {
-                    error?(createLocationError(
-                        code: INTERNAL_ERROR,
-                        message: "Unable to request temporary full accuracy: \(requestError.localizedDescription)"
-                    ))
-                    return
-                }
+                self.runLocationOperationOnMain {
+                    if let requestError {
+                        error?(createLocationError(
+                            code: INTERNAL_ERROR,
+                            message: "Unable to request temporary full accuracy: \(requestError.localizedDescription)"
+                        ))
+                        return
+                    }
 
-                success(self.getCurrentAccuracyAuthorization())
+                    success(self.getCurrentAccuracyAuthorization())
+                }
             }
         }
     }
@@ -254,29 +252,28 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         options: LocationRequestOptions,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        let status = CLLocationManager.authorizationStatus()
-        if status == .denied || status == .restricted {
-            let message = status == .restricted
-                ? "This application is not authorized to use location services"
-                : "User denied access to location services."
-            error?(createLocationError(
-                code: PERMISSION_DENIED,
-                message: message
-            ))
-            return
-        }
-
         let parsedOptions = ParsedOptions.parseLastKnown(from: options)
-        guard let cached = self.getBestCachedLocation(options: parsedOptions) else {
-            error?(createLocationError(
-                code: POSITION_UNAVAILABLE,
-                message: "No cached location available."
-            ))
-            return
-        }
+        runLocationOperationOnMain {
+            let status = CLLocationManager.authorizationStatus()
+            if status == .denied || status == .restricted {
+                let message = status == .restricted
+                    ? "This application is not authorized to use location services"
+                    : "User denied access to location services."
+                error?(createLocationError(code: PERMISSION_DENIED, message: message))
+                return
+            }
 
-        self.lastLocation = cached
-        success(self.locationToPosition(cached))
+            guard let cached = self.getBestCachedLocation(options: parsedOptions) else {
+                error?(createLocationError(
+                    code: POSITION_UNAVAILABLE,
+                    message: "No cached location available."
+                ))
+                return
+            }
+
+            self.lastLocation = cached
+            success(self.locationToPosition(cached))
+        }
     }
 
     // MARK: - Geocoding
@@ -382,30 +379,28 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         success: @escaping (Heading) -> Void,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        guard validateHeadingAvailability(error: error) else { return }
+        runLocationOperationOnMain {
+            guard self.validateHeadingAvailability(error: error) else { return }
+            self.initializeLocationManagerIfNeeded()
 
-        initializeLocationManagerIfNeeded()
+            let id = UUID()
+            var request = HeadingRequest(
+                success: success,
+                error: { headingError in error?(headingError) },
+                timer: nil
+            )
+            let timer = DispatchSource.makeTimerSource(queue: .main)
+            timer.schedule(deadline: .now() + DEFAULT_HEADING_TIMEOUT_MS / 1000.0)
+            timer.setEventHandler { [weak self] in
+                self?.handleHeadingTimeout(requestId: id)
+            }
+            timer.resume()
+            request.timer = timer
 
-        let id = UUID()
-        var request = HeadingRequest(
-            success: success,
-            error: { headingError in
-                error?(headingError)
-            },
-            timer: nil
-        )
-
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + DEFAULT_HEADING_TIMEOUT_MS / 1000.0)
-        timer.setEventHandler { [weak self] in
-            self?.handleHeadingTimeout(requestId: id)
+            self.pendingHeadingRequests[id] = request
+            self.updateHeadingConfiguration()
+            self.startHeadingMonitoring()
         }
-        timer.resume()
-        request.timer = timer
-
-        pendingHeadingRequests[id] = request
-        updateHeadingConfiguration()
-        startHeadingMonitoring()
     }
 
     func watchHeading(
@@ -424,10 +419,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return token
         }
 
-        guard validateHeadingAvailability(error: error) else {
-            return token
-        }
-
         let subscription = HeadingSubscription(
             success: success,
             error: error,
@@ -435,11 +426,13 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             lastDeliveredHeading: nil
         )
 
-        headingSubscriptions[token] = subscription
-
-        initializeLocationManagerIfNeeded()
-        updateHeadingConfiguration()
-        startHeadingMonitoring()
+        runLocationOperationOnMain {
+            guard self.validateHeadingAvailability(error: error) else { return }
+            self.headingSubscriptions[token] = subscription
+            self.initializeLocationManagerIfNeeded()
+            self.updateHeadingConfiguration()
+            self.startHeadingMonitoring()
+        }
 
         return token
     }
@@ -452,13 +445,13 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             } else {
                 self.updateLocationManagerConfiguration()
             }
-        }
 
-        headingSubscriptions.removeValue(forKey: token)
-        if headingSubscriptions.isEmpty && pendingHeadingRequests.isEmpty {
-            stopHeadingMonitoring()
-        } else {
-            updateHeadingConfiguration()
+            self.headingSubscriptions.removeValue(forKey: token)
+            if self.headingSubscriptions.isEmpty && self.pendingHeadingRequests.isEmpty {
+                self.stopHeadingMonitoring()
+            } else {
+                self.updateHeadingConfiguration()
+            }
         }
     }
 
@@ -470,13 +463,13 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             } else {
                 self.updateLocationManagerConfiguration()
             }
-        }
 
-        headingSubscriptions.removeAll()
-        if pendingHeadingRequests.isEmpty {
-            stopHeadingMonitoring()
-        } else {
-            updateHeadingConfiguration()
+            self.headingSubscriptions.removeAll()
+            if self.pendingHeadingRequests.isEmpty {
+                self.stopHeadingMonitoring()
+            } else {
+                self.updateHeadingConfiguration()
+            }
         }
     }
 
@@ -506,19 +499,18 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         lastLocation = location
         let position = locationToPosition(location)
 
-        // 1. Resolve all pending getCurrentPosition requests
-        for (_, request) in pendingPositionRequests {
+        let positionRequests = Array(pendingPositionRequests.values)
+        pendingPositionRequests.removeAll()
+        for request in positionRequests {
             request.timer?.cancel()
             request.success(position)
         }
-        pendingPositionRequests.removeAll()
 
-        // 2. Notify all watch subscriptions (success)
-        for (_, subscription) in watchSubscriptions {
+        let subscriptions = Array(watchSubscriptions.values)
+        for subscription in subscriptions {
             subscription.success(position)
         }
 
-        // 3. Stop monitoring if no more subscriptions or pending requests
         if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
             stopMonitoring()
         } else {
@@ -552,15 +544,15 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             )
         }
 
-        // 1. Reject all pending getCurrentPosition requests
-        for (_, request) in pendingPositionRequests {
+        let positionRequests = Array(pendingPositionRequests.values)
+        pendingPositionRequests.removeAll()
+        for request in positionRequests {
             request.timer?.cancel()
             request.error(locationError)
         }
-        pendingPositionRequests.removeAll()
 
-        // 2. Notify all watch subscriptions (error)
-        for (_, subscription) in watchSubscriptions {
+        let subscriptions = Array(watchSubscriptions.values)
+        for subscription in subscriptions {
             subscription.error?(locationError)
         }
 
@@ -606,19 +598,24 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     // MARK: - Helper Functions
 
     internal func initializeLocationManagerIfNeeded() {
-        guard locationManager == nil else { return }
-
         if Thread.isMainThread {
-            locationManager = CLLocationManager()
-            locationManagerDelegate = LocationManagerDelegate(geolocation: self)
-            locationManager?.delegate = locationManagerDelegate
+            initializeLocationManagerOnMainIfNeeded()
         } else {
             DispatchQueue.main.sync {
-                locationManager = CLLocationManager()
-                locationManagerDelegate = LocationManagerDelegate(geolocation: self)
-                locationManager?.delegate = locationManagerDelegate
+                self.initializeLocationManagerOnMainIfNeeded()
             }
         }
+    }
+
+    private func initializeLocationManagerOnMainIfNeeded() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard locationManager == nil else { return }
+
+        let manager = CLLocationManager()
+        let delegate = LocationManagerDelegate(geolocation: self)
+        manager.delegate = delegate
+        locationManagerDelegate = delegate
+        locationManager = manager
     }
 
     private func validateHeadingAvailability(
@@ -714,16 +711,18 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return
         }
 
-        for (_, request) in pendingHeadingRequests {
+        let headingRequests = Array(pendingHeadingRequests.values)
+        pendingHeadingRequests.removeAll()
+        for request in headingRequests {
             request.timer?.cancel()
             request.error(locationError)
         }
-        pendingHeadingRequests.removeAll()
 
-        for (_, subscription) in headingSubscriptions {
+        let subscriptions = Array(headingSubscriptions.values)
+        headingSubscriptions.removeAll()
+        for subscription in subscriptions {
             subscription.error?(locationError)
         }
-        headingSubscriptions.removeAll()
 
         stopHeadingMonitoring()
     }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.cpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.cpp
@@ -257,6 +257,14 @@ namespace margelo::nitro::nitrogeolocation {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_GeolocationResponse::javaobject> /* success */, jni::alias_ref<JLocationRequestOptions> /* options */, jni::alias_ref<JFunc_void_LocationError::javaobject> /* error */)>("getCurrentPosition_cxx");
     method(_javaPart, JFunc_void_GeolocationResponse_cxx::fromCpp(success), JLocationRequestOptions::fromCpp(options), error.has_value() ? JFunc_void_LocationError_cxx::fromCpp(error.value()) : nullptr);
   }
+  void JHybridNitroGeolocationSpec::getCurrentPositionCancellable(const std::string& requestId, const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* requestId */, jni::alias_ref<JFunc_void_GeolocationResponse::javaobject> /* success */, jni::alias_ref<JLocationRequestOptions> /* options */, jni::alias_ref<JFunc_void_LocationError::javaobject> /* error */)>("getCurrentPositionCancellable_cxx");
+    method(_javaPart, jni::make_jstring(requestId), JFunc_void_GeolocationResponse_cxx::fromCpp(success), JLocationRequestOptions::fromCpp(options), error.has_value() ? JFunc_void_LocationError_cxx::fromCpp(error.value()) : nullptr);
+  }
+  void JHybridNitroGeolocationSpec::cancelCurrentPositionRequest(const std::string& requestId) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* requestId */)>("cancelCurrentPositionRequest");
+    method(_javaPart, jni::make_jstring(requestId));
+  }
   void JHybridNitroGeolocationSpec::getLastKnownPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_GeolocationResponse::javaobject> /* success */, jni::alias_ref<JLocationRequestOptions> /* options */, jni::alias_ref<JFunc_void_LocationError::javaobject> /* error */)>("getLastKnownPosition_cxx");
     method(_javaPart, JFunc_void_GeolocationResponse_cxx::fromCpp(success), JLocationRequestOptions::fromCpp(options), error.has_value() ? JFunc_void_LocationError_cxx::fromCpp(error.value()) : nullptr);

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.hpp
@@ -64,6 +64,8 @@ namespace margelo::nitro::nitrogeolocation {
     std::shared_ptr<Promise<AccuracyAuthorization>> getAccuracyAuthorization() override;
     void requestTemporaryFullAccuracy(const std::string& purposeKey, const std::function<void(AccuracyAuthorization /* authorization */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
     void getCurrentPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
+    void getCurrentPositionCancellable(const std::string& requestId, const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
+    void cancelCurrentPositionRequest(const std::string& requestId) override;
     void getLastKnownPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
     void geocode(const std::string& address, const std::function<void(const std::vector<GeocodedLocation>& /* locations */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
     void reverseGeocode(const GeocodingCoordinates& coords, const std::function<void(const std::vector<ReverseGeocodedAddress>& /* addresses */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HybridNitroGeolocationSpec.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HybridNitroGeolocationSpec.kt
@@ -58,7 +58,7 @@ abstract class HybridNitroGeolocationSpec: HybridObject() {
   @Keep
   abstract fun getLocationAvailability(): Promise<LocationAvailability>
 
-  abstract fun requestLocationSettings(success: (result: LocationSettingsResult) -> Unit, options: LocationSettingsOptions, error: ((error: LocationError) -> Unit)?): Unit
+  abstract fun requestLocationSettings(success: (status: LocationProviderStatus) -> Unit, options: LocationSettingsOptions, error: ((error: LocationError) -> Unit)?): Unit
 
   @DoNotStrip
   @Keep
@@ -88,6 +88,19 @@ abstract class HybridNitroGeolocationSpec: HybridObject() {
     val __result = getCurrentPosition(success, options, error?.let { it })
     return __result
   }
+
+  abstract fun getCurrentPositionCancellable(requestId: String, success: (position: GeolocationResponse) -> Unit, options: LocationRequestOptions, error: ((error: LocationError) -> Unit)?): Unit
+
+  @DoNotStrip
+  @Keep
+  private fun getCurrentPositionCancellable_cxx(requestId: String, success: Func_void_GeolocationResponse, options: LocationRequestOptions, error: Func_void_LocationError?): Unit {
+    val __result = getCurrentPositionCancellable(requestId, success, options, error?.let { it })
+    return __result
+  }
+
+  @DoNotStrip
+  @Keep
+  abstract fun cancelCurrentPositionRequest(requestId: String): Unit
 
   abstract fun getLastKnownPosition(success: (position: GeolocationResponse) -> Unit, options: LocationRequestOptions, error: ((error: LocationError) -> Unit)?): Unit
 

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/c++/HybridNitroGeolocationSpecSwift.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/c++/HybridNitroGeolocationSpecSwift.hpp
@@ -219,6 +219,18 @@ namespace margelo::nitro::nitrogeolocation {
         std::rethrow_exception(__result.error());
       }
     }
+    inline void getCurrentPositionCancellable(const std::string& requestId, const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override {
+      auto __result = _swiftPart.getCurrentPositionCancellable(requestId, success, std::forward<decltype(options)>(options), error);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
+    inline void cancelCurrentPositionRequest(const std::string& requestId) override {
+      auto __result = _swiftPart.cancelCurrentPositionRequest(requestId);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
     inline void getLastKnownPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override {
       auto __result = _swiftPart.getLastKnownPosition(success, std::forward<decltype(options)>(options), error);
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec.swift
@@ -23,6 +23,8 @@ public protocol HybridNitroGeolocationSpec_protocol: HybridObject {
   func getAccuracyAuthorization() throws -> Promise<AccuracyAuthorization>
   func requestTemporaryFullAccuracy(purposeKey: String, success: @escaping (_ authorization: AccuracyAuthorization) -> Void, error: ((_ error: LocationError) -> Void)?) throws -> Void
   func getCurrentPosition(success: @escaping (_ position: GeolocationResponse) -> Void, options: LocationRequestOptions, error: ((_ error: LocationError) -> Void)?) throws -> Void
+  func getCurrentPositionCancellable(requestId: String, success: @escaping (_ position: GeolocationResponse) -> Void, options: LocationRequestOptions, error: ((_ error: LocationError) -> Void)?) throws -> Void
+  func cancelCurrentPositionRequest(requestId: String) throws -> Void
   func getLastKnownPosition(success: @escaping (_ position: GeolocationResponse) -> Void, options: LocationRequestOptions, error: ((_ error: LocationError) -> Void)?) throws -> Void
   func geocode(address: String, success: @escaping (_ locations: [GeocodedLocation]) -> Void, error: ((_ error: LocationError) -> Void)?) throws -> Void
   func reverseGeocode(coords: GeocodingCoordinates, success: @escaping (_ addresses: [ReverseGeocodedAddress]) -> Void, error: ((_ error: LocationError) -> Void)?) throws -> Void

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec_cxx.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec_cxx.swift
@@ -343,6 +343,45 @@ open class HybridNitroGeolocationSpec_cxx {
   }
 
   @inline(__always)
+  public final func getCurrentPositionCancellable(requestId: std.string, success: bridge.Func_void_GeolocationResponse, options: LocationRequestOptions, error: bridge.std__optional_std__function_void_const_LocationError_____error______) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.getCurrentPositionCancellable(requestId: String(requestId), success: { () -> (GeolocationResponse) -> Void in
+        let __wrappedFunction = bridge.wrap_Func_void_GeolocationResponse(success)
+        return { (__position: GeolocationResponse) -> Void in
+          __wrappedFunction.call(__position)
+        }
+      }(), options: options, error: { () -> ((_ error: LocationError) -> Void)? in
+        if bridge.has_value_std__optional_std__function_void_const_LocationError_____error______(error) {
+          let __unwrapped = bridge.get_std__optional_std__function_void_const_LocationError_____error______(error)
+          return { () -> (LocationError) -> Void in
+            let __wrappedFunction = bridge.wrap_Func_void_LocationError(__unwrapped)
+            return { (__error: LocationError) -> Void in
+              __wrappedFunction.call(__error)
+            }
+          }()
+        } else {
+          return nil
+        }
+      }())
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+
+  @inline(__always)
+  public final func cancelCurrentPositionRequest(requestId: std.string) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.cancelCurrentPositionRequest(requestId: String(requestId))
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+
+  @inline(__always)
   public final func getLastKnownPosition(success: bridge.Func_void_GeolocationResponse, options: LocationRequestOptions, error: bridge.std__optional_std__function_void_const_LocationError_____error______) -> bridge.Result_void_ {
     do {
       try self.__implementation.getLastKnownPosition(success: { () -> (GeolocationResponse) -> Void in

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.cpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.cpp
@@ -24,6 +24,8 @@ namespace margelo::nitro::nitrogeolocation {
       prototype.registerHybridMethod("getAccuracyAuthorization", &HybridNitroGeolocationSpec::getAccuracyAuthorization);
       prototype.registerHybridMethod("requestTemporaryFullAccuracy", &HybridNitroGeolocationSpec::requestTemporaryFullAccuracy);
       prototype.registerHybridMethod("getCurrentPosition", &HybridNitroGeolocationSpec::getCurrentPosition);
+      prototype.registerHybridMethod("getCurrentPositionCancellable", &HybridNitroGeolocationSpec::getCurrentPositionCancellable);
+      prototype.registerHybridMethod("cancelCurrentPositionRequest", &HybridNitroGeolocationSpec::cancelCurrentPositionRequest);
       prototype.registerHybridMethod("getLastKnownPosition", &HybridNitroGeolocationSpec::getLastKnownPosition);
       prototype.registerHybridMethod("geocode", &HybridNitroGeolocationSpec::geocode);
       prototype.registerHybridMethod("reverseGeocode", &HybridNitroGeolocationSpec::reverseGeocode);

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.hpp
@@ -106,6 +106,8 @@ namespace margelo::nitro::nitrogeolocation {
       virtual std::shared_ptr<Promise<AccuracyAuthorization>> getAccuracyAuthorization() = 0;
       virtual void requestTemporaryFullAccuracy(const std::string& purposeKey, const std::function<void(AccuracyAuthorization /* authorization */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
       virtual void getCurrentPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
+      virtual void getCurrentPositionCancellable(const std::string& requestId, const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
+      virtual void cancelCurrentPositionRequest(const std::string& requestId) = 0;
       virtual void getLastKnownPosition(const std::function<void(const GeolocationResponse& /* position */)>& success, const LocationRequestOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
       virtual void geocode(const std::string& address, const std::function<void(const std::vector<GeocodedLocation>& /* locations */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
       virtual void reverseGeocode(const GeocodingCoordinates& coords, const std::function<void(const std::vector<ReverseGeocodedAddress>& /* addresses */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;

--- a/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
@@ -347,6 +347,17 @@ export interface NitroGeolocation
     error?: (error: LocationError) => void
   ): void;
 
+  /** @internal Start a request that can be cancelled by its JS-owned ID. */
+  getCurrentPositionCancellable(
+    requestId: string,
+    success: (position: GeolocationResponse) => void,
+    options: LocationRequestOptions,
+    error?: (error: LocationError) => void
+  ): void;
+
+  /** @internal Cancel one matching current-position request. */
+  cancelCurrentPositionRequest(requestId: string): void;
+
   /**
    * Get the best cached location without starting a fresh location request.
    *

--- a/packages/react-native-nitro-geolocation/src/api/currentPositionOptions.ts
+++ b/packages/react-native-nitro-geolocation/src/api/currentPositionOptions.ts
@@ -1,0 +1,33 @@
+import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
+
+/** Options for a one-shot location request. */
+export interface CurrentPositionOptions extends LocationRequestOptions {
+  /**
+   * Cancels only this request. A pre-aborted signal does not start native or
+   * browser location work. Cancellation rejects with `signal.reason`, or an
+   * `AbortError` when the runtime does not expose a reason.
+   */
+  signal?: AbortSignal;
+}
+
+export function getAbortReason(signal: AbortSignal): unknown {
+  const reason = (signal as AbortSignal & { reason?: unknown }).reason;
+  if (reason !== undefined) {
+    return reason;
+  }
+
+  const error = new Error("The location request was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+export function getNativeCurrentPositionOptions(
+  options?: CurrentPositionOptions
+): LocationRequestOptions {
+  if (!options) {
+    return {};
+  }
+
+  const { signal: _signal, ...nativeOptions } = options;
+  return nativeOptions;
+}

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const native = vi.hoisted(() => ({
+  cancelCurrentPositionRequest: vi.fn(),
+  getCurrentPosition: vi.fn(),
+  getCurrentPositionCancellable: vi.fn()
+}));
+
+vi.mock("../NitroGeolocationModule", () => ({
+  NitroGeolocationHybridObject: native
+}));
+vi.mock("../devtools", () => ({ isDevtoolsEnabled: () => false }));
+
+import { getCurrentPosition } from "./getCurrentPosition";
+
+const position = {
+  coords: {
+    latitude: 37.5665,
+    longitude: 126.978,
+    altitude: null,
+    accuracy: 5,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null
+  },
+  timestamp: 1779015190000,
+  provider: "gps" as const
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getCurrentPosition cancellation", () => {
+  it("keeps the existing native path when no signal is provided", async () => {
+    native.getCurrentPosition.mockImplementation((success) =>
+      success(position)
+    );
+
+    await expect(getCurrentPosition({ timeout: 1234 })).resolves.toEqual(
+      position
+    );
+
+    expect(native.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      { timeout: 1234 },
+      expect.any(Function)
+    );
+    expect(native.getCurrentPositionCancellable).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pre-aborted signal without starting a native request", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancel before start");
+    controller.abort(reason);
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).rejects.toBe(reason);
+
+    expect(native.getCurrentPosition).not.toHaveBeenCalled();
+    expect(native.getCurrentPositionCancellable).not.toHaveBeenCalled();
+  });
+
+  it("cancels only the matching in-flight native request", async () => {
+    const callbacks = new Map<
+      string,
+      { success: (value: typeof position) => void }
+    >();
+    native.getCurrentPositionCancellable.mockImplementation(
+      (requestId, success) => {
+        callbacks.set(requestId, { success });
+      }
+    );
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const reason = new Error("cancel first only");
+
+    const first = getCurrentPosition({ signal: firstController.signal });
+    const second = getCurrentPosition({ signal: secondController.signal });
+    const requestIds = [...callbacks.keys()];
+    firstController.abort(reason);
+
+    await expect(first).rejects.toBe(reason);
+    expect(native.cancelCurrentPositionRequest).toHaveBeenCalledTimes(1);
+    expect(native.cancelCurrentPositionRequest).toHaveBeenCalledWith(
+      requestIds[0]
+    );
+
+    callbacks.get(requestIds[1])?.success(position);
+    await expect(second).resolves.toEqual(position);
+  });
+
+  it("removes abort handling after the request completes", async () => {
+    native.getCurrentPositionCancellable.mockImplementation(
+      (_requestId, success) => success(position)
+    );
+    const controller = new AbortController();
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).resolves.toEqual(position);
+    controller.abort();
+
+    expect(native.cancelCurrentPositionRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -1,10 +1,43 @@
-import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
 import type { GeolocationResponse } from "../publicTypes";
-import { decoratePositionWithMetadata } from "./locationMetadata";
+import {
+  type CurrentPositionOptions,
+  getAbortReason,
+  getNativeCurrentPositionOptions
+} from "./currentPositionOptions";
 import { rememberPosition } from "./positionCache";
+
+let nextCurrentPositionRequestId = 1;
+
+function createCurrentPositionRequestId(): string {
+  const requestId = `current-position-${nextCurrentPositionRequestId}`;
+  nextCurrentPositionRequestId += 1;
+  return requestId;
+}
+
+function raceDevtoolsRequestWithSignal(
+  request: Promise<GeolocationResponse>,
+  signal: AbortSignal
+): Promise<GeolocationResponse> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      callback();
+    };
+    const handleAbort = () => finish(() => reject(getAbortReason(signal)));
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    request.then(
+      (position) => finish(() => resolve(rememberPosition(position))),
+      (error) => finish(() => reject(error))
+    );
+  });
+}
 
 /**
  * Get current location (one-time request).
@@ -33,29 +66,56 @@ import { rememberPosition } from "./positionCache";
  * ```
  */
 export function getCurrentPosition(
-  options?: LocationRequestOptions
+  options?: CurrentPositionOptions
 ): Promise<GeolocationResponse> {
-  const requestedAt = Date.now();
-  const rememberCurrentPosition = (position: GeolocationResponse) =>
-    rememberPosition(
-      decoratePositionWithMetadata(position, {
-        source: "currentPosition",
-        maximumAge: options?.maximumAge ?? 0,
-        requestedAt
-      })
-    );
+  const signal = options?.signal;
+  if (signal?.aborted) {
+    return Promise.reject(getAbortReason(signal));
+  }
 
   if (isDevtoolsEnabled()) {
     const devtoolsResult = getDevtoolsCurrentPosition();
     if (devtoolsResult) {
-      return devtoolsResult.then(rememberCurrentPosition);
+      if (signal) {
+        return raceDevtoolsRequestWithSignal(devtoolsResult, signal);
+      }
+      return devtoolsResult.then(rememberPosition);
     }
   }
+
+  const nativeOptions = getNativeCurrentPositionOptions(options);
+  if (!signal) {
+    return new Promise((resolve, reject) => {
+      NitroGeolocationHybridObject.getCurrentPosition(
+        (position) => resolve(rememberPosition(position)),
+        nativeOptions,
+        reject
+      );
+    });
+  }
+
   return new Promise((resolve, reject) => {
-    NitroGeolocationHybridObject.getCurrentPosition(
-      (position) => resolve(rememberCurrentPosition(position)),
-      options ?? {},
-      reject
+    const requestId = createCurrentPositionRequestId();
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      callback();
+    };
+    const handleAbort = () => {
+      finish(() => {
+        NitroGeolocationHybridObject.cancelCurrentPositionRequest(requestId);
+        reject(getAbortReason(signal));
+      });
+    };
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    NitroGeolocationHybridObject.getCurrentPositionCancellable(
+      requestId,
+      (position) => finish(() => resolve(rememberPosition(position))),
+      nativeOptions,
+      (error) => finish(() => reject(error))
     );
   });
 }

--- a/packages/react-native-nitro-geolocation/src/api/index.ts
+++ b/packages/react-native-nitro-geolocation/src/api/index.ts
@@ -8,6 +8,7 @@ export { requestLocationSettings } from "./requestLocationSettings";
 export { getAccuracyAuthorization } from "./getAccuracyAuthorization";
 export { requestTemporaryFullAccuracy } from "./requestTemporaryFullAccuracy";
 export { getCurrentPosition } from "./getCurrentPosition";
+export type { CurrentPositionOptions } from "./currentPositionOptions";
 export {
   getLastKnownPosition,
   getLastKnownPositionAsync

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -85,6 +85,8 @@ export type {
   LocationError
 } from "./NitroGeolocation.nitro";
 
+export type { CurrentPositionOptions } from "./api/currentPositionOptions";
+
 export type {
   GeolocationResponse,
   GeolocationCoordinates,

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -15,6 +15,8 @@ export type {
   LocationError
 } from "./NitroGeolocation.nitro";
 
+export type { CurrentPositionOptions } from "./api/currentPositionOptions";
+
 export type {
   GeolocationResponse,
   GeolocationCoordinates,

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -180,6 +180,92 @@ describe("web Modern API", () => {
     });
   });
 
+  it("does not start browser geolocation for a pre-aborted request", async () => {
+    const getCurrentPositionMock = vi.fn();
+    const watchPositionMock = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: getCurrentPositionMock,
+        watchPosition: watchPositionMock,
+        clearWatch: vi.fn()
+      }
+    });
+    const controller = new AbortController();
+    const reason = new Error("cancel before start");
+    controller.abort(reason);
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).rejects.toBe(reason);
+    expect(getCurrentPositionMock).not.toHaveBeenCalled();
+    expect(watchPositionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pre-aborted request before checking browser support", async () => {
+    setNavigator(undefined);
+    const controller = new AbortController();
+    const reason = new Error("cancel without browser support");
+    controller.abort(reason);
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).rejects.toBe(reason);
+  });
+
+  it("clears an in-flight browser request when its signal aborts", async () => {
+    let lateSuccess:
+      | ((position: ReturnType<typeof createPosition>) => void)
+      | undefined;
+    const clearWatch = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn((success) => {
+          lateSuccess = success;
+          return 41;
+        }),
+        clearWatch
+      }
+    });
+    const controller = new AbortController();
+    const reason = new Error("cancel active request");
+
+    const request = getCurrentPosition({ signal: controller.signal });
+    controller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+    expect(clearWatch).toHaveBeenCalledTimes(1);
+    expect(clearWatch).toHaveBeenCalledWith(41);
+    lateSuccess?.(createPosition());
+    expect(clearWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the browser watch after a cancellable request succeeds", async () => {
+    const clearWatch = vi.fn();
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn((success) => {
+          success(createPosition());
+          return 42;
+        }),
+        clearWatch
+      }
+    });
+    const controller = new AbortController();
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).resolves.toMatchObject({
+      coords: { latitude: 37.5665, longitude: 126.978 }
+    });
+    expect(clearWatch).toHaveBeenCalledTimes(1);
+    expect(clearWatch).toHaveBeenCalledWith(42);
+
+    controller.abort();
+    expect(clearWatch).toHaveBeenCalledTimes(1);
+  });
+
   it("returns an async cache miss without querying or requiring browser geolocation", async () => {
     const getCurrentPositionMock = vi.fn();
     setNavigator({

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -6,6 +6,10 @@ import type {
 } from "../NitroGeolocation.nitro";
 import { decoratePositionWithMetadata } from "../api/locationMetadata";
 import {
+  type CurrentPositionOptions,
+  getAbortReason
+} from "../api/currentPositionOptions";
+import {
   readLastKnownPosition,
   rememberPosition,
   selectCachedPosition
@@ -131,29 +135,62 @@ export function requestTemporaryFullAccuracy(
 }
 
 export function getCurrentPosition(
-  options?: LocationRequestOptions
+  options?: CurrentPositionOptions
 ): Promise<GeolocationResponse> {
+  const signal = options?.signal;
+  if (signal?.aborted) {
+    return Promise.reject(getAbortReason(signal));
+  }
+
   const geolocation = getGeolocation();
   if (!geolocation) {
     return rejectUnsupported();
   }
 
-  const requestedAt = Date.now();
+  if (!signal) {
+    return new Promise((resolve, reject) => {
+      geolocation.getCurrentPosition(
+        (position) => resolve(rememberPosition(normalizePosition(position))),
+        (error) => reject(mapBrowserError(error)),
+        toPositionOptions(options)
+      );
+    });
+  }
+
   return new Promise((resolve, reject) => {
-    geolocation.getCurrentPosition(
+    const requestWatch: { id?: number } = {};
+    let shouldClearWatch = false;
+    let didClearWatch = false;
+    let settled = false;
+
+    const clearRequestWatch = () => {
+      if (didClearWatch) return;
+      if (requestWatch.id === undefined) {
+        shouldClearWatch = true;
+        return;
+      }
+      didClearWatch = true;
+      geolocation.clearWatch(requestWatch.id);
+    };
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      clearRequestWatch();
+      callback();
+    };
+    const handleAbort = () => finish(() => reject(getAbortReason(signal)));
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    requestWatch.id = geolocation.watchPosition(
       (position) =>
-        resolve(
-          rememberPosition(
-            decoratePositionWithMetadata(normalizePosition(position), {
-              source: "currentPosition",
-              maximumAge: options?.maximumAge ?? 0,
-              requestedAt
-            })
-          )
-        ),
-      (error) => reject(mapBrowserError(error)),
+        finish(() => resolve(rememberPosition(normalizePosition(position)))),
+      (error) => finish(() => reject(mapBrowserError(error))),
       toPositionOptions(options)
     );
+    if (shouldClearWatch) {
+      clearRequestWatch();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- add optional `AbortSignal` cancellation to the Modern `getCurrentPosition` API while preserving the existing no-signal path
- cancel Android and iOS one-shot resources per request without affecting concurrent requests or watches
- serialize the iOS `CLLocationManager` and its configuration, permission, cache, current-position, watch, and heading state on the main queue
- use a one-shot watch plus `clearWatch` for cancellable Web requests while retaining the existing Web path when no signal is supplied
- preserve the exact abort reason when supported and return an `AbortError` fallback on runtimes without `signal.reason`
- keep `/compat` unchanged
- add natural native and Web test pages for pre-abort, active cancellation, concurrent one-shot isolation, cache-read/watch isolation, and active-watch survival
- publish the compatible feature with a minor changeset under the existing `rc` prerelease mode

## Red → green evidence

- five unit cases failed before signal support existed, covering native pre-abort/isolation and Web cancellation
- the first native Maestro run failed because the cancellable-current-position route and screen did not exist
- Android RN 0.81 E2E exposed the runtime's missing `signal.reason` support, establishing the documented `AbortError` fallback
- iOS E2E exposed an invalid survivor-timing assumption; the final scenario asserts the observable isolation result
- adversarial review found split iOS ownership for current-position requests and watches, followed by a `CLLocationManager` initialization race and an active-watch test that could accept an old coordinate
- the final iOS implementation creates and accesses the manager and related state on the main queue; callback collections are snapshotted before re-entrant JS callbacks
- a final performance review caught `locationServicesEnabled()` moving onto main with that serialization; the static service query now stays on the JSI caller thread and only its result plus manager state work crosses to main
- the final native scenario first proves the watch is active, confirms one-shot cancellation, then requires a distinct post-cancellation coordinate; a separate natural scenario reads the platform cache while a watch remains active

## Verification

- `yarn test:unit` (76 tests)
- package, example, and docs TypeScript checks
- `yarn lint` and `yarn format:check`
- Web production build and docs build
- `yarn pack:check`
- `yarn deadcode`, `yarn deadcode:prod`, and `yarn source-lines:check`
- changeset validation: minor release in `rc` prerelease mode
- Android Release build
- iOS Release build
- complete Android native E2E at final HEAD: 23 location-enabled flows plus 1 location-disabled settings flow, first sweep
- complete iOS native E2E at final HEAD: 21 flows, first sweep
- complete Android WebView E2E at final HEAD: success, denial, and provider-unavailable paths
- complete iOS WebView E2E at final HEAD: success and denial paths

Refs #98
