### PR TITLE
docs: clarify RN 0.87 SwiftPM compatibility

### DIFF
--- a/.changeset/quiet-swifts-wait.md
+++ b/.changeset/quiet-swifts-wait.md
@@ -1,0 +1,5 @@
+---
+---
+
+Document the React Native 0.87 Swift Package Manager compatibility boundary
+without changing published package behavior.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,15 @@ npm install react-native-nitro-modules react-native-nitro-geolocation
 Rebuild your native app:
 
 ```bash
-cd ios && pod install
+cd ios && bundle exec pod install
 ```
+
+Use `pod install` directly when your app does not check in a `Gemfile`.
+React Native 0.87's optional Swift Package Manager path is not yet compatible
+with the required Nitro Modules mixed-language native target. Keep CocoaPods
+for iOS and read the
+[Swift Package Manager guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
+before migrating an RN 0.87 app.
 
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
@@ -226,6 +233,7 @@ for setup, presets, troubleshooting, and the demo.
 Use the docs site for the detailed flows:
 
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
+- [Swift Package Manager](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager) - RN 0.87 compatibility and migration gate.
 - [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
 - [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, HTTP sync, and delivery diagnosis.
@@ -237,6 +245,7 @@ Use the docs site for the detailed flows:
 
 - [Introduction](https://react-native-nitro-geolocation.pages.dev/guide/)
 - [Quick Start Guide](https://react-native-nitro-geolocation.pages.dev/guide/quick-start)
+- [Swift Package Manager Guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
 - [Modern API Reference](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
 - [Compat API Reference](https://react-native-nitro-geolocation.pages.dev/guide/compat-api)
 - [Migration Skills](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance)

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -1,6 +1,7 @@
 [
   "index",
   "quick-start",
+  "swift-package-manager",
   "migration-assistance",
   "community-migration",
   "service-migration",

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -23,6 +23,8 @@ for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
+| React Native 0.87 app using CocoaPods | Supported |
+| React Native 0.87 SwiftPM-only app | Wait for official Nitro Modules SwiftPM support |
 | Web support required | Use the Modern API root import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -18,8 +18,14 @@ npm install react-native-nitro-modules react-native-nitro-geolocation
 After installation, rebuild your native app to ensure the new module is linked.
 
 ```bash
-cd ios && pod install
+cd ios && bundle exec pod install
 ```
+
+Use `pod install` directly when your app does not check in a `Gemfile`.
+React Native 0.87's Swift Package Manager workflow is not yet compatible with
+the required Nitro Modules native target. Keep CocoaPods for iOS and see the
+[Swift Package Manager compatibility guide](/guide/swift-package-manager)
+before migrating an RN 0.87 app.
 
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
@@ -129,6 +135,7 @@ const cached = await getLastKnownPosition({
 ## Next Steps
 
 - [Modern API Reference](/guide/modern-api) — Complete documentation
+- [Swift Package Manager](/guide/swift-package-manager) — RN 0.87 compatibility and migration gate
 - [Compat API Reference](/guide/compat-api) — Compatibility methods
 - [Background Location](/background/overview) — Native background tracking, geofencing, and storage recovery
 - [Migration Guides](/guide/migration-assistance) — Move from community/service geolocation packages

--- a/docs/docs/guide/swift-package-manager.md
+++ b/docs/docs/guide/swift-package-manager.md
@@ -1,0 +1,76 @@
+---
+title: Swift Package Manager
+---
+
+# Swift Package Manager
+
+React Native 0.87 introduced a Swift Package Manager (SwiftPM) build path for
+iOS. It is optional: CocoaPods remains the supported iOS installation path for
+`react-native-nitro-geolocation`.
+
+## Current Compatibility
+
+Do not run `npx react-native spm` in an app that installs this package yet.
+The React Native 0.87 SwiftPM autolinker requires every native dependency to
+ship a compatible `Package.swift`. The required
+`react-native-nitro-modules` peer dependency does not currently ship one.
+
+This package and Nitro Modules also contain a mixed Swift, Objective-C++, and
+C++ target with Swift/C++ interop. React Native's generated SwiftPM scaffold
+cannot safely translate that target. Running `npx react-native spm scaffold`
+does not make this combination supported.
+
+| iOS dependency manager | React Native 0.87 | Status |
+| --- | --- | --- |
+| CocoaPods | Supported | Recommended |
+| SwiftPM-only | Not yet supported | Wait for an official Nitro Modules SwiftPM package |
+
+## Supported RN 0.87 Installation
+
+Install both JavaScript packages normally, then keep the CocoaPods integration
+for iOS:
+
+```bash
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+cd ios
+bundle exec pod install
+```
+
+Use `pod install` instead of `bundle exec pod install` when the app does not
+check in a `Gemfile`. Open the generated `.xcworkspace` and rebuild the native
+app.
+
+Android setup is unchanged. The iOS dependency-manager choice does not affect
+the package's JavaScript API.
+
+## Avoid Unsupported Workarounds
+
+Do not:
+
+- disable iOS autolinking for `react-native-nitro-modules`;
+- add an empty or generated `Package.swift` to `node_modules`;
+- split the generated Nitro target into independent Swift and C++ targets;
+- link the same React or Nitro native symbols through both CocoaPods and
+  SwiftPM.
+
+These workarounds can pass package resolution while producing missing native
+registrations, duplicate symbols, or configuration-specific linker failures.
+
+## When SwiftPM Becomes Available
+
+SwiftPM-only installation can be documented as supported after all of these
+conditions are met:
+
+1. `react-native-nitro-modules` publishes an official SwiftPM product.
+2. `react-native-nitro-geolocation` publishes a manifest or binary package that
+   preserves Nitro's Swift/C++ interop settings.
+3. Debug and Release builds pass on both an iOS simulator and a physical-device
+   archive with React Native 0.87.
+4. The app can run Modern, `/compat`, and background registration checks
+   without CocoaPods products in the link graph.
+
+Until then, choose CocoaPods for apps that use this package. React Native's
+[0.87 changelog](https://github.com/facebook/react-native/blob/v0.87.0/CHANGELOG.md)
+and the upstream
+[Nitro Modules repository](https://github.com/mrousavy/nitro) are the source of
+truth for the two prerequisite implementations.

--- a/docs/docs/guide/swift-package-manager.md
+++ b/docs/docs/guide/swift-package-manager.md
@@ -12,8 +12,9 @@ iOS. It is optional: CocoaPods remains the supported iOS installation path for
 
 Do not run `npx react-native spm` in an app that installs this package yet.
 The React Native 0.87 SwiftPM autolinker requires every native dependency to
-ship a compatible `Package.swift`. The required
-`react-native-nitro-modules` peer dependency does not currently ship one.
+resolve through a compatible `Package.swift`, either shipped by the library or
+generated from a supported podspec. The required `react-native-nitro-modules`
+peer dependency does not currently ship one.
 
 This package and Nitro Modules also contain a mixed Swift, Objective-C++, and
 C++ target with Swift/C++ interop. React Native's generated SwiftPM scaffold
@@ -48,7 +49,8 @@ the package's JavaScript API.
 Do not:
 
 - disable iOS autolinking for `react-native-nitro-modules`;
-- add an empty or generated `Package.swift` to `node_modules`;
+- add an empty manifest or use a generated scaffold for these mixed-language
+  Nitro targets in `node_modules`;
 - split the generated Nitro target into independent Swift and C++ targets;
 - link the same React or Nitro native symbols through both CocoaPods and
   SwiftPM.

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -139,8 +139,15 @@ npm install react-native-nitro-modules react-native-nitro-geolocation
 Rebuild your native app:
 
 ```bash
-cd ios && pod install
+cd ios && bundle exec pod install
 ```
+
+Use `pod install` directly when your app does not check in a `Gemfile`.
+React Native 0.87's optional Swift Package Manager path is not yet compatible
+with the required Nitro Modules mixed-language native target. Keep CocoaPods
+for iOS and read the
+[Swift Package Manager guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
+before migrating an RN 0.87 app.
 
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
@@ -226,6 +233,7 @@ for setup, presets, troubleshooting, and the demo.
 Use the docs site for the detailed flows:
 
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
+- [Swift Package Manager](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager) - RN 0.87 compatibility and migration gate.
 - [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
 - [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, HTTP sync, and delivery diagnosis.
@@ -237,6 +245,7 @@ Use the docs site for the detailed flows:
 
 - [Introduction](https://react-native-nitro-geolocation.pages.dev/guide/)
 - [Quick Start Guide](https://react-native-nitro-geolocation.pages.dev/guide/quick-start)
+- [Swift Package Manager Guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
 - [Modern API Reference](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
 - [Compat API Reference](https://react-native-nitro-geolocation.pages.dev/guide/compat-api)
 - [Migration Skills](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance)


### PR DESCRIPTION
## Summary

- document the React Native 0.87 SwiftPM compatibility boundary
- keep CocoaPods as the supported iOS installation path while the required Nitro Modules package has no SwiftPM manifest
- explain why generated manifests, autolinking opt-outs, and mixed package-manager link graphs are unsafe workarounds
- add an explicit readiness checklist for enabling SwiftPM-only installation later

## Why this does not claim SwiftPM support

React Native 0.87's SwiftPM autolinker requires native packages to provide a compatible `Package.swift`. `react-native-nitro-modules` currently ships only CocoaPods integration, and the Nitro target mixes Swift, Objective-C++, and C++ with Swift/C++ interop. React Native's scaffold path explicitly rejects that mixed-language shape. This PR documents the real compatibility gate instead of publishing a manifest that can resolve but cannot build correctly.

## Verification

- `yarn format:check`
- `yarn workspace docs build`
- `yarn pack:check`
- `yarn changeset status --since=origin/main`
- `git diff --check`

Runtime E2E was not run because this PR changes documentation only.

## Adversarial review

- fixed a P2 overgeneralization: RN 0.87 can scaffold compatible pure-language
  podspec dependencies; the unsupported case is Nitro's mixed-language target
- final review rerun is tracked against the latest commit

## Release

- empty changeset: documentation only; no package version bump

## References

- React Native 0.87 SwiftPM support: https://github.com/facebook/react-native/blob/v0.87.0/CHANGELOG.md
- React Native SwiftPM implementation/RFC: https://github.com/facebook/react-native/tree/v0.87.0/packages/react-native/scripts/spm
- Nitro Modules: https://github.com/mrousavy/nitro
