### PR TITLE
feat: add provider status watcher

### DIFF
--- a/.changeset/shiny-ravens-listen.md
+++ b/.changeset/shiny-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add a cancellable provider status watcher that emits an initial snapshot and distinct readiness changes.

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -164,7 +164,8 @@ function PermissionButton() {
 
 ### Android Provider and Settings
 
-Available since `v1.2`.
+The provider/settings snapshot helpers are available since `v1.2`.
+`watchProviderStatus()` is available since `v1.5`.
 
 Use these helpers before user-facing precise-location flows where the app needs
 to know whether Android device settings can satisfy the request.
@@ -218,7 +219,7 @@ unwatch(providerToken);
   it.
 - `watchProviderStatus(callback): string` - Delivers an asynchronous initial
   provider snapshot and then only distinct readiness changes. Pass its token to
-  `unwatch()` for cleanup.
+  `unwatch()` for cleanup. Available since `v1.5`.
 - `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -175,7 +175,9 @@ import {
   getLocationAvailability,
   getProviderStatus,
   hasServicesEnabled,
-  requestLocationSettings
+  requestLocationSettings,
+  unwatch,
+  watchProviderStatus
 } from 'react-native-nitro-geolocation';
 
 async function prepareAccurateLocation() {
@@ -196,6 +198,13 @@ async function prepareAccurateLocation() {
     timeout: 15000
   });
 }
+
+const providerToken = watchProviderStatus((status) => {
+  console.log('Location services:', status.locationServicesEnabled);
+});
+
+// Stop when this readiness observer is no longer needed.
+unwatch(providerToken);
 ```
 
 **Functions**:
@@ -207,6 +216,9 @@ async function prepareAccurateLocation() {
   `networkAvailable`, `passiveAvailable`, Android Google Play Services
   availability, and Google Location Accuracy when Google Play Services exposes
   it.
+- `watchProviderStatus(callback): string` - Delivers an asynchronous initial
+  provider snapshot and then only distinct readiness changes. Pass its token to
+  `unwatch()` for cleanup.
 - `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
@@ -219,6 +231,13 @@ async function prepareAccurateLocation() {
 
 `requestLocationSettings()` is Android-focused. On iOS it resolves with the
 current Core Location service status and does not show a settings dialog.
+
+`watchProviderStatus()` only observes readiness: it does not request permission,
+open settings, or start position updates. Android reacts to system provider and
+location-mode broadcasts. iOS rechecks after authorization changes and when the
+app becomes active, which covers returning from Settings. Browser builds recheck
+when the page becomes visible or active. Provider-specific optional fields stay
+`undefined` on platforms that cannot report them.
 
 ### Android Reliability Notes
 
@@ -251,7 +270,9 @@ Supported on web:
 - `getCurrentPosition()` wraps `navigator.geolocation.getCurrentPosition()`.
 - `watchPosition()` wraps `navigator.geolocation.watchPosition()` and returns a
   string token.
-- `unwatch()` and `stopObserving()` clear browser watch IDs.
+- `watchProviderStatus()` reports whether browser geolocation is available and
+  rechecks on page visibility/focus lifecycle events.
+- `unwatch()` and `stopObserving()` clear position and provider-status watches.
 
 Web option behavior:
 

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -171,6 +171,7 @@ Use these helpers before user-facing precise-location flows where the app needs
 to know whether Android device settings can satisfy the request.
 
 ```tsx
+import { useEffect } from 'react';
 import {
   getCurrentPosition,
   getLocationAvailability,
@@ -200,12 +201,17 @@ async function prepareAccurateLocation() {
   });
 }
 
-const providerToken = watchProviderStatus((status) => {
-  console.log('Location services:', status.locationServicesEnabled);
-});
+function ProviderStatusObserver() {
+  useEffect(() => {
+    const providerToken = watchProviderStatus((status) => {
+      console.log('Location services:', status.locationServicesEnabled);
+    });
 
-// Stop when this readiness observer is no longer needed.
-unwatch(providerToken);
+    return () => unwatch(providerToken);
+  }, []);
+
+  return null;
+}
 ```
 
 **Functions**:

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -71,6 +71,10 @@ appId: nitrogeolocation.example
 - runFlow: location-quality-metadata.yaml
 - runFlow: geocoding.yaml
 - runFlow: location-availability.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: provider-status-watcher.yaml
 - runFlow: heading.yaml
 - runFlow:
     when:

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-changed.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-changed.yaml
@@ -7,7 +7,7 @@ appId: nitrogeolocation.example
     visible: "Services: disabled"
     timeout: 10000
 - extendedWaitUntil:
-    visible: "Events: 2"
+    visible: "Events: 3"
     timeout: 10000
 - tapOn:
     id: "e2e-action-provider-status-watcher-stop-button"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-changed.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-changed.yaml
@@ -1,0 +1,14 @@
+appId: nitrogeolocation.example
+---
+# The Android runner disables location services while the listener remains
+# active. The watcher must emit one distinct disabled snapshot.
+
+- extendedWaitUntil:
+    visible: "Services: disabled"
+    timeout: 10000
+- extendedWaitUntil:
+    visible: "Events: 2"
+    timeout: 10000
+- tapOn:
+    id: "e2e-action-provider-status-watcher-stop-button"
+- assertVisible: "Listener: stopped"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-resumed.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-resumed.yaml
@@ -1,0 +1,16 @@
+appId: nitrogeolocation.example
+---
+# The Android runner grants background permission while the watcher remains
+# active, then resumes the existing host. Resume must refresh non-broadcast
+# readiness fields without replacing the subscription.
+
+- openLink:
+    link: nitrogeolocation://app/provider-status-watcher
+- extendedWaitUntil:
+    visible: "Background: enabled"
+    timeout: 10000
+- extendedWaitUntil:
+    visible: "Events: 2"
+    timeout: 10000
+- assertVisible: "Listener: listening"
+- assertVisible: "Services: enabled"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-start.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-start.yaml
@@ -1,0 +1,22 @@
+appId: nitrogeolocation.example
+---
+# Start with location services enabled and leave the listener active so the
+# shell-controlled settings change can be observed by the same subscription.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- stopApp
+- openLink:
+    link: nitrogeolocation://app/provider-status-watcher
+- extendedWaitUntil:
+    visible: "Provider Status Watcher"
+    timeout: 10000
+- tapOn:
+    id: "e2e-action-provider-status-watcher-start-button"
+- extendedWaitUntil:
+    visible: "Events: 1"
+    timeout: 10000
+- assertVisible: "Listener: listening"
+- assertVisible: "Services: enabled"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-start.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-start.yaml
@@ -3,11 +3,6 @@ appId: nitrogeolocation.example
 # Start with location services enabled and leave the listener active so the
 # shell-controlled settings change can be observed by the same subscription.
 
-- launchApp:
-    clearState: true
-    permissions:
-      all: allow
-- stopApp
 - openLink:
     link: nitrogeolocation://app/provider-status-watcher
 - extendedWaitUntil:
@@ -20,3 +15,4 @@ appId: nitrogeolocation.example
     timeout: 10000
 - assertVisible: "Listener: listening"
 - assertVisible: "Services: enabled"
+- assertVisible: "Background: disabled"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
@@ -4,11 +4,11 @@ appId: nitrogeolocation.example
 # delivered, while an explicit snapshot must see the new enabled state.
 
 - assertVisible: "Listener: stopped"
-- assertVisible: "Events: 2"
+- assertVisible: "Events: 3"
 - assertVisible: "Services: disabled"
 - tapOn:
     id: "e2e-action-provider-status-watcher-refresh-button"
 - extendedWaitUntil:
     visible: "Manual snapshot: enabled"
     timeout: 10000
-- assertVisible: "Events: 2"
+- assertVisible: "Events: 3"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# The Android runner re-enables location after unwatch. No third event may be
+# The Android runner re-enables location after unwatch. No fourth event may be
 # delivered, while an explicit snapshot must see the new enabled state.
 
 - assertVisible: "Listener: stopped"

--- a/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher-android-stopped.yaml
@@ -1,0 +1,14 @@
+appId: nitrogeolocation.example
+---
+# The Android runner re-enables location after unwatch. No third event may be
+# delivered, while an explicit snapshot must see the new enabled state.
+
+- assertVisible: "Listener: stopped"
+- assertVisible: "Events: 2"
+- assertVisible: "Services: disabled"
+- tapOn:
+    id: "e2e-action-provider-status-watcher-refresh-button"
+- extendedWaitUntil:
+    visible: "Manual snapshot: enabled"
+    timeout: 10000
+- assertVisible: "Events: 2"

--- a/examples/v0.81.1/.maestro/provider-status-watcher.yaml
+++ b/examples/v0.81.1/.maestro/provider-status-watcher.yaml
@@ -1,0 +1,51 @@
+appId: nitrogeolocation.example
+---
+# User flow: observe the initial provider snapshot, stop listening, and verify
+# an on-demand check still reports the current device state.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/provider-status-watcher
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/provider-status-watcher
+- extendedWaitUntil:
+    visible: "Provider Status Watcher"
+    timeout: 10000
+
+- assertVisible: "Listener: stopped"
+- assertVisible: "Events: 0"
+- tapOn:
+    id: "e2e-action-provider-status-watcher-start-button"
+- extendedWaitUntil:
+    visible: "Listener: listening"
+    timeout: 10000
+- extendedWaitUntil:
+    visible: "Events: 1"
+    timeout: 10000
+- assertVisible: "Services: enabled"
+
+- tapOn:
+    id: "e2e-action-provider-status-watcher-stop-button"
+- assertVisible: "Listener: stopped"
+- tapOn:
+    id: "e2e-action-provider-status-watcher-refresh-button"
+- extendedWaitUntil:
+    visible: "Manual snapshot: enabled"
+    timeout: 10000
+- assertVisible: "Events: 1"

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -154,6 +154,18 @@ run_maestro_flows \
   "android GPS stale-readiness setup" \
   gps-only-recipe-stale-readiness-prepare.yaml || status=1
 
+run_maestro_flows \
+  "android provider watcher started" \
+  provider-status-watcher-android-start.yaml || status=1
+set_location_enabled false
+run_maestro_flows \
+  "android provider watcher changed" \
+  provider-status-watcher-android-changed.yaml || status=1
+set_location_enabled true
+run_maestro_flows \
+  "android provider watcher stopped" \
+  provider-status-watcher-android-stopped.yaml || status=1
+
 set_location_enabled false
 run_maestro_flows \
   "android GPS stale-readiness verification" \

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -9,7 +9,7 @@ ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
 DISABLED_LAUNCHER_PACKAGE=""
-LOCATION_WAS_ENABLED=""
+EXAMPLE_APP_ID="nitrogeolocation.example"
 
 adb_cmd() {
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
@@ -21,6 +21,26 @@ adb_cmd() {
 
 set_location_enabled() {
   adb_cmd shell cmd location set-location-enabled "$1" >/dev/null
+}
+
+prepare_provider_watcher_permissions() {
+  adb_cmd shell am force-stop "$EXAMPLE_APP_ID" >/dev/null
+  adb_cmd shell pm clear "$EXAMPLE_APP_ID" >/dev/null
+  adb_cmd shell pm grant \
+    "$EXAMPLE_APP_ID" android.permission.ACCESS_COARSE_LOCATION
+  adb_cmd shell pm grant \
+    "$EXAMPLE_APP_ID" android.permission.ACCESS_FINE_LOCATION
+  adb_cmd shell pm revoke \
+    "$EXAMPLE_APP_ID" android.permission.ACCESS_BACKGROUND_LOCATION \
+    >/dev/null 2>&1 || true
+}
+
+grant_background_permission_and_pause_host() {
+  adb_cmd shell pm grant \
+    "$EXAMPLE_APP_ID" android.permission.ACCESS_BACKGROUND_LOCATION
+  adb_cmd shell am start \
+    -a android.settings.APPLICATION_DETAILS_SETTINGS \
+    -d "package:$EXAMPLE_APP_ID" >/dev/null
 }
 
 disable_emulator_launcher() {
@@ -154,9 +174,14 @@ run_maestro_flows \
   "android GPS stale-readiness setup" \
   gps-only-recipe-stale-readiness-prepare.yaml || status=1
 
+prepare_provider_watcher_permissions
 run_maestro_flows \
   "android provider watcher started" \
   provider-status-watcher-android-start.yaml || status=1
+grant_background_permission_and_pause_host
+run_maestro_flows \
+  "android provider watcher resumed" \
+  provider-status-watcher-android-resumed.yaml || status=1
 set_location_enabled false
 run_maestro_flows \
   "android provider watcher changed" \

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -37,6 +37,7 @@ import { LongRunBackgroundE2EScreen } from "./screens/LongRunBackgroundE2EScreen
 import MockedMetadataScreen from "./screens/MockedMetadataScreen";
 import PermissionCheckScreen from "./screens/PermissionCheckScreen";
 import ProviderSettingsScreen from "./screens/ProviderSettingsScreen";
+import ProviderStatusWatcherScreen from "./screens/ProviderStatusWatcherScreen";
 import WatchPositionScreen from "./screens/WatchPositionScreen";
 import WebE2EScreen from "./screens/WebE2EScreen";
 
@@ -53,6 +54,7 @@ const linking = {
       LocationSimulation: "location-simulation",
       MockedMetadata: "mocked-metadata",
       ProviderSettings: "provider-settings",
+      ProviderStatusWatcher: "provider-status-watcher",
       ApiErrors: "api-errors",
       AccuracyPresets: "accuracy-presets",
       LastKnownPosition: "last-known-position",
@@ -150,6 +152,11 @@ export default function App() {
           <Tab.Screen
             name="ProviderSettings"
             component={ProviderSettingsScreen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="ProviderStatusWatcher"
+            component={ProviderStatusWatcherScreen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/ProviderStatusWatcherScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderStatusWatcherScreen.tsx
@@ -85,6 +85,11 @@ export default function ProviderStatusWatcherScreen() {
               testID: "provider-status-watcher-services"
             },
             {
+              label: "Background",
+              value: formatBoolean(status?.backgroundModeEnabled),
+              testID: "provider-status-watcher-background"
+            },
+            {
               label: "GPS",
               value: formatBoolean(status?.gpsAvailable),
               testID: "provider-status-watcher-gps"

--- a/examples/v0.81.1/src/screens/ProviderStatusWatcherScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderStatusWatcherScreen.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  getProviderStatus,
+  unwatch,
+  watchProviderStatus
+} from "react-native-nitro-geolocation";
+import type { LocationProviderStatus } from "react-native-nitro-geolocation";
+import {
+  KeyValueBlock,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection
+} from "./scenario";
+
+const formatBoolean = (value: boolean | undefined) => {
+  if (value === undefined) return "unknown";
+  return value ? "enabled" : "disabled";
+};
+
+export default function ProviderStatusWatcherScreen() {
+  const tokenRef = useRef<string | null>(null);
+  const [status, setStatus] = useState<LocationProviderStatus | null>(null);
+  const [manualStatus, setManualStatus] =
+    useState<LocationProviderStatus | null>(null);
+  const [eventCount, setEventCount] = useState(0);
+  const [listening, setListening] = useState(false);
+
+  const stopListening = () => {
+    if (tokenRef.current) {
+      unwatch(tokenRef.current);
+      tokenRef.current = null;
+    }
+    setListening(false);
+  };
+
+  const startListening = () => {
+    if (tokenRef.current) return;
+
+    const token = watchProviderStatus((nextStatus) => {
+      setStatus(nextStatus);
+      setEventCount((count) => count + 1);
+    });
+    tokenRef.current = token;
+    setListening(true);
+  };
+
+  const refreshSnapshot = async () => {
+    setManualStatus(await getProviderStatus());
+  };
+
+  useEffect(
+    () => () => {
+      if (tokenRef.current) unwatch(tokenRef.current);
+    },
+    []
+  );
+
+  return (
+    <ScenarioScreen
+      prefix="provider-status-watcher"
+      title="Provider Status Watcher"
+      subtitle="Observe readiness changes without opening settings"
+    >
+      <ScenarioSection
+        index={1}
+        title="Live Readiness"
+        description="Start one listener for the initial provider snapshot and distinct device setting changes."
+      >
+        <KeyValueBlock
+          testID="provider-status-watcher-status"
+          rows={[
+            {
+              label: "Listener",
+              value: listening ? "listening" : "stopped",
+              testID: "provider-status-watcher-state"
+            },
+            {
+              label: "Events",
+              value: String(eventCount),
+              testID: "provider-status-watcher-event-count"
+            },
+            {
+              label: "Services",
+              value: formatBoolean(status?.locationServicesEnabled),
+              testID: "provider-status-watcher-services"
+            },
+            {
+              label: "GPS",
+              value: formatBoolean(status?.gpsAvailable),
+              testID: "provider-status-watcher-gps"
+            },
+            {
+              label: "Network",
+              value: formatBoolean(status?.networkAvailable),
+              testID: "provider-status-watcher-network"
+            }
+          ]}
+        />
+        <ScenarioButton
+          title="Start Listening"
+          onPress={startListening}
+          disabled={listening}
+          color="#1565C0"
+          testID="provider-status-watcher-start-button"
+        />
+        <ScenarioButton
+          title="Stop Listening"
+          onPress={stopListening}
+          disabled={!listening}
+          color="#455A64"
+          testID="provider-status-watcher-stop-button"
+        />
+      </ScenarioSection>
+
+      <ScenarioSection
+        index={2}
+        title="On-Demand Check"
+        description="Read the current provider state without restarting the listener or changing device settings."
+        divided
+      >
+        <KeyValueBlock
+          testID="provider-status-watcher-manual-status"
+          rows={[
+            {
+              label: "Manual snapshot",
+              value: formatBoolean(manualStatus?.locationServicesEnabled),
+              testID: "provider-status-watcher-manual-services"
+            }
+          ]}
+        />
+        <ScenarioButton
+          title="Refresh Snapshot"
+          onPress={refreshSnapshot}
+          color="#2E7D32"
+          testID="provider-status-watcher-refresh-button"
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidProviderStatusWatcher.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidProviderStatusWatcher.kt
@@ -1,0 +1,100 @@
+package com.margelo.nitro.nitrogeolocation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.location.LocationManager
+import android.os.Handler
+import android.os.Looper
+import androidx.core.content.ContextCompat
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+internal class AndroidProviderStatusWatcher(
+    private val context: Context,
+    private val locationSettings: AndroidLocationSettings
+) {
+    private val callbacks = mutableMapOf<String, (LocationProviderStatus) -> Unit>()
+    private val lastStatuses = mutableMapOf<String, LocationProviderStatus>()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val refreshGeneration = AtomicLong(0L)
+    private var receiverRegistered = false
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            refresh()
+        }
+    }
+
+    fun watch(success: (LocationProviderStatus) -> Unit): String {
+        val token = UUID.randomUUID().toString()
+        synchronized(this) {
+            callbacks[token] = success
+            if (!receiverRegistered) registerReceiver()
+        }
+        refresh()
+        return token
+    }
+
+    fun unwatch(token: String) {
+        synchronized(this) {
+            callbacks.remove(token)
+            lastStatuses.remove(token)
+            if (callbacks.isEmpty()) unregisterReceiver()
+        }
+    }
+
+    fun stopObserving() {
+        synchronized(this) {
+            callbacks.clear()
+            lastStatuses.clear()
+            refreshGeneration.incrementAndGet()
+            unregisterReceiver()
+        }
+    }
+
+    private fun refresh() {
+        val generation = refreshGeneration.incrementAndGet()
+        locationSettings.getProviderStatus { status ->
+            if (generation != refreshGeneration.get()) return@getProviderStatus
+
+            val tokens = synchronized(this) {
+                callbacks.keys.filter { token ->
+                    if (lastStatuses[token] == status) {
+                        false
+                    } else {
+                        lastStatuses[token] = status
+                        true
+                    }
+                }
+            }
+            tokens.forEach { token ->
+                mainHandler.post {
+                    val callback = synchronized(this) { callbacks[token] }
+                    callback?.invoke(status)
+                }
+            }
+        }
+    }
+
+    private fun registerReceiver() {
+        val filter = IntentFilter().apply {
+            addAction(LocationManager.PROVIDERS_CHANGED_ACTION)
+            addAction(LocationManager.MODE_CHANGED_ACTION)
+        }
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            filter,
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        receiverRegistered = true
+    }
+
+    private fun unregisterReceiver() {
+        if (!receiverRegistered) return
+        context.unregisterReceiver(receiver)
+        receiverRegistered = false
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidProviderStatusWatcher.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidProviderStatusWatcher.kt
@@ -8,18 +8,21 @@ import android.location.LocationManager
 import android.os.Handler
 import android.os.Looper
 import androidx.core.content.ContextCompat
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.ReactApplicationContext
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 internal class AndroidProviderStatusWatcher(
-    private val context: Context,
+    private val reactContext: ReactApplicationContext,
     private val locationSettings: AndroidLocationSettings
-) {
+) : LifecycleEventListener {
     private val callbacks = mutableMapOf<String, (LocationProviderStatus) -> Unit>()
     private val lastStatuses = mutableMapOf<String, LocationProviderStatus>()
     private val mainHandler = Handler(Looper.getMainLooper())
     private val refreshGeneration = AtomicLong(0L)
     private var receiverRegistered = false
+    private var lifecycleRegistered = false
 
     private val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -31,7 +34,7 @@ internal class AndroidProviderStatusWatcher(
         val token = UUID.randomUUID().toString()
         synchronized(this) {
             callbacks[token] = success
-            if (!receiverRegistered) registerReceiver()
+            if (!receiverRegistered) startObserving()
         }
         refresh()
         return token
@@ -41,7 +44,10 @@ internal class AndroidProviderStatusWatcher(
         synchronized(this) {
             callbacks.remove(token)
             lastStatuses.remove(token)
-            if (callbacks.isEmpty()) unregisterReceiver()
+            if (callbacks.isEmpty()) {
+                refreshGeneration.incrementAndGet()
+                stopObservingSources()
+            }
         }
     }
 
@@ -50,8 +56,23 @@ internal class AndroidProviderStatusWatcher(
             callbacks.clear()
             lastStatuses.clear()
             refreshGeneration.incrementAndGet()
-            unregisterReceiver()
+            stopObservingSources()
         }
+    }
+
+    fun dispose() {
+        stopObserving()
+    }
+
+    override fun onHostResume() {
+        val hasCallbacks = synchronized(this) { callbacks.isNotEmpty() }
+        if (hasCallbacks) refresh()
+    }
+
+    override fun onHostPause() = Unit
+
+    override fun onHostDestroy() {
+        stopObserving()
     }
 
     private fun refresh() {
@@ -78,23 +99,30 @@ internal class AndroidProviderStatusWatcher(
         }
     }
 
-    private fun registerReceiver() {
+    private fun startObserving() {
         val filter = IntentFilter().apply {
             addAction(LocationManager.PROVIDERS_CHANGED_ACTION)
             addAction(LocationManager.MODE_CHANGED_ACTION)
         }
         ContextCompat.registerReceiver(
-            context,
+            reactContext,
             receiver,
             filter,
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         receiverRegistered = true
+        reactContext.addLifecycleEventListener(this)
+        lifecycleRegistered = true
     }
 
-    private fun unregisterReceiver() {
-        if (!receiverRegistered) return
-        context.unregisterReceiver(receiver)
-        receiverRegistered = false
+    private fun stopObservingSources() {
+        if (lifecycleRegistered) {
+            reactContext.removeLifecycleEventListener(this)
+            lifecycleRegistered = false
+        }
+        if (receiverRegistered) {
+            reactContext.unregisterReceiver(receiver)
+            receiverRegistered = false
+        }
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -57,6 +57,7 @@ class NitroGeolocation(
             createLocationError = ::createLocationError
         )
     }
+    private val providerStatusWatcher by lazy { AndroidProviderStatusWatcher(reactContext, locationSettings) }
     private val fusedLocationClient by lazy {
         LocationServices.getFusedLocationProviderClient(reactContext)
     }
@@ -172,6 +173,10 @@ class NitroGeolocation(
             promise.resolve(status)
         }
         return promise
+    }
+
+    override fun watchProviderStatus(success: (LocationProviderStatus) -> Unit): String {
+        return providerStatusWatcher.watch(success)
     }
 
     override fun getLocationAvailability(): Promise<LocationAvailability> {
@@ -529,6 +534,7 @@ class NitroGeolocation(
     override fun unwatch(token: String) {
         val didRemoveLocationSubscription = watchSubscriptions.remove(token) != null
         headingManager.unwatch(token)
+        providerStatusWatcher.unwatch(token)
 
         if (!didRemoveLocationSubscription) {
             return
@@ -545,6 +551,7 @@ class NitroGeolocation(
     override fun stopObserving() {
         watchSubscriptions.clear()
         headingManager.stopObserving()
+        providerStatusWatcher.stopObserving()
         stopWatchingLocation()
     }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -533,7 +533,7 @@ class NitroGeolocation(
     override fun unwatch(token: String) {
         val didRemoveLocationSubscription = watchSubscriptions.remove(token) != null
         headingManager.unwatch(token)
-        providerStatusWatcher.unwatch(token)
+        providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.unwatch(token)
 
         if (!didRemoveLocationSubscription) {
             return
@@ -550,7 +550,7 @@ class NitroGeolocation(
     override fun stopObserving() {
         watchSubscriptions.clear()
         headingManager.stopObserving()
-        providerStatusWatcher.stopObserving()
+        providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.stopObserving()
         stopWatchingLocation()
     }
     override fun dispose() {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -57,7 +57,8 @@ class NitroGeolocation(
             createLocationError = ::createLocationError
         )
     }
-    private val providerStatusWatcher by lazy { AndroidProviderStatusWatcher(reactContext, locationSettings) }
+    private val providerStatusWatcherDelegate = lazy { AndroidProviderStatusWatcher(reactContext, locationSettings) }
+    private val providerStatusWatcher by providerStatusWatcherDelegate
     private val fusedLocationClient by lazy {
         LocationServices.getFusedLocationProviderClient(reactContext)
     }
@@ -175,9 +176,7 @@ class NitroGeolocation(
         return promise
     }
 
-    override fun watchProviderStatus(success: (LocationProviderStatus) -> Unit): String {
-        return providerStatusWatcher.watch(success)
-    }
+    override fun watchProviderStatus(success: (LocationProviderStatus) -> Unit) = providerStatusWatcher.watch(success)
 
     override fun getLocationAvailability(): Promise<LocationAvailability> {
         val promise = Promise<LocationAvailability>()
@@ -553,6 +552,10 @@ class NitroGeolocation(
         headingManager.stopObserving()
         providerStatusWatcher.stopObserving()
         stopWatchingLocation()
+    }
+    override fun dispose() {
+        runCatching { providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.dispose() }
+        super.dispose()
     }
 
     // MARK: - Helper Functions - Permission

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationErrors.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationErrors.swift
@@ -17,8 +17,16 @@ func createLocationError(code: LocationErrorCode, message: String) -> LocationEr
 }
 
 func createLocationProviderStatus() -> LocationProviderStatus {
+    return createLocationProviderStatus(
+        locationServicesEnabled: CLLocationManager.locationServicesEnabled()
+    )
+}
+
+func createLocationProviderStatus(
+    locationServicesEnabled: Bool
+) -> LocationProviderStatus {
     return LocationProviderStatus(
-        locationServicesEnabled: CLLocationManager.locationServicesEnabled(),
+        locationServicesEnabled: locationServicesEnabled,
         backgroundModeEnabled: isLocationBackgroundModeEnabled(),
         gpsAvailable: nil,
         networkAvailable: nil,

--- a/packages/react-native-nitro-geolocation/ios/IOSProviderStatusWatcher.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSProviderStatusWatcher.swift
@@ -1,0 +1,134 @@
+import CoreLocation
+import Foundation
+import UIKit
+
+final class IOSProviderStatusWatcher: NSObject, CLLocationManagerDelegate {
+    private var callbacks: [String: (LocationProviderStatus) -> Void] = [:]
+    private var lastStatuses: [String: LocationProviderStatus] = [:]
+    private var locationManager: CLLocationManager?
+    private var activeObserver: NSObjectProtocol?
+    private var refreshGeneration = 0
+    private let statusQueue = DispatchQueue(
+        label: "com.nitrogeolocation.provider-status",
+        qos: .utility
+    )
+
+    func watch(
+        success: @escaping (LocationProviderStatus) -> Void
+    ) -> String {
+        let token = UUID().uuidString
+        onMain {
+            self.callbacks[token] = success
+            if self.callbacks.count == 1 { self.startObserving() }
+            self.refreshOnMain()
+        }
+        return token
+    }
+
+    func unwatch(token: String) {
+        onMain {
+            self.callbacks.removeValue(forKey: token)
+            self.lastStatuses.removeValue(forKey: token)
+            if self.callbacks.isEmpty { self.stopObservingOnMain() }
+        }
+    }
+
+    func stopObserving() {
+        onMain {
+            self.callbacks.removeAll()
+            self.lastStatuses.removeAll()
+            self.stopObservingOnMain()
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        refreshOnMain()
+    }
+
+    deinit {
+        if let activeObserver {
+            NotificationCenter.default.removeObserver(activeObserver)
+        }
+        locationManager?.delegate = nil
+    }
+
+    private func startObserving() {
+        let manager = CLLocationManager()
+        manager.delegate = self
+        locationManager = manager
+        activeObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshOnMain()
+        }
+    }
+
+    private func stopObservingOnMain() {
+        refreshGeneration += 1
+        if let activeObserver {
+            NotificationCenter.default.removeObserver(activeObserver)
+            self.activeObserver = nil
+        }
+        locationManager?.delegate = nil
+        locationManager = nil
+    }
+
+    private func refreshOnMain() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        refreshGeneration += 1
+        let generation = refreshGeneration
+        statusQueue.async { [weak self] in
+            let status = createLocationProviderStatus(
+                locationServicesEnabled: CLLocationManager.locationServicesEnabled()
+            )
+            DispatchQueue.main.async {
+                self?.deliver(status, generation: generation)
+            }
+        }
+    }
+
+    private func deliver(
+        _ status: LocationProviderStatus,
+        generation: Int
+    ) {
+        guard generation == refreshGeneration else { return }
+        var pending: [(LocationProviderStatus) -> Void] = []
+        for (token, callback) in callbacks {
+            guard !sameStatus(lastStatuses[token], status) else { continue }
+            lastStatuses[token] = status
+            pending.append(callback)
+        }
+        pending.forEach { $0(status) }
+    }
+
+    private func sameStatus(
+        _ first: LocationProviderStatus?,
+        _ second: LocationProviderStatus
+    ) -> Bool {
+        return first?.locationServicesEnabled == second.locationServicesEnabled
+            && first?.backgroundModeEnabled == second.backgroundModeEnabled
+            && first?.gpsAvailable == second.gpsAvailable
+            && first?.networkAvailable == second.networkAvailable
+            && first?.passiveAvailable == second.passiveAvailable
+            && first?.googlePlayServicesAvailable == second.googlePlayServicesAvailable
+            && first?.googleLocationAccuracyEnabled == second.googleLocationAccuracyEnabled
+    }
+
+    private func onMain(_ action: @escaping () -> Void) {
+        if Thread.isMainThread {
+            action()
+        } else {
+            DispatchQueue.main.sync(execute: action)
+        }
+    }
+}
+
+extension NitroGeolocation {
+    func watchProviderStatus(
+        success: @escaping (LocationProviderStatus) -> Void
+    ) -> String {
+        return providerStatusWatcher.watch(success: success)
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -19,8 +19,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     private var locationManagerDelegate: LocationManagerDelegate?
     private var lastLocation: CLLocation?
     private var usingSignificantChanges: Bool = false
-
-    // Permission callbacks
+    lazy var providerStatusWatcher = IOSProviderStatusWatcher()
     private var pendingPermissionResolvers: [(PermissionStatus) -> Void] = []
 
     // getCurrentPosition promise resolvers with timeout
@@ -470,6 +469,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     func unwatch(token: String) {
         watchSubscriptions.removeValue(forKey: token)
         headingSubscriptions.removeValue(forKey: token)
+        providerStatusWatcher.unwatch(token: token)
 
         // Stop monitoring if no more subscriptions or pending requests
         if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
@@ -488,6 +488,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     func stopObserving() {
         watchSubscriptions.removeAll()
         headingSubscriptions.removeAll()
+        providerStatusWatcher.stopObserving()
 
         // Stop monitoring if no pending requests
         if pendingPositionRequests.isEmpty {
@@ -502,8 +503,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             updateHeadingConfiguration()
         }
     }
-
-    // MARK: - Location Manager Callbacks
 
     func handleAuthorizationChange(_ manager: CLLocationManager) {
         let status = getCurrentAuthorizationStatus(from: manager)

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.cpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.cpp
@@ -63,9 +63,9 @@ namespace margelo::nitro::nitrogeolocation { struct HeadingOptions; }
 #include "LocationProviderStatus.hpp"
 #include "JLocationProviderStatus.hpp"
 #include <optional>
+#include <string>
 #include "LocationAvailability.hpp"
 #include "JLocationAvailability.hpp"
-#include <string>
 #include "AccuracyAuthorization.hpp"
 #include "JAccuracyAuthorization.hpp"
 #include "GeolocationConfiguration.hpp"
@@ -212,6 +212,11 @@ namespace margelo::nitro::nitrogeolocation {
       });
       return __promise;
     }();
+  }
+  std::string JHybridNitroGeolocationSpec::watchProviderStatus(const std::function<void(const LocationProviderStatus& /* status */)>& success) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<JFunc_void_LocationProviderStatus::javaobject> /* success */)>("watchProviderStatus_cxx");
+    auto __result = method(_javaPart, JFunc_void_LocationProviderStatus_cxx::fromCpp(success));
+    return __result->toStdString();
   }
   std::shared_ptr<Promise<LocationAvailability>> JHybridNitroGeolocationSpec::getLocationAvailability() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("getLocationAvailability");

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JHybridNitroGeolocationSpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::nitrogeolocation {
     void requestPermission(const std::function<void(PermissionStatus /* status */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
     std::shared_ptr<Promise<bool>> hasServicesEnabled() override;
     std::shared_ptr<Promise<LocationProviderStatus>> getProviderStatus() override;
+    std::string watchProviderStatus(const std::function<void(const LocationProviderStatus& /* status */)>& success) override;
     std::shared_ptr<Promise<LocationAvailability>> getLocationAvailability() override;
     void requestLocationSettings(const std::function<void(const LocationSettingsResult& /* result */)>& success, const LocationSettingsOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) override;
     std::shared_ptr<Promise<AccuracyAuthorization>> getAccuracyAuthorization() override;

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HybridNitroGeolocationSpec.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/HybridNitroGeolocationSpec.kt
@@ -53,6 +53,15 @@ abstract class HybridNitroGeolocationSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun getProviderStatus(): Promise<LocationProviderStatus>
+  
+  abstract fun watchProviderStatus(success: (status: LocationProviderStatus) -> Unit): String
+
+  @DoNotStrip
+  @Keep
+  private fun watchProviderStatus_cxx(success: Func_void_LocationProviderStatus): String {
+    val __result = watchProviderStatus(success)
+    return __result
+  }
 
   @DoNotStrip
   @Keep

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/NitroGeolocation-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/NitroGeolocation-Swift-Cxx-Bridge.hpp
@@ -835,6 +835,15 @@ namespace margelo::nitro::nitrogeolocation::bridge::swift {
     return Result<std::shared_ptr<Promise<LocationProviderStatus>>>::withError(error);
   }
 
+  // pragma MARK: Result<std::string>
+  using Result_std__string_ = Result<std::string>;
+  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
+    return Result<std::string>::withValue(value);
+  }
+  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
+    return Result<std::string>::withError(error);
+  }
+
   // pragma MARK: Result<std::shared_ptr<Promise<LocationAvailability>>>
   using Result_std__shared_ptr_Promise_LocationAvailability___ = Result<std::shared_ptr<Promise<LocationAvailability>>>;
   inline Result_std__shared_ptr_Promise_LocationAvailability___ create_Result_std__shared_ptr_Promise_LocationAvailability___(const std::shared_ptr<Promise<LocationAvailability>>& value) noexcept {
@@ -851,15 +860,6 @@ namespace margelo::nitro::nitrogeolocation::bridge::swift {
   }
   inline Result_std__shared_ptr_Promise_AccuracyAuthorization___ create_Result_std__shared_ptr_Promise_AccuracyAuthorization___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<AccuracyAuthorization>>>::withError(error);
-  }
-
-  // pragma MARK: Result<std::string>
-  using Result_std__string_ = Result<std::string>;
-  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
-    return Result<std::string>::withValue(value);
-  }
-  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
-    return Result<std::string>::withError(error);
   }
 
   // pragma MARK: std::optional<AuthorizationLevelInternal>

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/c++/HybridNitroGeolocationSpecSwift.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/c++/HybridNitroGeolocationSpecSwift.hpp
@@ -185,6 +185,14 @@ namespace margelo::nitro::nitrogeolocation {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::string watchProviderStatus(const std::function<void(const LocationProviderStatus& /* status */)>& success) override {
+      auto __result = _swiftPart.watchProviderStatus(success);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::shared_ptr<Promise<LocationAvailability>> getLocationAvailability() override {
       auto __result = _swiftPart.getLocationAvailability();
       if (__result.hasError()) [[unlikely]] {

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec.swift
@@ -18,6 +18,7 @@ public protocol HybridNitroGeolocationSpec_protocol: HybridObject {
   func requestPermission(success: @escaping (_ status: PermissionStatus) -> Void, error: ((_ error: LocationError) -> Void)?) throws -> Void
   func hasServicesEnabled() throws -> Promise<Bool>
   func getProviderStatus() throws -> Promise<LocationProviderStatus>
+  func watchProviderStatus(success: @escaping (_ status: LocationProviderStatus) -> Void) throws -> String
   func getLocationAvailability() throws -> Promise<LocationAvailability>
   func requestLocationSettings(success: @escaping (_ result: LocationSettingsResult) -> Void, options: LocationSettingsOptions, error: ((_ error: LocationError) -> Void)?) throws -> Void
   func getAccuracyAuthorization() throws -> Promise<AccuracyAuthorization>

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec_cxx.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/HybridNitroGeolocationSpec_cxx.swift
@@ -221,6 +221,23 @@ open class HybridNitroGeolocationSpec_cxx {
   }
 
   @inline(__always)
+  public final func watchProviderStatus(success: bridge.Func_void_LocationProviderStatus) -> bridge.Result_std__string_ {
+    do {
+      let __result = try self.__implementation.watchProviderStatus(success: { () -> (LocationProviderStatus) -> Void in
+        let __wrappedFunction = bridge.wrap_Func_void_LocationProviderStatus(success)
+        return { (__status: LocationProviderStatus) -> Void in
+          __wrappedFunction.call(__status)
+        }
+      }())
+      let __resultCpp = std.string(__result)
+      return bridge.create_Result_std__string_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__string_(__exceptionPtr)
+    }
+  }
+
+  @inline(__always)
   public final func getLocationAvailability() -> bridge.Result_std__shared_ptr_Promise_LocationAvailability___ {
     do {
       let __result = try self.__implementation.getLocationAvailability()

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.cpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::nitrogeolocation {
       prototype.registerHybridMethod("requestPermission", &HybridNitroGeolocationSpec::requestPermission);
       prototype.registerHybridMethod("hasServicesEnabled", &HybridNitroGeolocationSpec::hasServicesEnabled);
       prototype.registerHybridMethod("getProviderStatus", &HybridNitroGeolocationSpec::getProviderStatus);
+      prototype.registerHybridMethod("watchProviderStatus", &HybridNitroGeolocationSpec::watchProviderStatus);
       prototype.registerHybridMethod("getLocationAvailability", &HybridNitroGeolocationSpec::getLocationAvailability);
       prototype.registerHybridMethod("requestLocationSettings", &HybridNitroGeolocationSpec::requestLocationSettings);
       prototype.registerHybridMethod("getAccuracyAuthorization", &HybridNitroGeolocationSpec::getAccuracyAuthorization);

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/HybridNitroGeolocationSpec.hpp
@@ -51,11 +51,11 @@ namespace margelo::nitro::nitrogeolocation { struct HeadingOptions; }
 #include "LocationError.hpp"
 #include <optional>
 #include "LocationProviderStatus.hpp"
+#include <string>
 #include "LocationAvailability.hpp"
 #include "LocationSettingsResult.hpp"
 #include "LocationSettingsOptions.hpp"
 #include "AccuracyAuthorization.hpp"
-#include <string>
 #include "GeolocationResponse.hpp"
 #include "LocationRequestOptions.hpp"
 #include "GeocodedLocation.hpp"
@@ -101,6 +101,7 @@ namespace margelo::nitro::nitrogeolocation {
       virtual void requestPermission(const std::function<void(PermissionStatus /* status */)>& success, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
       virtual std::shared_ptr<Promise<bool>> hasServicesEnabled() = 0;
       virtual std::shared_ptr<Promise<LocationProviderStatus>> getProviderStatus() = 0;
+      virtual std::string watchProviderStatus(const std::function<void(const LocationProviderStatus& /* status */)>& success) = 0;
       virtual std::shared_ptr<Promise<LocationAvailability>> getLocationAvailability() = 0;
       virtual void requestLocationSettings(const std::function<void(const LocationSettingsResult& /* result */)>& success, const LocationSettingsOptions& options, const std::optional<std::function<void(const LocationError& /* error */)>>& error) = 0;
       virtual std::shared_ptr<Promise<AccuracyAuthorization>> getAccuracyAuthorization() = 0;

--- a/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
@@ -278,6 +278,16 @@ export interface NitroGeolocation
   getProviderStatus(): Promise<LocationProviderStatus>;
 
   /**
+   * Observe provider/settings readiness without opening system settings.
+   *
+   * The callback receives an asynchronous initial snapshot, followed only by
+   * distinct status changes. Use `unwatch(token)` to stop the subscription.
+   */
+  watchProviderStatus(
+    success: (status: LocationProviderStatus) => void
+  ): string;
+
+  /**
    * Get whether the current platform is likely to deliver location updates.
    *
    * Android: uses Fused Location availability when the configured provider is

--- a/packages/react-native-nitro-geolocation/src/api/index.ts
+++ b/packages/react-native-nitro-geolocation/src/api/index.ts
@@ -3,6 +3,7 @@ export { checkPermission } from "./checkPermission";
 export { requestPermission } from "./requestPermission";
 export { hasServicesEnabled } from "./hasServicesEnabled";
 export { getProviderStatus } from "./getProviderStatus";
+export { watchProviderStatus } from "./watchProviderStatus";
 export { getLocationAvailability } from "./getLocationAvailability";
 export { requestLocationSettings } from "./requestLocationSettings";
 export { getAccuracyAuthorization } from "./getAccuracyAuthorization";

--- a/packages/react-native-nitro-geolocation/src/api/watchProviderStatus.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchProviderStatus.ts
@@ -1,0 +1,16 @@
+import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
+import type { LocationProviderStatus } from "../publicTypes";
+
+/**
+ * Observe device provider/settings readiness.
+ *
+ * The callback receives an asynchronous initial snapshot and then only
+ * distinct changes. This API never opens settings or requests permission.
+ *
+ * @returns Subscription token for cleanup with `unwatch(token)`
+ */
+export function watchProviderStatus(
+  success: (status: LocationProviderStatus) => void
+): string {
+  return NitroGeolocationHybridObject.watchProviderStatus(success);
+}

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -55,6 +55,7 @@ export {
   requestPermission,
   hasServicesEnabled,
   getProviderStatus,
+  watchProviderStatus,
   getLocationAvailability,
   requestLocationSettings,
   getAccuracyAuthorization,

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -9,7 +9,8 @@ import {
   requestPermission,
   stopObserving,
   unwatch,
-  watchPosition
+  watchPosition,
+  watchProviderStatus
 } from ".";
 import { clearLastKnownPositionCache } from "../api/positionCache";
 import { LocationErrorCode } from "../utils/errors";
@@ -51,6 +52,7 @@ afterEach(() => {
   stopObserving();
   clearLastKnownPositionCache();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   Reflect.deleteProperty(globalThis, "navigator");
 });
 
@@ -362,5 +364,89 @@ describe("web Modern API", () => {
 
     stopObserving();
     expect(clearWatch).toHaveBeenCalledWith(11);
+  });
+
+  it("observes distinct provider status changes and stops by token", async () => {
+    const windowListeners = new Map<string, EventListener>();
+    const documentListeners = new Map<string, EventListener>();
+    vi.stubGlobal(
+      "addEventListener",
+      vi.fn((type: string, listener: EventListener) => {
+        windowListeners.set(type, listener);
+      })
+    );
+    vi.stubGlobal(
+      "removeEventListener",
+      vi.fn((type: string) => {
+        windowListeners.delete(type);
+      })
+    );
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        documentListeners.set(type, listener);
+      }),
+      removeEventListener: vi.fn((type: string) => {
+        documentListeners.delete(type);
+      })
+    });
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+    const success = vi.fn();
+
+    const token = watchProviderStatus(success);
+    expect(success).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(success).toHaveBeenCalledWith({
+      locationServicesEnabled: true,
+      backgroundModeEnabled: false
+    });
+
+    windowListeners.get("focus")?.({} as Event);
+    await Promise.resolve();
+    expect(success).toHaveBeenCalledTimes(1);
+
+    setNavigator(undefined);
+    documentListeners.get("visibilitychange")?.({} as Event);
+    await Promise.resolve();
+    expect(success).toHaveBeenLastCalledWith({
+      locationServicesEnabled: false,
+      backgroundModeEnabled: false
+    });
+    expect(success).toHaveBeenCalledTimes(2);
+
+    const stalePageShowListener = windowListeners.get("pageshow");
+    unwatch(token);
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(),
+        clearWatch: vi.fn()
+      }
+    });
+    stalePageShowListener?.({} as Event);
+    await Promise.resolve();
+    expect(success).toHaveBeenCalledTimes(2);
+  });
+
+  it("stopObserving cancels every provider status watcher", async () => {
+    setNavigator(undefined);
+    const first = vi.fn();
+    const second = vi.fn();
+
+    watchProviderStatus(first);
+    watchProviderStatus(second);
+    await Promise.resolve();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    stopObserving();
+    await Promise.resolve();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -33,7 +33,13 @@ import {
   rejectUnsupported,
   toPositionOptions
 } from "./browser";
-export { stopObserving, unwatch, watchHeading, watchPosition } from "./watch";
+export {
+  stopObserving,
+  unwatch,
+  watchHeading,
+  watchPosition,
+  watchProviderStatus
+} from "./watch";
 export {
   useWatchPosition,
   type UseWatchPositionOptions

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -7,7 +7,8 @@ import { rememberPosition } from "../api/positionCache";
 import type {
   GeolocationResponse,
   Heading,
-  HeadingOptions
+  HeadingOptions,
+  LocationProviderStatus
 } from "../publicTypes";
 import {
   createUnsupportedError,
@@ -19,7 +20,83 @@ import {
 } from "./browser";
 
 const activeWatches = new Map<string, number>();
+type ProviderStatusSubscription = {
+  success: (status: LocationProviderStatus) => void;
+  lastStatus?: LocationProviderStatus;
+};
+type LifecycleTarget = {
+  addEventListener?: (type: string, listener: () => void) => void;
+  removeEventListener?: (type: string, listener: () => void) => void;
+};
+const providerStatusSubscriptions = new Map<
+  string,
+  ProviderStatusSubscription
+>();
+let providerStatusRegistrations: Array<{
+  event: string;
+  target: LifecycleTarget;
+}> = [];
 let nextWatchId = 1;
+let providerRefreshGeneration = 0;
+
+function getLifecycleTarget(): LifecycleTarget {
+  return globalThis as unknown as LifecycleTarget;
+}
+
+function readProviderStatus(): LocationProviderStatus {
+  return {
+    locationServicesEnabled: Boolean(getGeolocation()),
+    backgroundModeEnabled: false
+  };
+}
+
+function sameProviderStatus(
+  first: LocationProviderStatus | undefined,
+  second: LocationProviderStatus
+): boolean {
+  return (
+    first?.locationServicesEnabled === second.locationServicesEnabled &&
+    first?.backgroundModeEnabled === second.backgroundModeEnabled
+  );
+}
+
+function refreshProviderStatus(): void {
+  const generation = ++providerRefreshGeneration;
+  Promise.resolve().then(() => {
+    if (generation !== providerRefreshGeneration) return;
+
+    const status = readProviderStatus();
+    for (const subscription of providerStatusSubscriptions.values()) {
+      if (sameProviderStatus(subscription.lastStatus, status)) continue;
+      subscription.lastStatus = status;
+      subscription.success(status);
+    }
+  });
+}
+
+function startProviderStatusEvents(): void {
+  const lifecycleGlobal = getLifecycleTarget();
+  const lifecycleDocument = (
+    globalThis as typeof globalThis & { document?: LifecycleTarget }
+  ).document;
+  providerStatusRegistrations = [
+    { event: "focus", target: lifecycleGlobal },
+    { event: "pageshow", target: lifecycleGlobal },
+    ...(lifecycleDocument
+      ? [{ event: "visibilitychange", target: lifecycleDocument }]
+      : [])
+  ];
+  for (const { event, target } of providerStatusRegistrations) {
+    target.addEventListener?.(event, refreshProviderStatus);
+  }
+}
+
+function stopProviderStatusEvents(): void {
+  for (const { event, target } of providerStatusRegistrations) {
+    target.removeEventListener?.(event, refreshProviderStatus);
+  }
+  providerStatusRegistrations = [];
+}
 
 export function watchHeading(
   _success: (heading: Heading) => void,
@@ -74,7 +151,26 @@ export function watchPosition(
   return token;
 }
 
+export function watchProviderStatus(
+  success: (status: LocationProviderStatus) => void
+): string {
+  const token = `web-provider-${nextWatchId++}`;
+  const shouldStartEvents = providerStatusSubscriptions.size === 0;
+  providerStatusSubscriptions.set(token, { success });
+  if (shouldStartEvents) startProviderStatusEvents();
+  refreshProviderStatus();
+  return token;
+}
+
 export function unwatch(token: string): void {
+  if (providerStatusSubscriptions.delete(token)) {
+    if (providerStatusSubscriptions.size === 0) {
+      providerRefreshGeneration++;
+      stopProviderStatusEvents();
+    }
+    return;
+  }
+
   const watchId = activeWatches.get(token);
   if (watchId === undefined) {
     return;
@@ -86,6 +182,9 @@ export function unwatch(token: string): void {
 
 export function stopObserving(): void {
   for (const token of activeWatches.keys()) {
+    unwatch(token);
+  }
+  for (const token of providerStatusSubscriptions.keys()) {
     unwatch(token);
   }
 }


### PR DESCRIPTION
## Roadmap

Implements #98 v1.5 checkbox 5: Provider status watcher.

## What changed

- Add watchProviderStatus(success), returning a token cleaned up with unwatch(token).
- Deliver one asynchronous initial snapshot and only distinct provider/readiness changes afterward.
- Observe Android provider/mode broadcasts and host resume, iOS authorization/app-active lifecycle, and web lifecycle refreshes.
- Remove Android receiver/lifecycle registrations on last unwatch, stopObserving, React host destruction, and HybridObject disposal.
- Keep the API observation-only: no permission prompt, settings launch, recovery, or hidden provider switching.
- Add a natural test page with independent live-listener and manual-snapshot controls.
- Add a compatible-feature minor changeset; repository prereleases remain on the rc tag.

## Red to green

- Initial red: the two new web contract tests failed with TypeError: watchProviderStatus is not a function while the existing 68 tests passed.
- Initial green: 70/70 unit tests pass after implementing the public API and platform watchers.
- Review red: with an active Android watcher, foreground-only location permission reported Background disabled, but granting background permission and resuming the same host never produced Background enabled.
- Review green: host resume now refreshes non-broadcast readiness fields, producing exactly one distinct second event; teardown cancels pending delivery and unregisters native sources.

## Affected E2E

- Android Release: initial enabled/foreground-only snapshot, background-permission grant plus host resume, enabled-to-disabled provider change, token stop, and independent manual refresh all passed.
- iOS Release: initial enabled snapshot, listener stop, no extra callback after stop, and independent manual refresh all passed.
- Android flow discovery keeps mutually exclusive enabled/disabled phases in the platform runner.

## Validation

- yarn lint
- yarn format:check
- yarn test:unit (70/70)
- direct TypeScript checks for package, example, and docs
- yarn source-lines:check
- yarn deadcode
- yarn deadcode:prod
- yarn pack:check
- Android Release unit tests and Release app build
- iOS Release build with code signing disabled
- affected Android and iOS Maestro E2E flows
- Rspress docs build
