### PR TITLE
feat: add background reliability contract

### DIFF
--- a/.changeset/quiet-lions-report.md
+++ b/.changeset/quiet-lions-report.md
@@ -2,4 +2,4 @@
 "react-native-nitro-geolocation": minor
 ---
 
-Add native background reliability timestamps, long-run assertions, and a foreground/background/termination/reboot verification contract.
+Add native background reliability timestamps, run- and config-generation-aware serialized HTTP sync with bounded burst coalescing and automatic batch draining, long-run assertions, and a foreground/background/termination/reboot verification contract.

--- a/.changeset/quiet-lions-report.md
+++ b/.changeset/quiet-lions-report.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add native background reliability timestamps, long-run assertions, and a foreground/background/termination/reboot verification contract.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,45 @@ jobs:
         run: |
           yarn typecheck
 
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install java node
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          mise reshim node
+
+      - name: Install dependencies
+        run: |
+          yarn install
+
+      - name: Run TypeScript unit tests
+        run: |
+          yarn test:unit
+
+      - name: Run Android unit tests
+        run: |
+          ./examples/v0.81.1/android/gradlew \
+            -p examples/v0.81.1/android \
+            --no-daemon \
+            --console=plain \
+            :react-native-nitro-geolocation:testDebugUnitTest
+
   guardrails:
     name: Dead Code / Package Guardrails
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -196,13 +196,32 @@ jobs:
           ../../scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Installing iOS release app"
           xcrun simctl install "$SIMULATOR_UDID" ios/build/Build/Products/Release-iphonesimulator/NitroGeolocationExample.app
 
-      - name: Run iOS E2E
+      - name: Run iOS background long-run E2E
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED_BY: ${{ inputs.requested_by }}
+          IOS_UDID: ${{ env.SIMULATOR_UDID }}
         run: |
-          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Running Maestro flows"
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Running background long-run flow"
+          yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:ios
+
+      - name: Run iOS native E2E
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+          IOS_UDID: ${{ env.SIMULATOR_UDID }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Running native Maestro flows"
           yarn test:e2e:ios
+
+      - name: Run iOS web E2E
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+          IOS_UDID: ${{ env.SIMULATOR_UDID }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.ios_comment_id }}" "iOS" "running" "Running web fallback flows"
+          yarn test:e2e:web:ios
 
       - name: Upload iOS E2E artifacts
         if: always()
@@ -361,13 +380,30 @@ jobs:
           scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Installing Android release app"
           adb install -r examples/v0.81.1/android/app/build/outputs/apk/release/app-release.apk
 
-      - name: Run Android E2E
+      - name: Run Android background long-run E2E
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+          RUN_REBOOT: "1"
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Running background long-run flow"
+          yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android
+
+      - name: Run Android native E2E
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
-          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Running Maestro flows"
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Running native Maestro flows"
           yarn test:e2e:android
+
+      - name: Run Android web E2E
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_BY: ${{ inputs.requested_by }}
+        run: |
+          scripts/ci/update-e2e-comment.sh "${{ inputs.android_comment_id }}" "Android" "running" "Running web fallback flows"
+          yarn test:e2e:web:android
 
       - name: Stop Android emulator
         if: always()

--- a/docs/docs/background/_meta.json
+++ b/docs/docs/background/_meta.json
@@ -9,6 +9,7 @@
   "headless-js",
   "http-sync",
   "storage",
+  "reliability-contract",
   "long-run-e2e",
   "troubleshooting"
 ]

--- a/docs/docs/background/activity-recognition.md
+++ b/docs/docs/background/activity-recognition.md
@@ -22,6 +22,11 @@ Activity events are delivered through the same native event pipeline as location
 and geofence events. Android uses Activity Recognition APIs. iOS uses Core
 Motion when available.
 
+On iOS, starting standalone or activity-aware tracking waits for the Core Motion
+authorization decision. It rejects when activity recognition is unavailable,
+denied, restricted, or still undetermined after the permission timeout; it does
+not report a silently inactive motion provider as running.
+
 On Android 10+, request `android.permission.ACTIVITY_RECOGNITION` at runtime
 before calling `startActivityRecognition()` or using `trackingMode:
 'activityAware'`.

--- a/docs/docs/background/http-sync.md
+++ b/docs/docs/background/http-sync.md
@@ -27,4 +27,16 @@ await startBackgroundLocation({
 When `sync` is configured, native code attempts a flush after stored locations
 reach `syncThreshold`, respecting `syncInterval`. Failed flushes can retry up to
 `maxRetries` when `retry` is enabled. Call `syncStoredLocations()` to manually
-flush the native queue.
+flush the native queue. Manual and automatic flushes share one serial native
+queue. Automatic work rechecks the active run, current sync options, threshold,
+batch, and interval when its turn begins, so queued work cannot reuse a stale
+batch or upload the same stored locations alongside a manual flush.
+While an automatic upload is running, further location callbacks coalesce into
+one latest pending check instead of growing an unbounded upload backlog.
+Pending work from an older run cannot replace a newer run's check. After a
+successful upload, native code continues one batch at a time until the unsynced
+count falls below `syncThreshold`; each batch returns to the serial queue first,
+so manual sync and a newer run can take precedence.
+Calling `configureBackgroundLocation()` starts a new sync-config revision. An
+older upload may finish, but its continuation must reapply the replacement
+config's `syncInterval` before starting another batch.

--- a/docs/docs/background/long-run-e2e.md
+++ b/docs/docs/background/long-run-e2e.md
@@ -24,10 +24,18 @@ This flow:
 4. establishes an outside foreground baseline, then arms a new proof marker,
 5. sends the app home and injects inside, then outside locations,
 6. reopens the page,
-7. requires both injected coordinates and their location events after the proof marker,
+7. requires the injected inside coordinate followed by the outside coordinate, for both stored locations and location events, after the proof marker,
 8. verifies `lastLocationAt` and `lastEventAt` are at or after that marker,
-9. verifies the registered Headless task marked the post-marker inside event delivered,
-10. verifies geofence enter and exit events after the marker.
+9. verifies the registered Headless task marked an inside event whose native measurement timestamp is after the marker,
+10. verifies geofence enter and exit events after the marker,
+11. stops tracking, removes geofences, and polls the native lifecycle briefly
+    before failing cleanup if desired tracking, the actual foreground service,
+    or a geofence remains active.
+
+The prepare and arm registrations omit Android initial triggers, so the required
+exit cannot be satisfied by the already-outside foreground baseline. Both
+location payloads are matched to the exact injected coordinates, and the
+outside row/event must have been stored after the matching inside row/event.
 
 The Headless assertion proves handler delivery without an in-process background
 listener. It does not terminate the React runtime or claim cold-start delivery.
@@ -40,9 +48,11 @@ RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:back
 
 The reboot pass is emulator-only. The wrapper refuses `RUN_REBOOT=1` on a
 physical Android device before issuing `adb reboot`, then arms a post-reboot
-proof window, injects outside/inside/outside locations after boot, and requires
-post-reboot location plus geofence events. Physical Android devices need real
-movement or another trusted location injection setup.
+proof window, waits for `sys.boot_completed=1`, injects
+outside/inside/outside locations after boot, and requires
+the same ordered coordinates in both location rows and events using their
+native measurement timestamps, plus ordered geofence events. Physical Android
+devices need real movement or another trusted location injection setup.
 
 ## iOS
 
@@ -60,7 +70,9 @@ This flow:
 4. sends the app home and injects inside, then outside locations,
 5. reopens the page,
 6. requires stored geofence enter and exit events after the proof marker,
-7. verifies `lastEventAt` is at or after that marker.
+7. proves target-region enter-to-exit callback order with native transition timestamps,
+8. verifies `lastEventAt` is at or after that marker,
+9. stops tracking, removes geofences, and verifies cleanup from native status.
 
 The Simulator does not reliably emit standard or significant-change location
 rows after the app goes home. The iOS gate therefore uses region transitions,

--- a/docs/docs/background/long-run-e2e.md
+++ b/docs/docs/background/long-run-e2e.md
@@ -18,16 +18,19 @@ yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-r
 
 This flow:
 
-1. clears native storage and verifies both last-delivery timestamps are absent,
+1. clears native storage and verifies both last native-record timestamps are absent,
 2. starts background tracking with `stopOnTerminate: false` and `startOnBoot: true`,
 3. registers a geofence,
-4. sends the app home,
-5. injects outside, inside, and outside locations,
+4. establishes an outside foreground baseline, then arms a new proof marker,
+5. sends the app home and injects inside, then outside locations,
 6. reopens the page,
-7. verifies stored background location events recorded after the run marker,
+7. requires both injected coordinates and their location events after the proof marker,
 8. verifies `lastLocationAt` and `lastEventAt` are at or after that marker,
-9. verifies Headless JS delivery by checking delivered native event flags,
-10. verifies geofence enter and exit events.
+9. verifies the registered Headless task marked the post-marker inside event delivered,
+10. verifies geofence enter and exit events after the marker.
+
+The Headless assertion proves handler delivery without an in-process background
+listener. It does not terminate the React runtime or claim cold-start delivery.
 
 To include reboot restore on an emulator:
 
@@ -51,13 +54,19 @@ yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-r
 
 This flow:
 
-1. clears native storage and verifies both last-delivery timestamps are absent,
-2. starts iOS background/significant-change tracking,
-3. sends the app home,
-4. injects location changes,
+1. clears native storage and verifies both last native-record timestamps are absent,
+2. starts iOS background/significant-change tracking and records an initial native location timestamp,
+3. establishes an outside foreground baseline, then arms a new proof marker,
+4. sends the app home and injects inside, then outside locations,
 5. reopens the page,
-6. verifies native storage drain from events recorded after the run marker,
-7. verifies `lastLocationAt` and `lastEventAt` are at or after that marker.
+6. requires stored geofence enter and exit events after the proof marker,
+7. verifies `lastEventAt` is at or after that marker.
+
+The Simulator does not reliably emit standard or significant-change location
+rows after the app goes home. The iOS gate therefore uses region transitions,
+which are native background callbacks, and does not claim that the injected
+coordinates were retained as location rows. Real-device location delivery
+remains a manual matrix item.
 
 iOS does not have Android Headless JS or an Android-style boot receiver. The E2E
 page reports those as platform limits instead of pretending they are supported.

--- a/docs/docs/background/long-run-e2e.md
+++ b/docs/docs/background/long-run-e2e.md
@@ -18,14 +18,16 @@ yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-r
 
 This flow:
 
-1. starts background tracking with `stopOnTerminate: false` and `startOnBoot: true`,
-2. registers a geofence,
-3. sends the app home,
-4. injects outside, inside, and outside locations,
-5. reopens the page,
-6. verifies stored background location events recorded after the run marker,
-7. verifies Headless JS delivery by checking delivered native event flags,
-8. verifies geofence enter and exit events.
+1. clears native storage and verifies both last-delivery timestamps are absent,
+2. starts background tracking with `stopOnTerminate: false` and `startOnBoot: true`,
+3. registers a geofence,
+4. sends the app home,
+5. injects outside, inside, and outside locations,
+6. reopens the page,
+7. verifies stored background location events recorded after the run marker,
+8. verifies `lastLocationAt` and `lastEventAt` are at or after that marker,
+9. verifies Headless JS delivery by checking delivered native event flags,
+10. verifies geofence enter and exit events.
 
 To include reboot restore on an emulator:
 
@@ -49,11 +51,13 @@ yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-r
 
 This flow:
 
-1. starts iOS background/significant-change tracking,
-2. sends the app home,
-3. injects location changes,
-4. reopens the page,
-5. verifies native storage drain from events recorded after the run marker.
+1. clears native storage and verifies both last-delivery timestamps are absent,
+2. starts iOS background/significant-change tracking,
+3. sends the app home,
+4. injects location changes,
+5. reopens the page,
+6. verifies native storage drain from events recorded after the run marker,
+7. verifies `lastLocationAt` and `lastEventAt` are at or after that marker.
 
 iOS does not have Android Headless JS or an Android-style boot receiver. The E2E
 page reports those as platform limits instead of pretending they are supported.
@@ -97,3 +101,6 @@ Long-run background behavior is platform and device-policy dependent. If the
 screen reports a failed result, keep it failed and inspect the device state,
 permissions, battery policy, and native logs. Do not change the E2E page to pass
 without a stored native event.
+
+The supported guarantees and the full automated/manual matrix are documented
+in [Background Reliability Contract](/background/reliability-contract).

--- a/docs/docs/background/overview.md
+++ b/docs/docs/background/overview.md
@@ -23,6 +23,7 @@ imports stay explicit and tree-shakable.
 - [Start And Stop](/background/start-stop) - start continuous tracking and subscribe to native updates.
 - [Troubleshooting](/background/troubleshooting) - use `diagnoseBackgroundLocation()` to interpret the native background status when delivery is silent.
 - [Storage Recovery](/background/storage) - drain events recorded while JavaScript was not running.
+- [Reliability Contract](/background/reliability-contract) - understand foreground, background, termination, reboot, iOS suspension, status timestamps, and the E2E matrix.
 - [Geofencing](/background/geofencing), [Activity Recognition](/background/activity-recognition), and [Native HTTP Sync](/background/http-sync) - add advanced background behavior.
 
 ## Diagnose Silent Background Delivery

--- a/docs/docs/background/permissions.md
+++ b/docs/docs/background/permissions.md
@@ -32,4 +32,7 @@ Android 11+, `requestBackgroundPermission()` can open the app settings screen
 because the platform no longer allows inline background-location prompts. On
 iOS, it can also remain true until Always authorization is granted; use
 `openAppLocationSettings()` after explaining why Always access is required.
+When the current iOS status is When In Use, the OS may keep that status without
+delivering another authorization callback. The request therefore returns the
+current result instead of waiting for a callback that may never arrive.
 Call `checkBackgroundPermission()` again from your app-resume path.

--- a/docs/docs/background/reliability-contract.md
+++ b/docs/docs/background/reliability-contract.md
@@ -15,9 +15,11 @@ terminated, force-stopped, or constrained by battery policy.
 | User force-stop / force-quit | Android stops the service and suppresses receivers until the user launches the app again. No library option overrides force-stop. | Treat user force-quit as stopped. Do not depend on background relaunch until the user opens the app again. |
 | Device reboot | With `startOnBoot: true`, persisted configuration, `RECEIVE_BOOT_COMPLETED`, and valid permissions, the boot receiver attempts to restore geofences and tracking. OS/OEM policy can delay or reject the start. | There is no `startOnBoot` contract or boot receiver. Re-establish the desired tracking session after the app is launched. |
 
-`stopOnTerminate` and `startOnBoot` keep their existing defaults. This API does
-not silently enable foreground services, Headless JS, storage, boot restore, or
-persistence.
+The new status fields do not change existing behavior or defaults. Native
+storage remains enabled unless `persist: false`; Android
+`stopOnTerminate` defaults to `true` and `startOnBoot` defaults to `false`.
+Starting Android tracking continues to use the existing foreground service and
+Headless fallback.
 
 ## Status timestamps
 
@@ -44,9 +46,10 @@ the counters alone.
 | Scenario | Android automation | iOS automation | Physical-device/manual proof |
 | --- | --- | --- | --- |
 | Foreground start/stop and invalid configuration | `background-e2e.yaml` | `background-e2e.yaml` | Confirm permission and notification UX on the target OS versions. |
-| Background delivery with React UI inactive | `background-long-run-android.yaml` injects movement after Home and requires retained locations/events plus fresh status timestamps. | `background-long-run-ios.yaml` injects movement after Home and requires native storage drain plus fresh status timestamps. | Lock the screen and walk/drive long enough to exceed the configured distance and interval filters. |
-| JS unavailable | Android long-run requires delivered Headless JS event flags. | iOS has no Headless JS contract; verify storage drain after reopening. | Terminate the React runtime without force-stopping the app, then inspect native storage and logs. |
-| Geofence enter/exit | Android long-run injects outside → inside → outside and requires both transitions. | Not part of the simulator reliability gate. | Cross the boundary on real hardware; account for OS batching and region limits. |
+| Background delivery with React UI inactive | After a foreground baseline, `background-long-run-android.yaml` arms a new marker, presses Home, injects inside/outside coordinates, and requires both retained coordinates plus fresh status timestamps. | After a foreground baseline, the iOS flow arms a new marker, presses Home, and requires post-marker region enter/exit records plus a fresh event timestamp. Simulator location rows are not claimed. | Lock the screen and walk/drive long enough to exceed the configured distance and interval filters. |
+| No in-process background listener | Android long-run requires the registered Headless task to mark the post-marker inside event delivered. | iOS has no Headless JS contract; the flow verifies storage drain after reopening. | Inspect task receipts and native logs for the exact test run. |
+| React runtime unavailable | Not automated by the Home-key flow. | Not automated by the Home-key flow. | Terminate the React runtime without force-stopping/force-quitting the app, then inspect native storage and logs after relaunch. |
+| Geofence enter/exit | Android long-run injects outside → inside → outside and requires both transitions. | The iOS simulator gate requires both post-marker transitions from the same path. | Cross the boundary on real hardware; account for OS batching and region limits. |
 | Reboot restore | Optional `RUN_REBOOT=1` emulator pass verifies post-boot locations and geofences after a new proof marker. | Not supported. | Test reboot on each Android OEM targeted by the app; keep failures visible. |
 | User force-stop / force-quit | Not asserted as recoverable. Relaunch is required. | Not asserted as recoverable. Relaunch is required. | Verify the app reports stopped/stale state after the user reopens it. |
 

--- a/docs/docs/background/reliability-contract.md
+++ b/docs/docs/background/reliability-contract.md
@@ -1,0 +1,55 @@
+# Background Reliability Contract
+
+Background location is a native, best-effort pipeline. Starting it means the
+library has registered the platform mechanisms described below; it does not
+promise a fixed delivery interval while the app is backgrounded, suspended,
+terminated, force-stopped, or constrained by battery policy.
+
+## Runtime states
+
+| App/device state | Android contract | iOS contract |
+| --- | --- | --- |
+| Foreground | The foreground service owns continuous updates. Live JS listeners receive events while the React runtime exists; retained events remain available through the storage APIs. | Core Location runs with the selected mode. Live JS listeners receive events while the React runtime exists; retained events remain available through the storage APIs. |
+| Background or screen off | A visible location foreground service continues when permissions and OS policy allow it. Native storage records retained events, and Headless JS is attempted when no in-process listener is available. | `allowsBackgroundLocationUpdates` and the Location background mode allow Core Location delivery, but iOS controls timing and may suspend the process. Significant-change and region monitoring are more restart-friendly than continuous standard updates. |
+| Task removed / process killed | `stopOnTerminate: true` stops tracking. With `false`, the service requests sticky restart, but OEM policy, Android background-start limits, permission changes, or resource pressure can still prevent or delay it. | System termination is not a continuous-delivery guarantee. Significant-change or region monitoring may allow a later system relaunch; standard updates and arbitrary JS execution are not promised. |
+| User force-stop / force-quit | Android stops the service and suppresses receivers until the user launches the app again. No library option overrides force-stop. | Treat user force-quit as stopped. Do not depend on background relaunch until the user opens the app again. |
+| Device reboot | With `startOnBoot: true`, persisted configuration, `RECEIVE_BOOT_COMPLETED`, and valid permissions, the boot receiver attempts to restore geofences and tracking. OS/OEM policy can delay or reject the start. | There is no `startOnBoot` contract or boot receiver. Re-establish the desired tracking session after the app is launched. |
+
+`stopOnTerminate` and `startOnBoot` keep their existing defaults. This API does
+not silently enable foreground services, Headless JS, storage, boot restore, or
+persistence.
+
+## Status timestamps
+
+`getBackgroundLocationStatus()` includes two optional native-storage fields:
+
+```ts
+const status = await getBackgroundLocationStatus();
+
+console.log(status.lastLocationAt); // newest retained native location record
+console.log(status.lastEventAt);    // newest retained native event
+```
+
+Both values are Unix timestamps in milliseconds. They are absent when no
+matching record is retained, such as in a fresh or reset store. With
+`persist: false`, new records do not advance these fields, but previously
+retained records remain visible until they are removed. The fields describe
+native recording, not a promise that a live JS listener, Headless task, server
+sync, or application UI consumed the record.
+Compare them with your own run marker and inspect stored rows instead of using
+the counters alone.
+
+## Verification matrix
+
+| Scenario | Android automation | iOS automation | Physical-device/manual proof |
+| --- | --- | --- | --- |
+| Foreground start/stop and invalid configuration | `background-e2e.yaml` | `background-e2e.yaml` | Confirm permission and notification UX on the target OS versions. |
+| Background delivery with React UI inactive | `background-long-run-android.yaml` injects movement after Home and requires retained locations/events plus fresh status timestamps. | `background-long-run-ios.yaml` injects movement after Home and requires native storage drain plus fresh status timestamps. | Lock the screen and walk/drive long enough to exceed the configured distance and interval filters. |
+| JS unavailable | Android long-run requires delivered Headless JS event flags. | iOS has no Headless JS contract; verify storage drain after reopening. | Terminate the React runtime without force-stopping the app, then inspect native storage and logs. |
+| Geofence enter/exit | Android long-run injects outside → inside → outside and requires both transitions. | Not part of the simulator reliability gate. | Cross the boundary on real hardware; account for OS batching and region limits. |
+| Reboot restore | Optional `RUN_REBOOT=1` emulator pass verifies post-boot locations and geofences after a new proof marker. | Not supported. | Test reboot on each Android OEM targeted by the app; keep failures visible. |
+| User force-stop / force-quit | Not asserted as recoverable. Relaunch is required. | Not asserted as recoverable. Relaunch is required. | Verify the app reports stopped/stale state after the user reopens it. |
+
+See [Long-Run Background E2E](/background/long-run-e2e) for commands and
+coordinates. A failed device-policy case is evidence to diagnose, not a reason
+to weaken the assertion.

--- a/docs/docs/background/reliability-contract.md
+++ b/docs/docs/background/reliability-contract.md
@@ -21,6 +21,13 @@ storage remains enabled unless `persist: false`; Android
 Starting Android tracking continues to use the existing foreground service and
 Headless fallback.
 
+On Android, a successful `startBackgroundLocation()` resolves only after the
+foreground service and location provider are active. Activity-aware sessions
+also wait for Activity Recognition registration. A failed replacement leaves a
+previously confirmed standalone Activity Recognition registration intact.
+`android.isForegroundServiceRunning` observes the actual process-local service
+lifecycle; it is not an alias for the desired `isRunning` state.
+
 ## Status timestamps
 
 `getBackgroundLocationStatus()` includes two optional native-storage fields:
@@ -50,7 +57,7 @@ the counters alone.
 | No in-process background listener | Android long-run requires the registered Headless task to mark the post-marker inside event delivered. | iOS has no Headless JS contract; the flow verifies storage drain after reopening. | Inspect task receipts and native logs for the exact test run. |
 | React runtime unavailable | Not automated by the Home-key flow. | Not automated by the Home-key flow. | Terminate the React runtime without force-stopping/force-quitting the app, then inspect native storage and logs after relaunch. |
 | Geofence enter/exit | Android long-run injects outside → inside → outside and requires both transitions. | The iOS simulator gate requires both post-marker transitions from the same path. | Cross the boundary on real hardware; account for OS batching and region limits. |
-| Reboot restore | Optional `RUN_REBOOT=1` emulator pass verifies post-boot locations and geofences after a new proof marker. | Not supported. | Test reboot on each Android OEM targeted by the app; keep failures visible. |
+| Reboot restore | `RUN_REBOOT=1` waits for Android's boot-complete signal, then verifies post-marker outside → inside → outside native measurement order for both retained locations and events, plus ordered geofence transitions. The receiver requests `startOnBoot` tracking immediately and delegates persisted geofence restoration to an OS-owned `JobService`, including when tracking itself is not restarted. | Not supported. | Test reboot on each Android OEM targeted by the app; keep failures visible. |
 | User force-stop / force-quit | Not asserted as recoverable. Relaunch is required. | Not asserted as recoverable. Relaunch is required. | Verify the app reports stopped/stale state after the user reopens it. |
 
 See [Long-Run Background E2E](/background/long-run-e2e) for commands and

--- a/docs/docs/guide/agent-context-map.md
+++ b/docs/docs/guide/agent-context-map.md
@@ -15,7 +15,7 @@ Pick the smallest entry point that matches your change:
 | Android foreground native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt` | Nearby Android helper for the specific feature |
 | Android background native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/` |
 | iOS foreground native bug | `packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift` | Nearby iOS helper for the specific feature |
-| iOS background native bug | `packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift` | `IOSBackgroundLocationDelegate.swift`, `IOSBackgroundMotion.swift`, `IOSBackgroundHttpSync.swift` |
+| iOS background native bug | `packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift` | `IOSBackgroundLocationDelegate.swift`, `IOSBackgroundPermission.swift`, `IOSBackgroundRuntime.swift`, `IOSBackgroundMotion.swift`, `IOSBackgroundSync.swift`, `IOSBackgroundSyncScheduler.swift`, `IOSBackgroundHttpSync.swift` |
 | E2E failure | Matching `examples/v0.81.1/.maestro/*.yaml` file | Matching `examples/v0.81.1/src/screens/*Screen.tsx` file |
 | E2E shared UI or selectors | `examples/v0.81.1/src/screens/scenario/` | `examples/v0.81.1/src/App.tsx` for route names |
 
@@ -59,7 +59,7 @@ Avoid these until needed:
 | Nitro background module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` |
 | Background orchestration | `android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt` |
 | Foreground service tracking | `NitroBackgroundLocationService.kt`, `NitroBackgroundNotificationFactory.kt` |
-| Location delivery from system callbacks | `NitroLocationUpdateReceiver.kt` |
+| Location delivery and run-scoped PendingIntents | `NitroLocationUpdateReceiver.kt`, `NitroBackgroundPendingIntents.kt` |
 | Event fan-out to JS listeners | `NitroBackgroundEventHub.kt` |
 | Native persistence | `NitroBackgroundStore.kt`, `AndroidBackgroundSerialization.kt` |
 | Background permission contract | `AndroidBackgroundPermissions.kt` |
@@ -67,7 +67,8 @@ Avoid these until needed:
 | Android Headless JS | `NitroBackgroundHeadlessTaskService.kt` |
 | Start on boot | `NitroBootReceiver.kt` |
 | Activity recognition | `NitroActivityRecognitionReceiver.kt` |
-| HTTP sync | `AndroidBackgroundHttpSync.kt` |
+| HTTP sync scheduling, serial admission, and batch ownership | `NitroBackgroundSyncCoordinator.kt`, `NitroBackgroundSyncQueue.kt`, `NitroBackgroundSyncGate.kt` |
+| HTTP transport and retry | `AndroidBackgroundHttpSync.kt` |
 
 ### iOS Foreground
 
@@ -86,8 +87,11 @@ Avoid these until needed:
 | --- | --- |
 | Nitro background module, storage, status, geofences, and Core Location start/stop | `ios/NitroBackgroundLocation.swift` |
 | Background Core Location delegate | `ios/IOSBackgroundLocationDelegate.swift` |
+| Background permission reporting | `ios/IOSBackgroundPermission.swift` |
+| Background manager lifecycle, listener registration, and errors | `ios/IOSBackgroundRuntime.swift` |
 | Activity recognition conversion | `ios/IOSBackgroundMotion.swift` |
-| Native HTTP sync | `ios/IOSBackgroundHttpSync.swift` |
+| HTTP sync scheduling, batch ownership, and store marking | `ios/IOSBackgroundSync.swift`, `ios/IOSBackgroundSyncScheduler.swift` |
+| HTTP transport and retry | `ios/IOSBackgroundHttpSync.swift` |
 | Persistence serialization | `ios/IOSBackgroundSerialization.swift` |
 
 ## E2E Scenario File Map
@@ -121,7 +125,9 @@ permission helpers, and location assertions live in
 | Background API smoke | `background-e2e.yaml` | `BackgroundE2EScreen.tsx` |
 | Android long-run background | `background-long-run-android.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
 | Android long-run reboot arming | `background-long-run-android-arm-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| Android long-run reboot route drive | `background-long-run-android-reboot-drive.yaml` | Native store proof only; the app remains backgrounded |
 | Android long-run reboot proof | `background-long-run-android-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
+| Long-run cleanup | `background-long-run-cleanup.yaml` | `LongRunBackgroundE2EScreen.tsx` |
 | iOS long-run background | `background-long-run-ios.yaml` | `LongRunBackgroundE2EScreen.tsx` |
 | Mocked metadata Android true | `mocked-metadata-android-true.yaml` | `MockedMetadataScreen.tsx` |
 | Mocked metadata Android false | `mocked-metadata-android-false.yaml` | `MockedMetadataScreen.tsx` |

--- a/examples/v0.81.1/.maestro/background-e2e.yaml
+++ b/examples/v0.81.1/.maestro/background-e2e.yaml
@@ -55,13 +55,31 @@ appId: nitrogeolocation.example
 
 - tapOn:
     id: "e2e-action-background-e2e-invalid-config-button"
+- extendedWaitUntil:
+    visible: "Missing notification: passed"
+    timeout: 10000
 - tapOn:
     id: "e2e-action-background-e2e-configure-button"
+- extendedWaitUntil:
+    visible: "Configure: passed"
+    timeout: 10000
 - tapOn:
     id: "e2e-action-background-e2e-start-stop-button"
+- extendedWaitUntil:
+    visible: "Start stop: passed"
+    timeout: 20000
 - tapOn:
     id: "e2e-action-background-e2e-geofence-button"
+- extendedWaitUntil:
+    visible: "Geofence: passed"
+    timeout: 15000
 - tapOn:
     id: "e2e-action-background-e2e-storage-button"
+- extendedWaitUntil:
+    visible: "Storage: passed"
+    timeout: 10000
 - tapOn:
     id: "e2e-action-background-e2e-sync-button"
+- extendedWaitUntil:
+    visible: "Sync: passed"
+    timeout: 30000

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot-drive.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot-drive.yaml
@@ -1,0 +1,16 @@
+appId: nitrogeolocation.example
+---
+# Drive one complete post-reboot route through the same device-level location
+# injection path as the rest of the Maestro suite.
+- setLocation:
+    latitude: 37.563
+    longitude: 126.97
+- runScript: scripts/wait-15s.js
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+- runScript: scripts/wait-15s.js
+- setLocation:
+    latitude: 37.563
+    longitude: 126.97
+- runScript: scripts/wait-15s.js

--- a/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android-reboot.yaml
@@ -1,7 +1,7 @@
 appId: nitrogeolocation.example
 ---
 # Run after background-long-run-android.yaml and an external adb reboot.
-# The shell script injects one post-boot emulator location before this flow.
+# The shell wrapper first runs the post-boot recovery and ordered-location drive.
 
 - openLink:
     link: nitrogeolocation://app/background-long-run

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -59,6 +59,12 @@ appId: nitrogeolocation.example
 - setLocation:
     latitude: 37.563
     longitude: 126.97
+- runScript: scripts/wait-15s.js
+- tapOn:
+    id: "e2e-action-background-long-run-arm-background-button"
+- extendedWaitUntil:
+    visible: "Background probe: passed"
+    timeout: 15000
 - pressKey: Home
 - setLocation:
     latitude: 37.5665

--- a/examples/v0.81.1/.maestro/background-long-run-android.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-android.yaml
@@ -104,6 +104,8 @@ appId: nitrogeolocation.example
 - extendedWaitUntil:
     visible: "Background location: passed"
     timeout: 15000
+- assertVisible: ".*Last location at: [0-9]+.*"
+- assertVisible: ".*Last event at: [0-9]+.*"
 
 - tapOn:
     id: "e2e-action-background-long-run-validate-headless-button"

--- a/examples/v0.81.1/.maestro/background-long-run-cleanup.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-cleanup.yaml
@@ -1,0 +1,33 @@
+appId: nitrogeolocation.example
+---
+- openLink:
+    link: nitrogeolocation://app/background-long-run
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/background-long-run
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "Background Long Run E2E"
+    timeout: 10000
+- tapOn:
+    id: "e2e-action-background-long-run-cleanup-button"
+- extendedWaitUntil:
+    visible: "Cleanup: passed"
+    timeout: 30000

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -103,6 +103,8 @@ appId: nitrogeolocation.example
 - extendedWaitUntil:
     visible: "iOS drain: passed"
     timeout: 15000
+- assertVisible: ".*Last location at: [0-9]+.*"
+- assertVisible: ".*Last event at: [0-9]+.*"
 
 - tapOn:
     id: "e2e-action-background-long-run-platform-limits-button"

--- a/examples/v0.81.1/.maestro/background-long-run-ios.yaml
+++ b/examples/v0.81.1/.maestro/background-long-run-ios.yaml
@@ -1,7 +1,7 @@
 appId: nitrogeolocation.example
 ---
 # iOS long-run flow. iOS has no Headless JS or boot receiver contract, so this
-# verifies background/significant-change storage drain and platform limits.
+# verifies significant-change/region storage drain and platform limits.
 
 - launchApp:
     clearState: true
@@ -58,6 +58,12 @@ appId: nitrogeolocation.example
 - setLocation:
     latitude: 37.563
     longitude: 126.97
+- runScript: scripts/wait-15s.js
+- tapOn:
+    id: "e2e-action-background-long-run-arm-background-button"
+- extendedWaitUntil:
+    visible: "Background probe: passed"
+    timeout: 15000
 - pressKey: Home
 - setLocation:
     latitude: 37.5665

--- a/examples/v0.81.1/scripts/test-background-long-run-android.sh
+++ b/examples/v0.81.1/scripts/test-background-long-run-android.sh
@@ -8,6 +8,8 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 RUN_REBOOT="${RUN_REBOOT:-0}"
+cleanup_flow_armed=0
+cleanup_flow_ran=0
 
 MAESTRO_ARGS=(--platform android)
 
@@ -50,24 +52,59 @@ restore_location() {
   set_android_location_enabled true || true
 }
 
-trap restore_location EXIT
+stop_emulator_settings() {
+  # The API 34 test image can leave Settings in an ANR state after the permission
+  # handoff. Its system dialog obscures assertions even though the app proof passed.
+  if [[ "$(adb_device shell getprop ro.kernel.qemu | tr -d '\r')" != "1" ]]; then
+    return
+  fi
+  adb_device shell am force-stop com.android.settings >/dev/null 2>&1 || true
+}
+
+finish() {
+  local status=$?
+  trap - EXIT
+  restore_location
+  if [[ "$cleanup_flow_armed" == "1" && "$cleanup_flow_ran" == "0" ]]; then
+    "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-cleanup.yaml" || true
+  fi
+  exit "$status"
+}
+
+trap finish EXIT
 
 set_android_location_enabled true
+cleanup_flow_armed=1
 "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-android.yaml"
+stop_emulator_settings
 
 if [[ "$RUN_REBOOT" == "1" ]]; then
   require_android_emulator
   "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-android-arm-reboot.yaml"
   adb_device reboot
   adb_device wait-for-device
-  sleep 30
+  boot_completed=""
+  for _ in {1..600}; do
+    boot_completed="$(adb_device shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" ||
+      boot_completed=""
+    if [[ "$boot_completed" == "1" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$boot_completed" != "1" ]]; then
+    echo "Android did not report sys.boot_completed=1 within 10 minutes." >&2
+    exit 1
+  fi
   set_android_location_enabled true
+  stop_emulator_settings
   adb_device shell input keyevent 82 >/dev/null 2>&1 || true
-  set_emulator_location 37.563 126.970
-  sleep 10
-  set_emulator_location 37.5665 126.978
-  sleep 20
-  set_emulator_location 37.563 126.970
-  sleep 20
+  # The persisted proof marker is 15 seconds ahead of the arm action so that
+  # pre-reboot callbacks cannot satisfy the reboot gate.
+  sleep 15
+  "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-android-reboot-drive.yaml"
   "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-android-reboot.yaml"
 fi
+
+cleanup_flow_ran=1
+"$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-cleanup.yaml"

--- a/examples/v0.81.1/scripts/test-background-long-run-ios.sh
+++ b/examples/v0.81.1/scripts/test-background-long-run-ios.sh
@@ -7,9 +7,23 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 
 MAESTRO_BIN="${MAESTRO:-maestro}"
 MAESTRO_ARGS=(--platform ios)
+cleanup_flow_ran=0
 
 if [[ -n "${IOS_UDID:-}" ]]; then
   MAESTRO_ARGS+=(--device "$IOS_UDID")
 fi
 
+finish() {
+  local status=$?
+  trap - EXIT
+  if [[ "$cleanup_flow_ran" == "0" ]]; then
+    "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-cleanup.yaml" || true
+  fi
+  exit "$status"
+}
+
+trap finish EXIT
+
 "$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-ios.yaml"
+cleanup_flow_ran=1
+"$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/background-long-run-cleanup.yaml"

--- a/examples/v0.81.1/scripts/test-e2e-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-ios.sh
@@ -25,9 +25,15 @@ while IFS= read -r flow; do
   IOS_FLOWS+=("$flow")
 done <<<"$ios_flow_output"
 
+DEVICE_ARGS=()
+if [[ -n "${IOS_UDID:-}" ]]; then
+  DEVICE_ARGS+=(--maestro-arg --device --maestro-arg "$IOS_UDID")
+fi
+
 "$SCRIPT_DIR/maestro-retry-flows.sh" \
   --platform ios \
   --flow-dir "$FLOW_DIR" \
   --maestro "$MAESTRO_BIN" \
   --suite-name "ios" \
+  "${DEVICE_ARGS[@]}" \
   -- "${IOS_FLOWS[@]}"

--- a/examples/v0.81.1/scripts/test-e2e-web-ios.sh
+++ b/examples/v0.81.1/scripts/test-e2e-web-ios.sh
@@ -9,6 +9,11 @@ FLOW_DIR="$EXAMPLE_DIR/.maestro"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 WEB_E2E_PORT="${WEB_E2E_PORT:-4173}"
 WEB_SERVER_PID=""
+MAESTRO_ARGS=(--platform ios)
+
+if [[ -n "${IOS_UDID:-}" ]]; then
+  MAESTRO_ARGS+=(--device "$IOS_UDID")
+fi
 
 cleanup() {
   if [[ -n "$WEB_SERVER_PID" ]]; then
@@ -47,4 +52,4 @@ if ! curl -fsS "http://127.0.0.1:$WEB_E2E_PORT" | grep -q "Nitro Geolocation Web
   exit 1
 fi
 
-"$MAESTRO_BIN" test --platform ios "$FLOW_DIR/web-e2e.yaml"
+"$MAESTRO_BIN" test "${MAESTRO_ARGS[@]}" "$FLOW_DIR/web-e2e.yaml"

--- a/examples/v0.81.1/src/screens/BackgroundE2EScreen.tsx
+++ b/examples/v0.81.1/src/screens/BackgroundE2EScreen.tsx
@@ -4,6 +4,7 @@ import {
   addGeofences,
   checkBackgroundPermission,
   configureBackgroundLocation,
+  getBackgroundConfiguration,
   getBackgroundLocationStatus,
   getRegisteredGeofences,
   getStoredBackgroundEvents,
@@ -37,7 +38,10 @@ const initialResults = createScenarioResults([
 ] as const);
 
 const validOptions = {
-  trackingMode: "activityAware" as const,
+  trackingMode:
+    Platform.OS === "android"
+      ? ("activityAware" as const)
+      : ("continuous" as const),
   interval: 10_000,
   fastestInterval: 5_000,
   distanceFilter: 25,
@@ -59,7 +63,7 @@ const validOptions = {
     showsBackgroundLocationIndicator: true
   },
   activityRecognition: {
-    enabled: true,
+    enabled: Platform.OS === "android",
     interval: 10_000,
     stopOnStill: true,
     minimumConfidence: 70
@@ -70,6 +74,22 @@ const shortError = (error: any) =>
   String(error?.message ?? error)
     .split("\n")[0]
     .slice(0, 140);
+
+const wait = (durationMs: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+
+const waitForStoppedStatus = async () => {
+  const deadline = Date.now() + 5_000;
+  let status = await getBackgroundLocationStatus();
+  while (
+    (status.isRunning || status.android?.isForegroundServiceRunning === true) &&
+    Date.now() < deadline
+  ) {
+    await wait(250);
+    status = await getBackgroundLocationStatus();
+  }
+  return status;
+};
 
 export default function BackgroundE2EScreen() {
   const { results, setResult, resetResults } =
@@ -178,11 +198,55 @@ export default function BackgroundE2EScreen() {
     try {
       await configureBackgroundLocation(validOptions);
       await startBackgroundLocation(validOptions);
+      const first = await getBackgroundLocationStatus();
+      if (!first.isRunning || first.state !== "running") {
+        throw new Error(`Initial tracking did not start: state=${first.state}`);
+      }
+      const replacementOptions = {
+        ...validOptions,
+        trackingMode: "continuous",
+        activityRecognition: {
+          ...validOptions.activityRecognition,
+          enabled: false
+        },
+        ios: {
+          ...validOptions.ios,
+          useSignificantChanges: false
+        }
+      } as const;
+      await startBackgroundLocation(replacementOptions);
+      const [replacement, replacementConfig] = await Promise.all([
+        getBackgroundLocationStatus(),
+        getBackgroundConfiguration()
+      ]);
+      if (
+        !replacement.isRunning ||
+        replacement.state !== "running" ||
+        replacementConfig?.trackingMode !== "continuous" ||
+        (Platform.OS === "android" &&
+          replacement.android?.isForegroundServiceRunning !== true)
+      ) {
+        throw new Error(
+          `Replacement not active: state=${replacement.state}, running=${String(replacement.isRunning)}, mode=${String(replacementConfig?.trackingMode)}, foregroundService=${String(replacement.android?.isForegroundServiceRunning)}`
+        );
+      }
       await stopBackgroundLocation();
+      const stopped = await waitForStoppedStatus();
+      if (
+        stopped.isRunning ||
+        stopped.android?.isForegroundServiceRunning === true
+      ) {
+        throw new Error(
+          `Tracking still active: running=${String(stopped.isRunning)}, foregroundService=${String(stopped.android?.isForegroundServiceRunning)}`
+        );
+      }
       await refreshStatus();
       setResult(
         "startStop",
-        createScenarioResult("passed", "Start/stop contract completed")
+        createScenarioResult(
+          "passed",
+          "Replacement start stopped the previous provider and shut down cleanly"
+        )
       );
     } catch (error: any) {
       setResult("startStop", createScenarioResult("failed", shortError(error)));
@@ -209,6 +273,14 @@ export default function BackgroundE2EScreen() {
         }
       ]);
       const registered = await getRegisteredGeofences();
+      const office = registered.find(
+        (region) => region.identifier === "office"
+      );
+      if (!office || office.metadata?.kind !== "workplace") {
+        throw new Error(
+          `Expected office geofence, received: ${registered.map((region) => region.identifier).join(", ") || "none"}`
+        );
+      }
       await refreshStatus();
       setResult(
         "geofence",

--- a/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
+++ b/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
@@ -100,6 +100,16 @@ export function LongRunBackgroundE2EScreen() {
               testID: `${PREFIX}-proof-locations`
             },
             {
+              label: "Proof location events (inside/outside):",
+              value: `${snapshot.proofInsideLocationEvents}/${snapshot.proofOutsideLocationEvents}`,
+              testID: `${PREFIX}-proof-location-events`
+            },
+            {
+              label: "Ordered inside/outside proof:",
+              value: String(snapshot.orderedBackgroundLocationProof),
+              testID: `${PREFIX}-ordered-location-proof`
+            },
+            {
               label: "Delivered events:",
               value: snapshot.deliveredEvents,
               testID: `${PREFIX}-delivered-events`
@@ -125,6 +135,11 @@ export function LongRunBackgroundE2EScreen() {
               testID: `${PREFIX}-geofence-exit-events`
             },
             {
+              label: "Ordered geofence proof:",
+              value: String(snapshot.orderedGeofenceTransitionProof),
+              testID: `${PREFIX}-ordered-geofence-proof`
+            },
+            {
               label: "Post-reboot locations:",
               value: snapshot.postRebootLocations,
               testID: `${PREFIX}-post-reboot-locations`
@@ -138,6 +153,11 @@ export function LongRunBackgroundE2EScreen() {
               label: "Post-reboot geofence:",
               value: `${snapshot.postRebootGeofenceEnterEvents}/${snapshot.postRebootGeofenceExitEvents}`,
               testID: `${PREFIX}-post-reboot-geofence-events`
+            },
+            {
+              label: "Ordered post-reboot geofence:",
+              value: String(snapshot.orderedPostRebootGeofenceTransitionProof),
+              testID: `${PREFIX}-ordered-post-reboot-geofence-proof`
             },
             {
               label: "Geofences:",

--- a/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
+++ b/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
@@ -74,6 +74,16 @@ export function LongRunBackgroundE2EScreen() {
               testID: `${PREFIX}-stored-events`
             },
             {
+              label: "Last location at:",
+              value: snapshot.lastLocationAt,
+              testID: `${PREFIX}-last-location-at`
+            },
+            {
+              label: "Last event at:",
+              value: snapshot.lastEventAt,
+              testID: `${PREFIX}-last-event-at`
+            },
+            {
               label: "Post-prepare locations:",
               value: snapshot.postPrepareLocations,
               testID: `${PREFIX}-post-prepare-locations`

--- a/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
+++ b/examples/v0.81.1/src/screens/LongRunBackgroundE2EScreen.tsx
@@ -19,6 +19,7 @@ export function LongRunBackgroundE2EScreen() {
     snapshot,
     refreshSnapshot,
     runPrepare,
+    armBackgroundProbe,
     armRebootProbe,
     validateBackgroundLocation,
     validateHeadless,
@@ -94,6 +95,11 @@ export function LongRunBackgroundE2EScreen() {
               testID: `${PREFIX}-post-prepare-location-events`
             },
             {
+              label: "Proof locations (inside/outside):",
+              value: `${snapshot.proofInsideLocations}/${snapshot.proofOutsideLocations}`,
+              testID: `${PREFIX}-proof-locations`
+            },
+            {
               label: "Delivered events:",
               value: snapshot.deliveredEvents,
               testID: `${PREFIX}-delivered-events`
@@ -144,6 +150,11 @@ export function LongRunBackgroundE2EScreen() {
               testID: `${PREFIX}-prepared-at`
             },
             {
+              label: "Background proof after:",
+              value: snapshot.backgroundProofAfter,
+              testID: `${PREFIX}-background-proof-after`
+            },
+            {
               label: "Reboot proof after:",
               value: snapshot.rebootProofAfter,
               testID: `${PREFIX}-reboot-proof-after`
@@ -184,6 +195,11 @@ export function LongRunBackgroundE2EScreen() {
           testID={`${PREFIX}-prepare-button`}
         />
         <ScenarioButton
+          title="Arm Background Proof"
+          onPress={armBackgroundProbe}
+          testID={`${PREFIX}-arm-background-button`}
+        />
+        <ScenarioButton
           title="Arm Reboot Probe"
           onPress={armRebootProbe}
           testID={`${PREFIX}-arm-reboot-button`}
@@ -193,6 +209,11 @@ export function LongRunBackgroundE2EScreen() {
           results={results}
           items={[
             { id: "prepare", label: "Prepare" },
+            {
+              id: "background-probe",
+              resultKey: "backgroundProbe",
+              label: "Background probe"
+            },
             {
               id: "reboot-probe",
               resultKey: "rebootProbe",

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Platform } from "react-native";
 import {
-  type BackgroundEvent,
   type BackgroundLocationOptions,
   type GeofenceRegion,
   type StoredBackgroundEvent,
@@ -21,17 +20,30 @@ import {
 } from "react-native-nitro-geolocation/background";
 import { useScenarioResults } from "../hooks/useScenarioResults";
 import { createScenarioResult, createScenarioResults } from "../utils/results";
-
-const GEOFENCE_ID = "long-run-office";
-const GEOFENCE_CENTER = {
-  latitude: 37.5665,
-  longitude: 126.978
-};
-const GEOFENCE_OUTSIDE = {
-  latitude: 37.563,
-  longitude: 126.97
-};
+import {
+  GEOFENCE_CENTER,
+  GEOFENCE_ID,
+  GEOFENCE_OUTSIDE,
+  eventType,
+  hasOrderedBackgroundLocationProof,
+  hasOrderedGeofenceTransitionProof,
+  hasOrderedRebootLocationProof,
+  isCoordinate,
+  isDeliveredLocationEvent,
+  isGeofenceTransition,
+  isLocationEventMeasuredAtOrAfter,
+  isTimestampAtOrAfter
+} from "./longRunBackgroundProof";
+import {
+  type LongRunSnapshot,
+  emptyLongRunSnapshot
+} from "./longRunBackgroundSnapshot";
 const REBOOT_PROOF_DELAY_MS = 15_000;
+const CLEANUP_STATUS_TIMEOUT_MS = 5_000;
+const CLEANUP_STATUS_POLL_MS = 250;
+
+const wait = (durationMs: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, durationMs));
 
 export const longRunBackgroundResults = createScenarioResults([
   "prepare",
@@ -79,94 +91,10 @@ const longRunOptions: BackgroundLocationOptions = {
   }
 };
 
-export type LongRunSnapshot = {
-  status: string;
-  running: string;
-  configured: string;
-  foregroundService: string;
-  storedLocations: number;
-  storedEvents: number;
-  lastLocationAt: string;
-  lastEventAt: string;
-  proofInsideLocations: number;
-  proofOutsideLocations: number;
-  postPrepareLocations: number;
-  postPrepareLocationEvents: number;
-  deliveredEvents: number;
-  locationEvents: number;
-  deliveredLocationEvents: number;
-  deliveredProofInsideLocationEvents: number;
-  geofenceEnterEvents: number;
-  geofenceExitEvents: number;
-  postRebootLocations: number;
-  postRebootLocationEvents: number;
-  postRebootGeofenceEnterEvents: number;
-  postRebootGeofenceExitEvents: number;
-  geofences: number;
-  preparedAt: string;
-  backgroundProofAfter: string;
-  rebootProofAfter: string;
-  lastEvent: string;
-};
-
-const emptySnapshot: LongRunSnapshot = {
-  status: "not checked",
-  running: "unknown",
-  configured: "unknown",
-  foregroundService: "unknown",
-  storedLocations: 0,
-  storedEvents: 0,
-  lastLocationAt: "none",
-  lastEventAt: "none",
-  proofInsideLocations: 0,
-  proofOutsideLocations: 0,
-  postPrepareLocations: 0,
-  postPrepareLocationEvents: 0,
-  deliveredEvents: 0,
-  locationEvents: 0,
-  deliveredLocationEvents: 0,
-  deliveredProofInsideLocationEvents: 0,
-  geofenceEnterEvents: 0,
-  geofenceExitEvents: 0,
-  postRebootLocations: 0,
-  postRebootLocationEvents: 0,
-  postRebootGeofenceEnterEvents: 0,
-  postRebootGeofenceExitEvents: 0,
-  geofences: 0,
-  preparedAt: "none",
-  backgroundProofAfter: "none",
-  rebootProofAfter: "none",
-  lastEvent: "none"
-};
-
 const shortError = (error: unknown) =>
   String(error instanceof Error ? error.message : error)
     .split("\n")[0]
     .slice(0, 160);
-
-const eventType = (event: StoredBackgroundEvent) => event.event.type;
-
-const isDeliveredLocationEvent = (event: StoredBackgroundEvent) =>
-  event.deliveredToJS && eventType(event) === "location";
-
-const isCoordinate = (
-  latitude: number,
-  longitude: number,
-  expected: { latitude: number; longitude: number }
-) =>
-  Math.abs(latitude - expected.latitude) < 0.000_1 &&
-  Math.abs(longitude - expected.longitude) < 0.000_1;
-
-const isGeofenceTransition = (
-  event: StoredBackgroundEvent,
-  transition: "enter" | "exit"
-) => {
-  const backgroundEvent: BackgroundEvent = event.event;
-  return (
-    backgroundEvent.type === "geofence" &&
-    backgroundEvent.geofence.transition === transition
-  );
-};
 
 const summarizeEvent = (event?: StoredBackgroundEvent) => {
   if (!event) return "none";
@@ -183,16 +111,6 @@ const metadataNumber = (value: unknown) => {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
-};
-
-const isTimestampAtOrAfter = (value: string, marker: string) => {
-  const timestamp = metadataNumber(value);
-  const markerTimestamp = metadataNumber(marker);
-  return (
-    timestamp !== undefined &&
-    markerTimestamp !== undefined &&
-    timestamp >= markerTimestamp
-  );
 };
 
 const longRunMarker = (geofences: GeofenceRegion[]) => {
@@ -226,7 +144,8 @@ export const useLongRunBackgroundScenario = () => {
   const { results, setResult, resetResults } = useScenarioResults(
     longRunBackgroundResults
   );
-  const [snapshot, setSnapshot] = useState<LongRunSnapshot>(emptySnapshot);
+  const [snapshot, setSnapshot] =
+    useState<LongRunSnapshot>(emptyLongRunSnapshot);
 
   const refreshSnapshot = async () => {
     const [status, geofences] = await Promise.all([
@@ -281,11 +200,30 @@ export const useLongRunBackgroundScenario = () => {
     const deliveredProofInsideLocationEvents = events.filter(
       (event) =>
         isDeliveredLocationEvent(event) &&
+        isLocationEventMeasuredAtOrAfter(event, marker.backgroundProofAfter) &&
         event.event.type === "location" &&
         isCoordinate(
           event.event.location.coords.latitude,
           event.event.location.coords.longitude,
           GEOFENCE_CENTER
+        )
+    );
+    const proofInsideLocationEvents = postPrepareLocationEvents.filter(
+      (event) =>
+        event.event.type === "location" &&
+        isCoordinate(
+          event.event.location.coords.latitude,
+          event.event.location.coords.longitude,
+          GEOFENCE_CENTER
+        )
+    );
+    const proofOutsideLocationEvents = postPrepareLocationEvents.filter(
+      (event) =>
+        event.event.type === "location" &&
+        isCoordinate(
+          event.event.location.coords.latitude,
+          event.event.location.coords.longitude,
+          GEOFENCE_OUTSIDE
         )
     );
     const postRebootLocationEvents = rebootEvents.filter(
@@ -315,6 +253,17 @@ export const useLongRunBackgroundScenario = () => {
         : "none",
       proofInsideLocations: proofInsideLocations.length,
       proofOutsideLocations: proofOutsideLocations.length,
+      proofInsideLocationEvents: proofInsideLocationEvents.length,
+      proofOutsideLocationEvents: proofOutsideLocationEvents.length,
+      orderedBackgroundLocationProof: hasOrderedBackgroundLocationProof(
+        locations,
+        events,
+        marker.backgroundProofAfter
+      ),
+      orderedGeofenceTransitionProof: hasOrderedGeofenceTransitionProof(
+        events,
+        marker.backgroundProofAfter
+      ),
       postPrepareLocations: locations.length,
       postPrepareLocationEvents: postPrepareLocationEvents.length,
       deliveredEvents: events.filter((event) => event.deliveredToJS).length,
@@ -330,8 +279,18 @@ export const useLongRunBackgroundScenario = () => {
       ).length,
       postRebootLocations: rebootLocations.length,
       postRebootLocationEvents: postRebootLocationEvents.length,
+      orderedPostRebootLocationProof: hasOrderedRebootLocationProof(
+        rebootLocations,
+        rebootEvents,
+        marker.rebootProofAfter
+      ),
       postRebootGeofenceEnterEvents: postRebootGeofenceEnterEvents.length,
       postRebootGeofenceExitEvents: postRebootGeofenceExitEvents.length,
+      orderedPostRebootGeofenceTransitionProof:
+        hasOrderedGeofenceTransitionProof(
+          rebootEvents,
+          marker.rebootProofAfter
+        ),
       geofences: geofences.length,
       preparedAt: marker.preparedAt
         ? String(Math.trunc(marker.preparedAt))
@@ -392,7 +351,6 @@ export const useLongRunBackgroundScenario = () => {
           })
         ],
         {
-          initialTrigger: ["enter", "exit"],
           notificationResponsiveness: 1_000
         }
       );
@@ -436,7 +394,6 @@ export const useLongRunBackgroundScenario = () => {
           })
         ],
         {
-          initialTrigger: ["enter", "exit"],
           notificationResponsiveness: 1_000
         }
       );
@@ -516,16 +473,14 @@ export const useLongRunBackgroundScenario = () => {
     try {
       const next = await refreshSnapshot();
       const passed =
-        next.proofInsideLocations > 0 &&
-        next.proofOutsideLocations > 0 &&
-        next.postPrepareLocationEvents > 0 &&
+        next.orderedBackgroundLocationProof &&
         isTimestampAtOrAfter(next.lastLocationAt, next.backgroundProofAfter) &&
         isTimestampAtOrAfter(next.lastEventAt, next.backgroundProofAfter);
       setResult(
         "backgroundLocation",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `inside=${next.proofInsideLocations}, outside=${next.proofOutsideLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
+          `ordered=${String(next.orderedBackgroundLocationProof)}, locations=${next.proofInsideLocations}/${next.proofOutsideLocations}, events=${next.proofInsideLocationEvents}/${next.proofOutsideLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {
@@ -574,12 +529,14 @@ export const useLongRunBackgroundScenario = () => {
     try {
       const next = await refreshSnapshot();
       const passed =
-        next.geofenceEnterEvents > 0 && next.geofenceExitEvents > 0;
+        next.geofenceEnterEvents > 0 &&
+        next.geofenceExitEvents > 0 &&
+        next.orderedGeofenceTransitionProof;
       setResult(
         "geofenceTransition",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `enter=${next.geofenceEnterEvents}, exit=${next.geofenceExitEvents}`
+          `ordered=${String(next.orderedGeofenceTransitionProof)}, enter=${next.geofenceEnterEvents}, exit=${next.geofenceExitEvents}`
         )
       );
     } catch (error) {
@@ -610,13 +567,15 @@ export const useLongRunBackgroundScenario = () => {
         next.geofences > 0 &&
         next.postRebootLocations > 0 &&
         next.postRebootLocationEvents > 0 &&
+        next.orderedPostRebootLocationProof &&
         next.postRebootGeofenceEnterEvents > 0 &&
-        next.postRebootGeofenceExitEvents > 0;
+        next.postRebootGeofenceExitEvents > 0 &&
+        next.orderedPostRebootGeofenceTransitionProof;
       setResult(
         "rebootRestore",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `running=${next.running}, locations=${next.postRebootLocations}, geofence=${next.postRebootGeofenceEnterEvents}/${next.postRebootGeofenceExitEvents}`
+          `running=${next.running}, orderedLocation=${String(next.orderedPostRebootLocationProof)}, locations=${next.postRebootLocations}, geofence=${next.postRebootGeofenceEnterEvents}/${next.postRebootGeofenceExitEvents}`
         )
       );
     } catch (error) {
@@ -645,12 +604,13 @@ export const useLongRunBackgroundScenario = () => {
         next.lastLocationAt !== "none" &&
         next.geofenceEnterEvents > 0 &&
         next.geofenceExitEvents > 0 &&
+        next.orderedGeofenceTransitionProof &&
         isTimestampAtOrAfter(next.lastEventAt, next.backgroundProofAfter);
       setResult(
         "iosDrain",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `geofence=${next.geofenceEnterEvents}/${next.geofenceExitEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
+          `ordered=${String(next.orderedGeofenceTransitionProof)}, geofence=${next.geofenceEnterEvents}/${next.geofenceExitEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {
@@ -671,10 +631,27 @@ export const useLongRunBackgroundScenario = () => {
     try {
       await stopBackgroundLocation();
       await removeGeofences();
-      const next = await refreshSnapshot();
+      const deadline = Date.now() + CLEANUP_STATUS_TIMEOUT_MS;
+      let next = await refreshSnapshot();
+      while (
+        (next.running !== "false" ||
+          next.foregroundService === "true" ||
+          next.geofences !== 0) &&
+        Date.now() < deadline
+      ) {
+        await wait(CLEANUP_STATUS_POLL_MS);
+        next = await refreshSnapshot();
+      }
+      const passed =
+        next.running === "false" &&
+        next.geofences === 0 &&
+        next.foregroundService !== "true";
       setResult(
         "cleanup",
-        createScenarioResult("passed", `running=${next.running}`)
+        createScenarioResult(
+          passed ? "passed" : "failed",
+          `running=${next.running}, foregroundService=${next.foregroundService}, geofences=${next.geofences}`
+        )
       );
     } catch (error) {
       setResult("cleanup", createScenarioResult("failed", shortError(error)));

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
@@ -27,10 +27,15 @@ const GEOFENCE_CENTER = {
   latitude: 37.5665,
   longitude: 126.978
 };
+const GEOFENCE_OUTSIDE = {
+  latitude: 37.563,
+  longitude: 126.97
+};
 const REBOOT_PROOF_DELAY_MS = 15_000;
 
 export const longRunBackgroundResults = createScenarioResults([
   "prepare",
+  "backgroundProbe",
   "rebootProbe",
   "backgroundLocation",
   "headless",
@@ -40,7 +45,6 @@ export const longRunBackgroundResults = createScenarioResults([
   "platformLimits",
   "cleanup"
 ] as const);
-
 const longRunOptions: BackgroundLocationOptions = {
   trackingMode: Platform.OS === "ios" ? "significantChanges" : "continuous",
   interval: 5_000,
@@ -84,11 +88,14 @@ export type LongRunSnapshot = {
   storedEvents: number;
   lastLocationAt: string;
   lastEventAt: string;
+  proofInsideLocations: number;
+  proofOutsideLocations: number;
   postPrepareLocations: number;
   postPrepareLocationEvents: number;
   deliveredEvents: number;
   locationEvents: number;
   deliveredLocationEvents: number;
+  deliveredProofInsideLocationEvents: number;
   geofenceEnterEvents: number;
   geofenceExitEvents: number;
   postRebootLocations: number;
@@ -97,6 +104,7 @@ export type LongRunSnapshot = {
   postRebootGeofenceExitEvents: number;
   geofences: number;
   preparedAt: string;
+  backgroundProofAfter: string;
   rebootProofAfter: string;
   lastEvent: string;
 };
@@ -110,11 +118,14 @@ const emptySnapshot: LongRunSnapshot = {
   storedEvents: 0,
   lastLocationAt: "none",
   lastEventAt: "none",
+  proofInsideLocations: 0,
+  proofOutsideLocations: 0,
   postPrepareLocations: 0,
   postPrepareLocationEvents: 0,
   deliveredEvents: 0,
   locationEvents: 0,
   deliveredLocationEvents: 0,
+  deliveredProofInsideLocationEvents: 0,
   geofenceEnterEvents: 0,
   geofenceExitEvents: 0,
   postRebootLocations: 0,
@@ -123,6 +134,7 @@ const emptySnapshot: LongRunSnapshot = {
   postRebootGeofenceExitEvents: 0,
   geofences: 0,
   preparedAt: "none",
+  backgroundProofAfter: "none",
   rebootProofAfter: "none",
   lastEvent: "none"
 };
@@ -136,6 +148,14 @@ const eventType = (event: StoredBackgroundEvent) => event.event.type;
 
 const isDeliveredLocationEvent = (event: StoredBackgroundEvent) =>
   event.deliveredToJS && eventType(event) === "location";
+
+const isCoordinate = (
+  latitude: number,
+  longitude: number,
+  expected: { latitude: number; longitude: number }
+) =>
+  Math.abs(latitude - expected.latitude) < 0.000_1 &&
+  Math.abs(longitude - expected.longitude) < 0.000_1;
 
 const isGeofenceTransition = (
   event: StoredBackgroundEvent,
@@ -182,6 +202,7 @@ const longRunMarker = (geofences: GeofenceRegion[]) => {
 
   return {
     preparedAt: metadataNumber(metadata?.preparedAt),
+    backgroundProofAfter: metadataNumber(metadata?.backgroundProofAfter),
     rebootProofAfter: metadataNumber(metadata?.rebootProofAfter)
   };
 };
@@ -213,7 +234,7 @@ export const useLongRunBackgroundScenario = () => {
       getRegisteredGeofences()
     ]);
     const marker = longRunMarker(geofences);
-    const preparedSince = marker.preparedAt ?? 0;
+    const preparedSince = marker.backgroundProofAfter ?? marker.preparedAt ?? 0;
     const rebootSince = marker.rebootProofAfter ?? Number.MAX_SAFE_INTEGER;
     const [locations, events, rebootLocations, rebootEvents] =
       await Promise.all([
@@ -243,6 +264,30 @@ export const useLongRunBackgroundScenario = () => {
     const postPrepareLocationEvents = events.filter(
       (event) => eventType(event) === "location"
     );
+    const proofInsideLocations = locations.filter((location) =>
+      isCoordinate(
+        location.coords.latitude,
+        location.coords.longitude,
+        GEOFENCE_CENTER
+      )
+    );
+    const proofOutsideLocations = locations.filter((location) =>
+      isCoordinate(
+        location.coords.latitude,
+        location.coords.longitude,
+        GEOFENCE_OUTSIDE
+      )
+    );
+    const deliveredProofInsideLocationEvents = events.filter(
+      (event) =>
+        isDeliveredLocationEvent(event) &&
+        event.event.type === "location" &&
+        isCoordinate(
+          event.event.location.coords.latitude,
+          event.event.location.coords.longitude,
+          GEOFENCE_CENTER
+        )
+    );
     const postRebootLocationEvents = rebootEvents.filter(
       (event) => eventType(event) === "location"
     );
@@ -268,11 +313,15 @@ export const useLongRunBackgroundScenario = () => {
       lastEventAt: status.lastEventAt
         ? String(Math.trunc(status.lastEventAt))
         : "none",
+      proofInsideLocations: proofInsideLocations.length,
+      proofOutsideLocations: proofOutsideLocations.length,
       postPrepareLocations: locations.length,
       postPrepareLocationEvents: postPrepareLocationEvents.length,
       deliveredEvents: events.filter((event) => event.deliveredToJS).length,
       locationEvents: postPrepareLocationEvents.length,
       deliveredLocationEvents: events.filter(isDeliveredLocationEvent).length,
+      deliveredProofInsideLocationEvents:
+        deliveredProofInsideLocationEvents.length,
       geofenceEnterEvents: events.filter((event) =>
         isGeofenceTransition(event, "enter")
       ).length,
@@ -286,6 +335,9 @@ export const useLongRunBackgroundScenario = () => {
       geofences: geofences.length,
       preparedAt: marker.preparedAt
         ? String(Math.trunc(marker.preparedAt))
+        : "none",
+      backgroundProofAfter: marker.backgroundProofAfter
+        ? String(Math.trunc(marker.backgroundProofAfter))
         : "none",
       rebootProofAfter: marker.rebootProofAfter
         ? String(Math.trunc(marker.rebootProofAfter))
@@ -359,6 +411,52 @@ export const useLongRunBackgroundScenario = () => {
     }
   };
 
+  const armBackgroundProbe = async () => {
+    setResult(
+      "backgroundProbe",
+      createScenarioResult(
+        "running",
+        "Recording a marker after foreground stabilization"
+      )
+    );
+    try {
+      const geofences = await getRegisteredGeofences();
+      const marker = longRunMarker(geofences);
+      if (marker.preparedAt === undefined) {
+        throw new Error("Prepare Long Run before arming background proof");
+      }
+
+      const backgroundProofAfter = Date.now();
+      await addGeofences(
+        [
+          longRunGeofence({
+            preparedAt: marker.preparedAt,
+            backgroundProofAfter,
+            runId: String(backgroundProofAfter)
+          })
+        ],
+        {
+          initialTrigger: ["enter", "exit"],
+          notificationResponsiveness: 1_000
+        }
+      );
+
+      const next = await refreshSnapshot();
+      setResult(
+        "backgroundProbe",
+        createScenarioResult(
+          next.backgroundProofAfter !== "none" ? "passed" : "failed",
+          `proofAfter=${next.backgroundProofAfter}`
+        )
+      );
+    } catch (error) {
+      setResult(
+        "backgroundProbe",
+        createScenarioResult("failed", shortError(error))
+      );
+    }
+  };
+
   const armRebootProbe = async () => {
     setResult(
       "rebootProbe",
@@ -381,6 +479,9 @@ export const useLongRunBackgroundScenario = () => {
         [
           longRunGeofence({
             preparedAt: marker.preparedAt ?? Date.now(),
+            ...(marker.backgroundProofAfter === undefined
+              ? {}
+              : { backgroundProofAfter: marker.backgroundProofAfter }),
             rebootProofAfter: Date.now() + REBOOT_PROOF_DELAY_MS,
             runId: String(Date.now())
           })
@@ -415,15 +516,16 @@ export const useLongRunBackgroundScenario = () => {
     try {
       const next = await refreshSnapshot();
       const passed =
-        next.postPrepareLocations > 0 &&
+        next.proofInsideLocations > 0 &&
+        next.proofOutsideLocations > 0 &&
         next.postPrepareLocationEvents > 0 &&
-        isTimestampAtOrAfter(next.lastLocationAt, next.preparedAt) &&
-        isTimestampAtOrAfter(next.lastEventAt, next.preparedAt);
+        isTimestampAtOrAfter(next.lastLocationAt, next.backgroundProofAfter) &&
+        isTimestampAtOrAfter(next.lastEventAt, next.backgroundProofAfter);
       setResult(
         "backgroundLocation",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
+          `inside=${next.proofInsideLocations}, outside=${next.proofOutsideLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {
@@ -451,12 +553,12 @@ export const useLongRunBackgroundScenario = () => {
         );
         return;
       }
-      const passed = next.deliveredLocationEvents > 0;
+      const passed = next.deliveredProofInsideLocationEvents > 0;
       setResult(
         "headless",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `deliveredLocationEvents=${next.deliveredLocationEvents}`
+          `deliveredInsideLocationEvents=${next.deliveredProofInsideLocationEvents}`
         )
       );
     } catch (error) {
@@ -540,15 +642,15 @@ export const useLongRunBackgroundScenario = () => {
         return;
       }
       const passed =
-        next.postPrepareLocations > 0 &&
-        next.postPrepareLocationEvents > 0 &&
-        isTimestampAtOrAfter(next.lastLocationAt, next.preparedAt) &&
-        isTimestampAtOrAfter(next.lastEventAt, next.preparedAt);
+        next.lastLocationAt !== "none" &&
+        next.geofenceEnterEvents > 0 &&
+        next.geofenceExitEvents > 0 &&
+        isTimestampAtOrAfter(next.lastEventAt, next.backgroundProofAfter);
       setResult(
         "iosDrain",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
+          `geofence=${next.geofenceEnterEvents}/${next.geofenceExitEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {
@@ -585,6 +687,7 @@ export const useLongRunBackgroundScenario = () => {
     snapshot,
     refreshSnapshot,
     runPrepare,
+    armBackgroundProbe,
     armRebootProbe,
     validateBackgroundLocation,
     validateHeadless,

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackground.ts
@@ -82,6 +82,8 @@ export type LongRunSnapshot = {
   foregroundService: string;
   storedLocations: number;
   storedEvents: number;
+  lastLocationAt: string;
+  lastEventAt: string;
   postPrepareLocations: number;
   postPrepareLocationEvents: number;
   deliveredEvents: number;
@@ -106,6 +108,8 @@ const emptySnapshot: LongRunSnapshot = {
   foregroundService: "unknown",
   storedLocations: 0,
   storedEvents: 0,
+  lastLocationAt: "none",
+  lastEventAt: "none",
   postPrepareLocations: 0,
   postPrepareLocationEvents: 0,
   deliveredEvents: 0,
@@ -159,6 +163,16 @@ const metadataNumber = (value: unknown) => {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
+};
+
+const isTimestampAtOrAfter = (value: string, marker: string) => {
+  const timestamp = metadataNumber(value);
+  const markerTimestamp = metadataNumber(marker);
+  return (
+    timestamp !== undefined &&
+    markerTimestamp !== undefined &&
+    timestamp >= markerTimestamp
+  );
 };
 
 const longRunMarker = (geofences: GeofenceRegion[]) => {
@@ -248,6 +262,12 @@ export const useLongRunBackgroundScenario = () => {
       ),
       storedLocations: status.storedLocationCount,
       storedEvents: status.storedEventCount,
+      lastLocationAt: status.lastLocationAt
+        ? String(Math.trunc(status.lastLocationAt))
+        : "none",
+      lastEventAt: status.lastEventAt
+        ? String(Math.trunc(status.lastEventAt))
+        : "none",
       postPrepareLocations: locations.length,
       postPrepareLocationEvents: postPrepareLocationEvents.length,
       deliveredEvents: events.filter((event) => event.deliveredToJS).length,
@@ -288,6 +308,18 @@ export const useLongRunBackgroundScenario = () => {
       await removeGeofences().catch(() => undefined);
       await clearStoredBackgroundEvents().catch(() => undefined);
       await clearStoredBackgroundLocations().catch(() => undefined);
+
+      const clearedStatus = await getBackgroundLocationStatus();
+      if (
+        clearedStatus.storedLocationCount !== 0 ||
+        clearedStatus.storedEventCount !== 0 ||
+        clearedStatus.lastLocationAt !== undefined ||
+        clearedStatus.lastEventAt !== undefined
+      ) {
+        throw new Error(
+          `Native store did not clear: locations=${clearedStatus.storedLocationCount}, events=${clearedStatus.storedEventCount}, lastLocationAt=${String(clearedStatus.lastLocationAt)}, lastEventAt=${String(clearedStatus.lastEventAt)}`
+        );
+      }
 
       const permission = await requestBackgroundPermission();
       if (
@@ -383,12 +415,15 @@ export const useLongRunBackgroundScenario = () => {
     try {
       const next = await refreshSnapshot();
       const passed =
-        next.postPrepareLocations > 0 && next.postPrepareLocationEvents > 0;
+        next.postPrepareLocations > 0 &&
+        next.postPrepareLocationEvents > 0 &&
+        isTimestampAtOrAfter(next.lastLocationAt, next.preparedAt) &&
+        isTimestampAtOrAfter(next.lastEventAt, next.preparedAt);
       setResult(
         "backgroundLocation",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}`
+          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {
@@ -505,12 +540,15 @@ export const useLongRunBackgroundScenario = () => {
         return;
       }
       const passed =
-        next.postPrepareLocations > 0 && next.postPrepareLocationEvents > 0;
+        next.postPrepareLocations > 0 &&
+        next.postPrepareLocationEvents > 0 &&
+        isTimestampAtOrAfter(next.lastLocationAt, next.preparedAt) &&
+        isTimestampAtOrAfter(next.lastEventAt, next.preparedAt);
       setResult(
         "iosDrain",
         createScenarioResult(
           passed ? "passed" : "failed",
-          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}`
+          `postPrepareLocations=${next.postPrepareLocations}, postPrepareEvents=${next.postPrepareLocationEvents}, lastLocationAt=${next.lastLocationAt}, lastEventAt=${next.lastEventAt}`
         )
       );
     } catch (error) {

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackgroundProof.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackgroundProof.ts
@@ -1,0 +1,178 @@
+import type {
+  BackgroundEvent,
+  StoredBackgroundEvent,
+  StoredBackgroundLocation
+} from "react-native-nitro-geolocation/background";
+
+export const GEOFENCE_ID = "long-run-office";
+export const GEOFENCE_CENTER = {
+  latitude: 37.5665,
+  longitude: 126.978
+};
+export const GEOFENCE_OUTSIDE = {
+  latitude: 37.563,
+  longitude: 126.97
+};
+
+export const eventType = (event: StoredBackgroundEvent) => event.event.type;
+
+export const isDeliveredLocationEvent = (event: StoredBackgroundEvent) =>
+  event.deliveredToJS && eventType(event) === "location";
+
+export const isLocationEventMeasuredAtOrAfter = (
+  event: StoredBackgroundEvent,
+  proofAfter: number | undefined
+) =>
+  proofAfter !== undefined &&
+  event.event.type === "location" &&
+  event.event.location.timestamp >= proofAfter;
+
+export const isCoordinate = (
+  latitude: number,
+  longitude: number,
+  expected: { latitude: number; longitude: number }
+) =>
+  Math.abs(latitude - expected.latitude) < 0.000_1 &&
+  Math.abs(longitude - expected.longitude) < 0.000_1;
+
+export const isGeofenceTransition = (
+  event: StoredBackgroundEvent,
+  transition: "enter" | "exit"
+) => {
+  const backgroundEvent: BackgroundEvent = event.event;
+  return (
+    backgroundEvent.type === "geofence" &&
+    backgroundEvent.geofence.transition === transition
+  );
+};
+
+type TimedCoordinate = {
+  timestamp: number;
+  latitude: number;
+  longitude: number;
+};
+
+const hasInsideThenOutside = (
+  samples: TimedCoordinate[],
+  proofAfter: number
+) => {
+  const insideAt = samples
+    .filter(
+      (sample) =>
+        sample.timestamp >= proofAfter &&
+        isCoordinate(sample.latitude, sample.longitude, GEOFENCE_CENTER)
+    )
+    .reduce(
+      (earliest, sample) => Math.min(earliest, sample.timestamp),
+      Number.POSITIVE_INFINITY
+    );
+  return samples.some(
+    (sample) =>
+      sample.timestamp > insideAt &&
+      isCoordinate(sample.latitude, sample.longitude, GEOFENCE_OUTSIDE)
+  );
+};
+
+const hasOutsideInsideOutside = (
+  samples: TimedCoordinate[],
+  proofAfter: number
+) => {
+  const firstOutsideAt = samples
+    .filter(
+      (sample) =>
+        sample.timestamp >= proofAfter &&
+        isCoordinate(sample.latitude, sample.longitude, GEOFENCE_OUTSIDE)
+    )
+    .reduce(
+      (earliest, sample) => Math.min(earliest, sample.timestamp),
+      Number.POSITIVE_INFINITY
+    );
+  const insideAt = samples
+    .filter(
+      (sample) =>
+        sample.timestamp > firstOutsideAt &&
+        isCoordinate(sample.latitude, sample.longitude, GEOFENCE_CENTER)
+    )
+    .reduce(
+      (earliest, sample) => Math.min(earliest, sample.timestamp),
+      Number.POSITIVE_INFINITY
+    );
+  return samples.some(
+    (sample) =>
+      sample.timestamp > insideAt &&
+      isCoordinate(sample.latitude, sample.longitude, GEOFENCE_OUTSIDE)
+  );
+};
+
+const locationCoordinates = (locations: StoredBackgroundLocation[]) =>
+  locations.map((location) => ({
+    timestamp: location.timestamp,
+    latitude: location.coords.latitude,
+    longitude: location.coords.longitude
+  }));
+
+const eventLocationCoordinates = (events: StoredBackgroundEvent[]) =>
+  events.flatMap((event) =>
+    event.event.type === "location"
+      ? [
+          {
+            timestamp: event.event.location.timestamp,
+            latitude: event.event.location.coords.latitude,
+            longitude: event.event.location.coords.longitude
+          }
+        ]
+      : []
+  );
+
+export const hasOrderedBackgroundLocationProof = (
+  locations: StoredBackgroundLocation[],
+  events: StoredBackgroundEvent[],
+  proofAfter: number | undefined
+) =>
+  proofAfter !== undefined &&
+  hasInsideThenOutside(locationCoordinates(locations), proofAfter) &&
+  hasInsideThenOutside(eventLocationCoordinates(events), proofAfter);
+
+export const hasOrderedRebootLocationProof = (
+  locations: StoredBackgroundLocation[],
+  events: StoredBackgroundEvent[],
+  proofAfter: number | undefined
+) =>
+  proofAfter !== undefined &&
+  hasOutsideInsideOutside(locationCoordinates(locations), proofAfter) &&
+  hasOutsideInsideOutside(eventLocationCoordinates(events), proofAfter);
+
+export const hasOrderedGeofenceTransitionProof = (
+  events: StoredBackgroundEvent[],
+  proofAfter: number | undefined
+) => {
+  if (proofAfter === undefined) return false;
+  const transitions = events.flatMap((event) =>
+    event.event.type === "geofence" &&
+    event.event.geofence.region.identifier === GEOFENCE_ID
+      ? [event.event.geofence]
+      : []
+  );
+  const enterAt = transitions
+    .filter(
+      (geofence) =>
+        geofence.transition === "enter" && geofence.timestamp >= proofAfter
+    )
+    .reduce(
+      (earliest, geofence) => Math.min(earliest, geofence.timestamp),
+      Number.POSITIVE_INFINITY
+    );
+  return transitions.some(
+    (geofence) => geofence.transition === "exit" && geofence.timestamp > enterAt
+  );
+};
+
+export const isTimestampAtOrAfter = (value: string, marker: string) => {
+  const timestamp = Number(value);
+  const markerTimestamp = Number(marker);
+  return (
+    Number.isFinite(timestamp) &&
+    Number.isFinite(markerTimestamp) &&
+    timestamp >= markerTimestamp
+  );
+};

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackgroundSnapshot.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackgroundSnapshot.ts
@@ -1,0 +1,71 @@
+export type LongRunSnapshot = {
+  status: string;
+  running: string;
+  configured: string;
+  foregroundService: string;
+  storedLocations: number;
+  storedEvents: number;
+  lastLocationAt: string;
+  lastEventAt: string;
+  proofInsideLocations: number;
+  proofOutsideLocations: number;
+  proofInsideLocationEvents: number;
+  proofOutsideLocationEvents: number;
+  orderedBackgroundLocationProof: boolean;
+  orderedGeofenceTransitionProof: boolean;
+  postPrepareLocations: number;
+  postPrepareLocationEvents: number;
+  deliveredEvents: number;
+  locationEvents: number;
+  deliveredLocationEvents: number;
+  deliveredProofInsideLocationEvents: number;
+  geofenceEnterEvents: number;
+  geofenceExitEvents: number;
+  postRebootLocations: number;
+  postRebootLocationEvents: number;
+  orderedPostRebootLocationProof: boolean;
+  postRebootGeofenceEnterEvents: number;
+  postRebootGeofenceExitEvents: number;
+  orderedPostRebootGeofenceTransitionProof: boolean;
+  geofences: number;
+  preparedAt: string;
+  backgroundProofAfter: string;
+  rebootProofAfter: string;
+  lastEvent: string;
+};
+
+export const emptyLongRunSnapshot: LongRunSnapshot = {
+  status: "not checked",
+  running: "unknown",
+  configured: "unknown",
+  foregroundService: "unknown",
+  storedLocations: 0,
+  storedEvents: 0,
+  lastLocationAt: "none",
+  lastEventAt: "none",
+  proofInsideLocations: 0,
+  proofOutsideLocations: 0,
+  proofInsideLocationEvents: 0,
+  proofOutsideLocationEvents: 0,
+  orderedBackgroundLocationProof: false,
+  orderedGeofenceTransitionProof: false,
+  postPrepareLocations: 0,
+  postPrepareLocationEvents: 0,
+  deliveredEvents: 0,
+  locationEvents: 0,
+  deliveredLocationEvents: 0,
+  deliveredProofInsideLocationEvents: 0,
+  geofenceEnterEvents: 0,
+  geofenceExitEvents: 0,
+  postRebootLocations: 0,
+  postRebootLocationEvents: 0,
+  orderedPostRebootLocationProof: false,
+  postRebootGeofenceEnterEvents: 0,
+  postRebootGeofenceExitEvents: 0,
+  orderedPostRebootGeofenceTransitionProof: false,
+  geofences: 0,
+  preparedAt: "none",
+  backgroundProofAfter: "none",
+  rebootProofAfter: "none",
+  lastEvent: "none"
+};

--- a/packages/react-native-nitro-geolocation/android/build.gradle
+++ b/packages/react-native-nitro-geolocation/android/build.gradle
@@ -299,5 +299,7 @@ dependencies {
   implementation "com.google.android.gms:play-services-location:${getExtOrDefaultValue('playServicesLocationVersion', '21.3.0')}"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation project(":react-native-nitro-modules")
+  testImplementation "androidx.test:core:1.6.1"
   testImplementation "junit:junit:4.13.2"
+  testImplementation "org.robolectric:robolectric:4.14.1"
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-nitro-geolocation/android/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
       android:name=".background.NitroBackgroundHeadlessTaskService"
       android:exported="false" />
 
+    <service
+      android:name=".background.NitroBootRestoreJobService"
+      android:exported="false"
+      android:permission="android.permission.BIND_JOB_SERVICE" />
+
     <receiver
       android:name=".background.NitroLocationUpdateReceiver"
       android:exported="false" />

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
@@ -2,6 +2,22 @@ package com.margelo.nitro.nitrogeolocation.background
 
 import android.app.PendingIntent
 import android.os.Build
+import com.google.android.gms.location.Priority
+import com.margelo.nitro.nitrogeolocation.AndroidAccuracyPreset
+import com.margelo.nitro.nitrogeolocation.BackgroundLocationOptions
+import com.margelo.nitro.nitrogeolocation.BackgroundTrackingMode
+import com.margelo.nitro.nitrogeolocation.DetectedActivity
+import com.margelo.nitro.nitrogeolocation.DetectedActivityType
+
+internal const val DEFAULT_MAX_STORED_LOCATIONS = 10_000
+internal const val DEFAULT_MAX_STORED_EVENTS = 10_000
+internal const val PREF_RUN_GENERATION = "runGeneration"
+
+// LocationError codes mirror the W3C GeolocationPositionError contract.
+internal const val ERROR_CODE_PERMISSION_DENIED = 1
+internal const val ERROR_CODE_POSITION_UNAVAILABLE = 2
+
+internal enum class ActivityTrackingAction { NONE, START, STOP }
 
 /**
  * Pure decision helpers for the background pipeline, extracted so they can be unit-tested with
@@ -51,6 +67,12 @@ internal fun resolveMaxStored(configured: Int?, default: Int): Int {
     }
 }
 
+internal fun maxStoredLocations(options: BackgroundLocationOptions?): Int =
+    resolveMaxStored(options?.maxStoredLocations?.toInt(), DEFAULT_MAX_STORED_LOCATIONS)
+
+internal fun maxStoredEvents(options: BackgroundLocationOptions?): Int =
+    resolveMaxStored(options?.maxStoredEvents?.toInt(), DEFAULT_MAX_STORED_EVENTS)
+
 /**
  * Headless JS is the fallback path when no in-process JS listener received the native event. If a
  * live listener already handled the event, starting Headless JS duplicates delivery and React
@@ -58,4 +80,75 @@ internal fun resolveMaxStored(configured: Int?, default: Int): Int {
  */
 internal fun shouldDispatchHeadlessTask(deliveredToInProcessListener: Boolean): Boolean {
     return !deliveredToInProcessListener
+}
+
+/** Rejects stale native callbacks after reset and never persists without configuration. */
+internal fun shouldPersistForGeneration(
+    isConfigured: Boolean,
+    persist: Boolean?,
+    currentGeneration: Long,
+    callbackGeneration: Long,
+    allowUnconfigured: Boolean = false
+): Boolean {
+    return (isConfigured || allowUnconfigured) &&
+        persist != false &&
+        currentGeneration == callbackGeneration
+}
+
+internal fun nextRegistrationGeneration(current: Long): Long = current + 1L
+
+internal fun isCurrentRegistration(
+    currentRunGeneration: Long,
+    currentRegistrationGeneration: Long,
+    callbackRunGeneration: Long,
+    callbackRegistrationGeneration: Long
+): Boolean = currentRunGeneration == callbackRunGeneration &&
+    currentRegistrationGeneration == callbackRegistrationGeneration
+
+internal fun shouldApplyStartupFailure(
+    activeServiceGeneration: Long?,
+    failedServiceGeneration: Long
+): Boolean = activeServiceGeneration == failedServiceGeneration
+
+internal fun requiresActivityRecognition(options: BackgroundLocationOptions): Boolean =
+    options.trackingMode == BackgroundTrackingMode.ACTIVITYAWARE ||
+        options.activityRecognition?.enabled == true
+
+internal fun validateAndroidBackgroundOptions(options: BackgroundLocationOptions) {
+    if (options.android?.foregroundService == null) {
+        throw IllegalArgumentException(
+            "Android background tracking requires android.foregroundService notification options"
+        )
+    }
+}
+
+internal fun resolvePriority(options: BackgroundLocationOptions): Int =
+    when (options.accuracy?.android) {
+        AndroidAccuracyPreset.HIGH -> Priority.PRIORITY_HIGH_ACCURACY
+        AndroidAccuracyPreset.LOW -> Priority.PRIORITY_LOW_POWER
+        AndroidAccuracyPreset.PASSIVE -> Priority.PRIORITY_PASSIVE
+        else -> Priority.PRIORITY_BALANCED_POWER_ACCURACY
+    }
+
+internal fun activityTrackingAction(
+    options: BackgroundLocationOptions,
+    activity: DetectedActivity,
+    isRunning: Boolean
+): ActivityTrackingAction {
+    val recognition = options.activityRecognition
+    if (options.trackingMode != BackgroundTrackingMode.ACTIVITYAWARE &&
+        recognition?.stopOnStill != true) return ActivityTrackingAction.NONE
+    if (activity.confidence < (recognition?.minimumConfidence ?: 0.0)) {
+        return ActivityTrackingAction.NONE
+    }
+    val stopOnStill = recognition?.stopOnStill ?: true
+    if (activity.type == DetectedActivityType.STILL && stopOnStill) {
+        return ActivityTrackingAction.STOP
+    }
+    return if (isRunning && activity.type != DetectedActivityType.STILL &&
+        activity.type != DetectedActivityType.UNKNOWN) {
+        ActivityTrackingAction.START
+    } else {
+        ActivityTrackingAction.NONE
+    }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroActivityRecognitionReceiver.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroActivityRecognitionReceiver.kt
@@ -6,8 +6,14 @@ import android.content.Intent
 
 class NitroActivityRecognitionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        NitroBackgroundLocationController
-            .getInstance(context)
-            .handleActivityRecognition(intent)
+        val controller = NitroBackgroundLocationController.getInstance(context)
+        controller.handleActivityRecognition(
+            intent,
+            intent.getLongExtra(EXTRA_RUN_GENERATION, MISSING_RUN_GENERATION),
+            intent.getLongExtra(
+                EXTRA_REGISTRATION_GENERATION,
+                MISSING_REGISTRATION_GENERATION
+            )
+        )
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundActivityCoordinator.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundActivityCoordinator.kt
@@ -1,0 +1,152 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+private const val ACTIVITY_COMMAND_TIMEOUT_SECONDS = 30L
+
+internal fun requireActivityRecognitionPermission(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACTIVITY_RECOGNITION
+        ) != PackageManager.PERMISSION_GRANTED) {
+        throw SecurityException("Activity recognition permission is required")
+    }
+}
+
+internal fun awaitActivityCommand(future: CompletableFuture<Void>) {
+    try {
+        future.get()
+    } catch (error: java.util.concurrent.ExecutionException) {
+        throw unwrapActivityCommandError(error)
+    }
+}
+
+internal fun unwrapActivityCommandError(error: Throwable): Exception {
+    val cause = error.cause ?: error
+    return cause as? Exception ?: IllegalStateException(cause.message, cause)
+}
+
+/** Serializes activity-provider replacements while desired owners change synchronously. */
+internal class NitroBackgroundActivityCoordinator(
+    private val pendingIntents: NitroBackgroundPendingIntents,
+    private val registrations: NitroBackgroundRegistrations,
+    private val currentRunGeneration: () -> Long,
+    private val requestUpdates: (Long, PendingIntent) -> Task<Void>,
+    private val removeUpdates: (PendingIntent) -> Task<Void>,
+    private val commandTimeoutNanos: Long =
+        TimeUnit.SECONDS.toNanos(ACTIVITY_COMMAND_TIMEOUT_SECONDS)
+) {
+    private val executor = Executors.newSingleThreadExecutor()
+
+    fun start(intervalMs: Long, owner: Long?): CompletableFuture<Void> {
+        val deadlineNanos = System.nanoTime() + commandTimeoutNanos
+        val runGeneration = currentRunGeneration()
+        val request = registrations.requestActivity(owner)
+        val callback = pendingIntents.activity(runGeneration, request.generation)
+        val completion = CompletableFuture<Void>()
+        executor.execute {
+            try {
+                await(requestUpdates(intervalMs, callback), deadlineNanos)
+            } catch (error: Throwable) {
+                removeProviderCallbackAsync(callback)
+                registrations.failActivity(request)?.let { active ->
+                    if (active.generation != request.generation) {
+                        removeProviderCallbackAsync(
+                            pendingIntents.activity(runGeneration, active.generation)
+                        )
+                    }
+                }
+                completion.completeExceptionally(error)
+                return@execute
+            }
+            val confirmation = registrations.confirmActivity(request)
+            if (!confirmation.accepted) {
+                removeProviderCallbackAsync(callback)
+                completion.completeExceptionally(
+                    CancellationException("Activity recognition request was superseded or stopped")
+                )
+                return@execute
+            }
+            // Provider ownership is now confirmed. Startup readiness must not wait for cleanup of
+            // a stale callback, which is best-effort and may consume the remaining command budget.
+            completion.complete(null)
+            confirmation.previous
+                ?.takeIf { it.generation != request.generation }
+                ?.let { previous ->
+                    runCatching {
+                        removeProviderCallback(
+                            pendingIntents.activity(runGeneration, previous.generation),
+                            deadlineNanos
+                        )
+                    }
+            }
+            runCatching { removeLegacy(deadlineNanos) }
+        }
+        return completion
+    }
+
+    /** Revokes the owner before returning, so its callback dispatch fence closes immediately. */
+    fun stop(owner: Long?): CompletableFuture<Void> {
+        val runGeneration = currentRunGeneration()
+        val registration = registrations.removeActivity(owner)
+        val deadlineNanos = System.nanoTime() + commandTimeoutNanos
+        val completion = CompletableFuture<Void>()
+        executor.execute {
+            try {
+                registration?.let { active ->
+                    removeProviderCallback(
+                        pendingIntents.activity(runGeneration, active.generation),
+                        deadlineNanos
+                    )
+                }
+                removeLegacy(deadlineNanos)
+                completion.complete(null)
+            } catch (error: Throwable) {
+                completion.completeExceptionally(error)
+            }
+        }
+        return completion
+    }
+
+    fun awaitIdle() {
+        executor.submit {}.get()
+    }
+
+    private fun removeLegacy(deadlineNanos: Long) {
+        pendingIntents.legacyActivity()?.let { callback ->
+            removeProviderCallback(callback, deadlineNanos)
+        }
+    }
+
+    private fun removeProviderCallback(callback: PendingIntent, deadlineNanos: Long) {
+        try {
+            await(removeUpdates(callback), deadlineNanos)
+        } finally {
+            callback.cancel()
+        }
+    }
+
+    private fun removeProviderCallbackAsync(callback: PendingIntent) {
+        runCatching { removeUpdates(callback) }
+        callback.cancel()
+    }
+
+    private fun await(task: Task<Void>, deadlineNanos: Long) {
+        val remainingNanos = deadlineNanos - System.nanoTime()
+        if (remainingNanos <= 0L) throw TimeoutException("Activity command timed out")
+        Tasks.await(task, remainingNanos, TimeUnit.NANOSECONDS)
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
@@ -1,0 +1,152 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.SharedPreferences
+import com.margelo.nitro.nitrogeolocation.*
+
+internal const val BACKGROUND_LOCATION_PREFS = "nitro_background_location"
+
+internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) {
+    fun persist(options: BackgroundLocationOptions) {
+        val service = options.android?.foregroundService
+        prefs.edit()
+            .putBoolean("configured", true)
+            .putBoolean("running", prefs.getBoolean("running", false))
+            .putBoolean("startOnBoot", options.startOnBoot == true)
+            .putBoolean("stopOnTerminate", options.stopOnTerminate != false)
+            .putString("trackingMode", options.trackingMode?.name)
+            .putString("accuracyAndroid", options.accuracy?.android?.name)
+            .putString("accuracyIos", options.accuracy?.ios?.name)
+            .putString("granularity", options.granularity?.name)
+            .putString("androidLocationProvider", options.android?.locationProvider?.name)
+            .putBoolean(
+                "androidRequestNotificationPermission",
+                options.android?.requestNotificationPermission != false
+            )
+            .putBoolean(
+                "androidRequestIgnoreBatteryOptimizations",
+                options.android?.requestIgnoreBatteryOptimizations == true
+            )
+            .putFloat("interval", (options.interval ?: 10_000.0).toFloat())
+            .putFloat("fastestInterval", (options.fastestInterval ?: 5_000.0).toFloat())
+            .putFloat("distanceFilter", (options.distanceFilter ?: 0.0).toFloat())
+            .putFloat("maxUpdateDelay", (options.maxUpdateDelay ?: 0.0).toFloat())
+            .putBoolean("waitForAccurateLocation", options.waitForAccurateLocation == true)
+            .putBoolean("persist", options.persist != false)
+            .putFloat("maxStoredLocations", (options.maxStoredLocations ?: 0.0).toFloat())
+            .putFloat("maxStoredEvents", (options.maxStoredEvents ?: 0.0).toFloat())
+            .putBoolean("activityConfigured", options.activityRecognition != null)
+            .putBoolean("activityEnabled", options.activityRecognition?.enabled == true)
+            .putFloat("activityInterval", (options.activityRecognition?.interval ?: 10_000.0).toFloat())
+            .putBoolean("activityStopOnStill", options.activityRecognition?.stopOnStill == true)
+            .putFloat(
+                "activityMinimumConfidence",
+                (options.activityRecognition?.minimumConfidence ?: 0.0).toFloat()
+            )
+            .putFloat("notificationId", (service?.notificationId ?: 9471.0).toFloat())
+            .putString("notificationTitle", service?.notificationTitle)
+            .putString("notificationText", service?.notificationText)
+            .putString("notificationChannelId", service?.notificationChannelId)
+            .putString("notificationChannelName", service?.notificationChannelName)
+            .putString("notificationChannelDescription", service?.notificationChannelDescription)
+            .putString("notificationIcon", service?.notificationIcon)
+            .putString("notificationColor", service?.notificationColor)
+            .putString("stopActionTitle", service?.stopActionTitle)
+            .putString("syncUrl", options.sync?.url)
+            .putString("syncMethod", options.sync?.method?.name)
+            .putString("syncHeaders", options.sync?.headers?.let(::stringMapToJson))
+            .putString("syncBodyTemplate", options.sync?.bodyTemplate?.let(::variantMapToJson))
+            .putBoolean("syncBatchConfigured", options.sync?.batch != null)
+            .putFloat("syncBatchSize", (options.sync?.batchSize ?: 50.0).toFloat())
+            .putFloat("syncThreshold", (options.sync?.syncThreshold ?: 1.0).toFloat())
+            .putFloat("syncInterval", (options.sync?.syncInterval ?: 0.0).toFloat())
+            .putBoolean("syncBatch", options.sync?.batch == true)
+            .putBoolean("syncRetry", options.sync?.retry == true)
+            .putFloat("syncMaxRetries", (options.sync?.maxRetries ?: 3.0).toFloat())
+            .putBoolean("syncAutoClear", options.sync?.autoClear == true)
+            .apply()
+    }
+
+    fun restore(): BackgroundLocationOptions? {
+        if (!prefs.getBoolean("configured", false)) return null
+        val title = prefs.getString("notificationTitle", null) ?: return null
+        val text = prefs.getString("notificationText", null) ?: return null
+        val service = AndroidForegroundServiceOptions(
+            prefs.getFloat("notificationId", 9471f).toDouble(),
+            title,
+            text,
+            prefs.getString("notificationChannelId", null),
+            prefs.getString("notificationChannelName", null),
+            prefs.getString("notificationChannelDescription", null),
+            prefs.getString("notificationIcon", null),
+            prefs.getString("notificationColor", null),
+            prefs.getString("stopActionTitle", null)
+        )
+        val sync = prefs.getString("syncUrl", null)?.let { url ->
+            BackgroundHttpSyncOptions(
+                url,
+                prefs.getString("syncMethod", null)?.let {
+                    runCatching { enumValueOf<BackgroundHttpMethod>(it) }.getOrNull()
+                },
+                prefs.getString("syncHeaders", null)?.let(::jsonToStringMap),
+                if (prefs.getBoolean("syncBatchConfigured", false)) {
+                    prefs.getBoolean("syncBatch", false)
+                } else null,
+                prefs.getFloat("syncBatchSize", 50f).toDouble(),
+                prefs.getFloat("syncThreshold", 1f).toDouble(),
+                prefs.getFloat("syncInterval", 0f).toDouble(),
+                prefs.getBoolean("syncRetry", false),
+                prefs.getFloat("syncMaxRetries", 3f).toDouble(),
+                prefs.getString("syncBodyTemplate", null)?.let(::jsonToVariantMap),
+                prefs.getBoolean("syncAutoClear", false)
+            )
+        }
+        val accuracyAndroid = prefs.getString("accuracyAndroid", null)?.let {
+            runCatching { enumValueOf<AndroidAccuracyPreset>(it) }.getOrNull()
+        }
+        val accuracyIos = prefs.getString("accuracyIos", null)?.let {
+            runCatching { enumValueOf<IOSAccuracyPreset>(it) }.getOrNull()
+        }
+        val accuracy = if (accuracyAndroid != null || accuracyIos != null) {
+            LocationAccuracyOptions(accuracyAndroid, accuracyIos)
+        } else null
+        val activityRecognition = if (prefs.getBoolean("activityConfigured", false)) {
+            ActivityRecognitionOptions(
+                prefs.getBoolean("activityEnabled", false),
+                prefs.getFloat("activityInterval", 10_000f).toDouble(),
+                prefs.getBoolean("activityStopOnStill", false),
+                prefs.getFloat("activityMinimumConfidence", 0f).toDouble()
+            )
+        } else null
+        return BackgroundLocationOptions(
+            prefs.getString("trackingMode", null)?.let {
+                runCatching { enumValueOf<BackgroundTrackingMode>(it) }.getOrNull()
+            },
+            accuracy,
+            prefs.getString("granularity", null)?.let {
+                runCatching { enumValueOf<AndroidGranularity>(it) }.getOrNull()
+            },
+            prefs.getFloat("interval", 10_000f).toDouble(),
+            prefs.getFloat("fastestInterval", 5_000f).toDouble(),
+            prefs.getFloat("distanceFilter", 0f).toDouble(),
+            prefs.getFloat("maxUpdateDelay", 0f).toDouble(),
+            prefs.getBoolean("waitForAccurateLocation", false),
+            prefs.getBoolean("persist", true),
+            prefs.getFloat("maxStoredLocations", 0f).toDouble().takeIf { it > 0 },
+            prefs.getFloat("maxStoredEvents", 0f).toDouble().takeIf { it > 0 },
+            prefs.getBoolean("stopOnTerminate", true),
+            prefs.getBoolean("startOnBoot", false),
+            AndroidBackgroundLocationOptions(
+                prefs.getString("androidLocationProvider", null)?.let {
+                    runCatching { enumValueOf<AndroidBackgroundProvider>(it) }.getOrNull()
+                } ?: AndroidBackgroundProvider.AUTO,
+                service,
+                prefs.getBoolean("androidRequestNotificationPermission", true),
+                prefs.getBoolean("androidRequestIgnoreBatteryOptimizations", false)
+            ),
+            null,
+            null,
+            activityRecognition,
+            sync
+        )
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundErrorState.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundErrorState.kt
@@ -1,0 +1,48 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.SharedPreferences
+import com.margelo.nitro.nitrogeolocation.BackgroundEventEnvelope
+import com.margelo.nitro.nitrogeolocation.BackgroundEventType
+import com.margelo.nitro.nitrogeolocation.LocationError
+import java.util.UUID
+
+internal class NitroBackgroundErrorState(
+    private val prefs: SharedPreferences
+) {
+    @Volatile
+    private var lastError: LocationError? = null
+
+    @Synchronized
+    fun store(code: Int, message: String): BackgroundEventEnvelope {
+        val error = LocationError(code.toDouble(), message)
+        lastError = error
+        prefs.edit()
+            .putInt("lastErrorCode", code)
+            .putString("lastErrorMessage", message)
+            .putLong("lastErrorAt", System.currentTimeMillis())
+            .apply()
+        return BackgroundEventEnvelope(
+            null, null, null, null, null, error,
+            UUID.randomUUID().toString(), BackgroundEventType.ERROR,
+            System.currentTimeMillis().toDouble(), false
+        )
+    }
+
+    @Synchronized
+    fun clear() {
+        lastError = null
+        prefs.edit()
+            .remove("lastErrorCode")
+            .remove("lastErrorMessage")
+            .remove("lastErrorAt")
+            .apply()
+    }
+
+    @Synchronized
+    fun current(): LocationError? {
+        lastError?.let { return it }
+        val message = prefs.getString("lastErrorMessage", null) ?: return null
+        return LocationError(prefs.getInt("lastErrorCode", 0).toDouble(), message)
+            .also { lastError = it }
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventDispatcher.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventDispatcher.kt
@@ -1,0 +1,40 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.HeadlessJsTaskService
+import com.margelo.nitro.nitrogeolocation.BackgroundEventEnvelope
+
+/** Serializes the final generation check with reset without holding the lifecycle lock. */
+internal class NitroBackgroundEventDispatcher(
+    private val appContext: Context,
+    private val eventHub: NitroBackgroundEventHub,
+    private val currentGeneration: () -> Long,
+    private val currentServiceGeneration: () -> Long
+) {
+    private val dispatchLock = Any()
+
+    fun dispatch(
+        event: BackgroundEventEnvelope,
+        callbackGeneration: Long,
+        callbackServiceGeneration: Long? = null
+    ) {
+        synchronized(dispatchLock) {
+            if (currentGeneration() != callbackGeneration) return
+            if (callbackServiceGeneration != null &&
+                currentServiceGeneration() != callbackServiceGeneration) return
+            val delivered = eventHub.emit(event)
+            if (!shouldDispatchHeadlessTask(delivered)) return
+            runCatching {
+                val intent = Intent(appContext, NitroBackgroundHeadlessTaskService::class.java)
+                    .putExtra("event", event.toJson().toString())
+                appContext.startService(intent)
+                HeadlessJsTaskService.acquireWakeLockNow(appContext)
+            }.onFailure { NitroGeoLog.w("dispatchEvent: headless task dispatch failed", it) }
+        }
+    }
+
+    fun awaitIdle() {
+        synchronized(dispatchLock) { /* Barrier for callbacks that started before reset. */ }
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHub.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHub.kt
@@ -5,66 +5,75 @@ import com.margelo.nitro.nitrogeolocation.BackgroundEventType
 import com.margelo.nitro.nitrogeolocation.BackgroundLocation
 import com.margelo.nitro.nitrogeolocation.LocationError
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
 class NitroBackgroundEventHub {
-    private val eventListeners =
-        ConcurrentHashMap<String, (BackgroundEventEnvelope) -> Unit>()
-    private val locationListeners =
-        ConcurrentHashMap<String, (BackgroundLocation) -> Unit>()
-    private val errorListeners =
-        ConcurrentHashMap<String, (LocationError) -> Unit>()
+    private val listenerLock = Any()
+    private val eventListeners = mutableMapOf<String, (BackgroundEventEnvelope) -> Unit>()
+    private val locationListeners = mutableMapOf<String, (BackgroundLocation) -> Unit>()
+    private val errorListeners = mutableMapOf<String, (LocationError) -> Unit>()
 
     fun addEventListener(listener: (BackgroundEventEnvelope) -> Unit): String {
         val token = UUID.randomUUID().toString()
-        eventListeners[token] = listener
+        synchronized(listenerLock) { eventListeners[token] = listener }
         return token
     }
 
     fun removeEventListener(token: String) {
-        eventListeners.remove(token)
+        synchronized(listenerLock) { eventListeners.remove(token) }
     }
 
     fun addLocationListener(listener: (BackgroundLocation) -> Unit): String {
         val token = UUID.randomUUID().toString()
-        locationListeners[token] = listener
+        synchronized(listenerLock) { locationListeners[token] = listener }
         return token
     }
 
     fun removeLocationListener(token: String) {
-        locationListeners.remove(token)
+        synchronized(listenerLock) { locationListeners.remove(token) }
     }
 
     fun addErrorListener(listener: (LocationError) -> Unit): String {
         val token = UUID.randomUUID().toString()
-        errorListeners[token] = listener
+        synchronized(listenerLock) { errorListeners[token] = listener }
         return token
     }
 
     fun removeErrorListener(token: String) {
-        errorListeners.remove(token)
+        synchronized(listenerLock) { errorListeners.remove(token) }
     }
 
     fun emit(event: BackgroundEventEnvelope): Boolean {
-        var delivered = eventListeners.isNotEmpty()
-        eventListeners.values.forEach { listener -> dispatch { listener(event) } }
+        return synchronized(listenerLock) {
+            var delivered = dispatchCurrent(eventListeners) { it(event) }
 
-        when (event.type) {
-            BackgroundEventType.LOCATION -> {
-                event.location?.let { location ->
-                    delivered = delivered || locationListeners.isNotEmpty()
-                    locationListeners.values.forEach { listener -> dispatch { listener(location) } }
+            when (event.type) {
+                BackgroundEventType.LOCATION -> {
+                    event.location?.let { location ->
+                        delivered = dispatchCurrent(locationListeners) { it(location) } || delivered
+                    }
                 }
-            }
-            BackgroundEventType.ERROR -> {
-                event.error?.let { error ->
-                    delivered = delivered || errorListeners.isNotEmpty()
-                    errorListeners.values.forEach { listener -> dispatch { listener(error) } }
+                BackgroundEventType.ERROR -> {
+                    event.error?.let { error ->
+                        delivered = dispatchCurrent(errorListeners) { it(error) } || delivered
+                    }
                 }
+                else -> Unit
             }
-            else -> Unit
+
+            delivered
         }
+    }
 
+    private inline fun <T> dispatchCurrent(
+        listeners: Map<String, T>,
+        invoke: (T) -> Unit
+    ): Boolean {
+        var delivered = false
+        listeners.keys.toList().forEach { token ->
+            val listener = listeners[token] ?: return@forEach
+            delivered = true
+            dispatch { invoke(listener) }
+        }
         return delivered
     }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundGeofenceCoordinator.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundGeofenceCoordinator.kt
@@ -1,0 +1,138 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingClient
+import com.google.android.gms.location.GeofencingRequest
+import com.google.android.gms.tasks.Tasks
+import com.margelo.nitro.nitrogeolocation.BackgroundPermissionStatus
+import com.margelo.nitro.nitrogeolocation.GeofenceRegion
+import com.margelo.nitro.nitrogeolocation.GeofencingOptions
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** Keeps Play Services waits off the service main thread and outside controller lifecycle locks. */
+internal class NitroBackgroundGeofenceCoordinator(
+    private val client: GeofencingClient,
+    private val pendingIntents: NitroBackgroundPendingIntents,
+    private val store: NitroBackgroundStore,
+    private val backgroundPermission: () -> BackgroundPermissionStatus,
+    private val currentRunGeneration: () -> Long,
+    private val activeServiceGeneration: () -> Long?,
+    private val reportError: (String, Throwable, Long?) -> Unit
+) {
+    private val commandLock = ReentrantLock()
+    private val restoreExecutor = Executors.newSingleThreadExecutor()
+
+    fun add(regions: Array<GeofenceRegion>, options: GeofencingOptions?) = commandLock.withLock {
+        if (backgroundPermission() != BackgroundPermissionStatus.GRANTED) {
+            throw SecurityException("Background location permission is required to register geofences")
+        }
+        if (regions.isEmpty()) return
+        register(regions, options, currentRunGeneration())
+        store.saveGeofences(regions)
+    }
+
+    fun remove(identifiers: Array<String>?) = commandLock.withLock {
+        if (identifiers == null) {
+            val callback = pendingIntents.geofence(currentRunGeneration())
+            await(client.removeGeofences(callback))
+            callback.cancel()
+            removeLegacy()
+        } else {
+            await(client.removeGeofences(identifiers.toList()))
+        }
+        store.removeGeofences(identifiers)
+    }
+
+    fun restore(expectedServiceGeneration: Long? = null): CompletableFuture<Void> {
+        val completion = CompletableFuture<Void>()
+        restoreExecutor.execute {
+            try {
+                restoreBlocking(expectedServiceGeneration)
+                completion.complete(null)
+            } catch (error: Throwable) {
+                completion.completeExceptionally(error)
+            }
+        }
+        return completion
+    }
+
+    fun restoreBlocking(expectedServiceGeneration: Long? = null) {
+        try {
+            commandLock.lockInterruptibly()
+            try {
+                if (expectedServiceGeneration == null ||
+                    activeServiceGeneration() == expectedServiceGeneration) {
+                    val regions = store.getGeofences()
+                    if (regions.isNotEmpty()) {
+                        register(regions, null, currentRunGeneration())
+                    }
+                }
+            } finally {
+                commandLock.unlock()
+            }
+        } catch (error: Throwable) {
+            if (error is InterruptedException) Thread.currentThread().interrupt() else {
+                reportError(
+                    "Failed to register persisted geofences: ${error.message}",
+                    error,
+                    expectedServiceGeneration
+                )
+            }
+            throw error
+        }
+    }
+
+    fun reset(resetState: () -> Unit) = commandLock.withLock {
+        val callback = pendingIntents.geofence(currentRunGeneration())
+        await(client.removeGeofences(callback))
+        callback.cancel()
+        removeLegacy()
+        resetState()
+    }
+
+    private fun register(
+        regions: Array<GeofenceRegion>,
+        options: GeofencingOptions?,
+        runGeneration: Long
+    ) {
+        val geofences = regions.map { region ->
+            Geofence.Builder()
+                .setRequestId(region.identifier)
+                .setCircularRegion(region.latitude, region.longitude, region.radius.toFloat())
+                .setTransitionTypes(region.toTransitionTypes())
+                .setLoiteringDelay(region.loiteringDelay?.toInt() ?: 0)
+                .setExpirationDuration(region.expirationDuration?.toLong() ?: Geofence.NEVER_EXPIRE)
+                .apply {
+                    options?.notificationResponsiveness?.toInt()?.takeIf { it >= 0 }?.let {
+                        setNotificationResponsiveness(it)
+                    }
+                }
+                .build()
+        }
+        removeLegacy()
+        await(
+            client.addGeofences(
+                GeofencingRequest.Builder()
+                    .setInitialTrigger(options.toInitialTrigger())
+                    .addGeofences(geofences)
+                    .build(),
+                pendingIntents.geofence(runGeneration)
+            )
+        )
+    }
+
+    private fun removeLegacy() {
+        pendingIntents.legacyGeofence()?.let { callback ->
+            await(client.removeGeofences(callback))
+            callback.cancel()
+        }
+    }
+
+    private fun await(task: com.google.android.gms.tasks.Task<Void>) {
+        Tasks.await(task, 30, TimeUnit.SECONDS)
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -168,8 +168,9 @@ class NitroBackgroundLocationController private constructor(
         val providerEnabled = runCatching {
             val manager = appContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
             manager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
-                manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+            manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
         }.getOrDefault(false)
+        val storeSnapshot = store.snapshot()
 
         return BackgroundLocationStatus(
             state,
@@ -180,11 +181,11 @@ class NitroBackgroundLocationController private constructor(
             permissions.accuracyAuthorization(),
             providerEnabled,
             null,
-            store.count("background_locations"),
-            store.count("background_events"),
-            store.lastLocationAt(),
-            store.lastEventAt(),
-            store.count("geofences"),
+            storeSnapshot.storedLocationCount,
+            storeSnapshot.storedEventCount,
+            storeSnapshot.lastLocationAt,
+            storeSnapshot.lastEventAt,
+            storeSnapshot.geofenceCount,
             AndroidBackgroundLocationStatus(
                 prefs.getBoolean("running", false),
                 null,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -182,6 +182,8 @@ class NitroBackgroundLocationController private constructor(
             null,
             store.count("background_locations"),
             store.count("background_events"),
+            store.lastLocationAt(),
+            store.lastEventAt(),
             store.count("geofences"),
             AndroidBackgroundLocationStatus(
                 prefs.getBoolean("running", false),

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -1,53 +1,31 @@
 package com.margelo.nitro.nitrogeolocation.background
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import com.facebook.react.HeadlessJsTaskService
 import com.facebook.react.bridge.ReactApplicationContext
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.ActivityRecognition
 import com.google.android.gms.location.ActivityRecognitionResult
 import com.google.android.gms.location.GeofencingEvent
-import com.google.android.gms.location.GeofencingRequest
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
-import com.google.android.gms.location.Priority
-import com.google.android.gms.tasks.Task
 import com.margelo.nitro.nitrogeolocation.*
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.CompletableFuture
 import java.util.UUID
-
-private const val ACTION_LOCATION_UPDATE =
-    "com.margelo.nitro.nitrogeolocation.background.LOCATION_UPDATE"
-private const val ACTION_GEOFENCE_UPDATE =
-    "com.margelo.nitro.nitrogeolocation.background.GEOFENCE_UPDATE"
-private const val ACTION_ACTIVITY_UPDATE =
-    "com.margelo.nitro.nitrogeolocation.background.ACTIVITY_UPDATE"
-
-// LocationError codes mirror the W3C GeolocationPositionError contract.
-private const val ERROR_CODE_PERMISSION_DENIED = 1
-private const val ERROR_CODE_POSITION_UNAVAILABLE = 2
-
-// Default store caps so an unconfigured store cannot grow without bound over a long trip.
-private const val DEFAULT_MAX_STORED_LOCATIONS = 10_000
-private const val DEFAULT_MAX_STORED_EVENTS = 10_000
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class NitroBackgroundLocationController private constructor(
     private val context: Context
 ) {
     val eventHub = NitroBackgroundEventHub()
     val store = NitroBackgroundStore(context)
-
     private val appContext = context.applicationContext
     private val fusedLocationClient by lazy {
         LocationServices.getFusedLocationProviderClient(appContext)
@@ -62,14 +40,37 @@ class NitroBackgroundLocationController private constructor(
         appContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     }
     private val prefs =
-        appContext.getSharedPreferences("nitro_background_location", Context.MODE_PRIVATE)
+        appContext.getSharedPreferences(BACKGROUND_LOCATION_PREFS, Context.MODE_PRIVATE)
     private val permissions = AndroidBackgroundPermissions(appContext) { getConfigOrNull() }
     private val httpSync = AndroidBackgroundHttpSync()
-    private val taskExecutor = Executors.newSingleThreadExecutor()
-
-    // Serializes HTTP-sync uploads: a burst of locations queues onto one worker instead of
-    // spawning an unbounded number of raw threads.
-    private val syncExecutor = Executors.newSingleThreadExecutor()
+    private val configStore = NitroBackgroundConfigStore(prefs)
+    private val pendingIntents by lazy { NitroBackgroundPendingIntents(appContext) }
+    private val registrations = NitroBackgroundRegistrations(prefs)
+    private val serviceStartup = NitroBackgroundServiceStartup()
+    private val syncGate = NitroBackgroundSyncGate(registrations, prefs)
+    private val serviceCommandLock = ReentrantLock()
+    private val geofenceCoordinator by lazy {
+        NitroBackgroundGeofenceCoordinator(
+            geofencingClient,
+            pendingIntents,
+            store,
+            permissions::backgroundPermission,
+            { runGeneration },
+            ::activeServiceGeneration,
+            ::recordError
+        )
+    }
+    private val activityCoordinator by lazy {
+        NitroBackgroundActivityCoordinator(
+            pendingIntents,
+            registrations,
+            { runGeneration },
+            { interval, callback ->
+                activityRecognitionClient.requestActivityUpdates(interval, callback)
+            },
+            { callback -> activityRecognitionClient.removeActivityUpdates(callback) }
+        )
+    }
 
     @Volatile
     private var config: BackgroundLocationOptions? = null
@@ -77,35 +78,56 @@ class NitroBackgroundLocationController private constructor(
     @Volatile
     private var state = BackgroundLocationState.IDLE
 
-    @Volatile
-    private var lastError: LocationError? = null
-
-    // Serializes lifecycle transitions (configure/start/stop/reset), which are invoked from
-    // Nitro Promise.async worker threads and must not interleave on the shared singleton.
+    // Promise workers must not interleave lifecycle transitions on the singleton.
     private val lifecycleLock = Any()
+    private val storageLock = Any()
 
-    fun checkBackgroundPermission(): BackgroundPermissionResult {
-        return permissions.checkBackgroundPermission()
-    }
+    @Volatile
+    private var runGeneration = prefs.getLong(PREF_RUN_GENERATION, 0L)
+    @Volatile
+    private var configRevision = 0L
+    private val syncCoordinator = NitroBackgroundSyncCoordinator(
+        store,
+        httpSync,
+        syncGate,
+        lifecycleLock,
+        storageLock,
+        { runGeneration },
+        { configRevision },
+        { requireConfig().sync },
+        { generation -> configForGeneration(generation)?.sync },
+        ::isActiveLocationRegistration
+    )
+    private val errorState = NitroBackgroundErrorState(prefs)
+    private val eventDispatcher = NitroBackgroundEventDispatcher(
+        appContext,
+        eventHub,
+        { runGeneration },
+        registrations::currentServiceGeneration
+    )
+    private val registrationDispatcher = NitroBackgroundRegistrationDispatcher(
+        registrations,
+        eventDispatcher,
+        ::activeServiceGeneration
+    )
 
-    fun requestBackgroundPermission(reactContext: ReactApplicationContext): BackgroundPermissionResult {
-        return permissions.requestBackgroundPermission(reactContext)
-    }
+    fun checkBackgroundPermission(): BackgroundPermissionResult = permissions.checkBackgroundPermission()
 
-    fun openAppLocationSettings() {
-        permissions.openAppLocationSettings()
-    }
+    fun requestBackgroundPermission(reactContext: ReactApplicationContext): BackgroundPermissionResult = permissions.requestBackgroundPermission(reactContext)
 
-    fun configure(options: BackgroundLocationOptions) {
+    fun openAppLocationSettings() = permissions.openAppLocationSettings()
+
+    fun configure(options: BackgroundLocationOptions) = serviceCommandLock.withLock {
         synchronized(lifecycleLock) {
-            validate(options)
+            validateAndroidBackgroundOptions(options)
+            configRevision += 1L
             config = options
-            persistConfig(options)
+            configStore.persist(options)
         }
     }
 
-    fun getConfigOrNull(): BackgroundLocationOptions? {
-        return config ?: restoreConfig()?.also { config = it }
+    fun getConfigOrNull(): BackgroundLocationOptions? = synchronized(lifecycleLock) {
+        config ?: configStore.restore()?.also { config = it }
     }
 
     fun requireConfig(): BackgroundLocationOptions {
@@ -114,11 +136,25 @@ class NitroBackgroundLocationController private constructor(
         )
     }
 
-    fun start(options: BackgroundLocationOptions?) {
+    internal fun activeServiceGeneration(): Long? = synchronized(lifecycleLock) {
+        runningServiceGeneration()?.takeIf { getConfigOrNull() != null }
+    }
+
+    internal fun runningServiceGeneration(): Long? = registrations.currentServiceGeneration().takeIf { prefs.getBoolean("running", false) }
+
+    fun start(options: BackgroundLocationOptions?) = serviceCommandLock.withLock {
+        awaitServiceStart(requestServiceStart(options))
+    }
+
+    internal fun startFromBoot() = serviceCommandLock.withLock {
+        requestServiceStart(null)
+    }
+
+    private fun requestServiceStart(options: BackgroundLocationOptions?): Long =
         synchronized(lifecycleLock) {
             options?.let(::configure)
             val current = requireConfig()
-            validate(current)
+            validateAndroidBackgroundOptions(current)
             NitroGeoLog.d(
                 "start(): provider=${current.android?.locationProvider} interval=${current.interval} state=$state"
             )
@@ -129,167 +165,286 @@ class NitroBackgroundLocationController private constructor(
                 permissions.backgroundPermission() != BackgroundPermissionStatus.GRANTED) {
                 throw SecurityException("Background location permission is required")
             }
+            activeServiceGeneration()?.let { previousGeneration ->
+                stopNativeLocationUpdates(previousGeneration)
+                stopActivityRecognition(previousGeneration)
+            }
+            val nextServiceGeneration = registrations.nextServiceGeneration()
             state = BackgroundLocationState.STARTING
-            prefs.edit().putBoolean("running", true).apply()
-            ContextCompat.startForegroundService(
-                appContext,
-                Intent(appContext, NitroBackgroundLocationService::class.java)
+            prefs.edit().putBoolean("running", true).commit()
+            serviceStartup.begin(
+                nextServiceGeneration,
+                requiresActivityRecognition(current)
             )
+            try {
+                ContextCompat.startForegroundService(
+                    appContext,
+                    backgroundServiceIntent(
+                        appContext,
+                        nextServiceGeneration,
+                        current.android!!.foregroundService
+                    )
+                )
+            } catch (error: Exception) {
+                serviceStartup.discard(nextServiceGeneration)
+                failStartup(
+                    nextServiceGeneration,
+                    ERROR_CODE_POSITION_UNAVAILABLE,
+                    "Failed to launch foreground location service: ${error.message}",
+                    error
+                )
+                throw error
+            }
             // State stays STARTING until the service actually registers updates and the provider
             // confirms (see startNativeLocationUpdates) — only then do we report RUNNING.
             NitroGeoLog.d("start(): foreground service requested, state=STARTING")
+            nextServiceGeneration
+        }
+
+    private fun awaitServiceStart(serviceGeneration: Long) {
+        val failure = try {
+            serviceStartup.await(serviceGeneration, SERVICE_START_TIMEOUT_MS)
+        } catch (error: Exception) {
+            failStartup(
+                serviceGeneration,
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "Foreground location service did not start: ${error.message}",
+                error
+            )
+            throw error
+        }
+        if (failure != null) {
+            failStartup(
+                serviceGeneration,
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "Foreground location service failed to start: ${failure.message}",
+                failure
+            )
+            throw IllegalStateException("Foreground location service failed to start", failure)
         }
     }
 
-    fun stop() {
+    fun stop(expectedGeneration: Long? = null) = serviceCommandLock.withLock {
+        stopFromService(expectedGeneration)
+    }
+
+    internal fun stopFromService(expectedGeneration: Long? = null) {
         synchronized(lifecycleLock) {
+            val activeGeneration = runningServiceGeneration()
+            if (expectedGeneration != null && activeGeneration != expectedGeneration) return
+            if (expectedGeneration != null && state == BackgroundLocationState.STARTING) {
+                serviceStartup.stopped(expectedGeneration)
+            }
+            val serviceGeneration = expectedGeneration
+                ?: registrations.currentServiceGeneration()
             NitroGeoLog.d("stop(): tearing down location updates")
             state = BackgroundLocationState.STOPPING
-            stopNativeLocationUpdates()
-            stopActivityRecognition()
+            prefs.edit().putBoolean("running", false).commit()
+            stopNativeLocationUpdates(serviceGeneration)
+            stopActivityRecognition(serviceGeneration)
             appContext.stopService(Intent(appContext, NitroBackgroundLocationService::class.java))
-            prefs.edit().putBoolean("running", false).apply()
             state = BackgroundLocationState.STOPPED
         }
     }
 
-    fun reset() {
-        synchronized(lifecycleLock) {
-            stop()
-            removeGeofences(null)
-            config = null
-            prefs.edit().clear().apply()
-            store.clearEvents(null)
-            store.clearLocations(null)
+    fun reset() = serviceCommandLock.withLock {
+        stopFromService()
+        stopActivityRecognition()
+        activityCoordinator.awaitIdle()
+        geofenceCoordinator.reset {
+            synchronized(lifecycleLock) {
+                val nextGeneration = runGeneration + 1L
+                val editor = prefs.edit().clear().putLong(PREF_RUN_GENERATION, nextGeneration)
+                registrations.invalidateForReset(editor)
+                synchronized(storageLock) {
+                    runGeneration = nextGeneration
+                    config = null
+                    errorState.clear()
+                    editor.commit()
+                    store.clearEvents(null)
+                    store.clearLocations(null)
+                    store.removeGeofences(null)
+                }
+            }
         }
+        eventDispatcher.awaitIdle()
     }
 
-    fun getStatus(): BackgroundLocationStatus {
-        val providerEnabled = runCatching {
-            val manager = appContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-            manager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
-            manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
-        }.getOrDefault(false)
-        val storeSnapshot = store.snapshot()
+    internal fun serviceForegroundDidPromote(serviceGeneration: Long) = serviceStartup.foregroundPromoted(serviceGeneration)
 
-        return BackgroundLocationStatus(
+    internal fun prepareRecoveredService(serviceGeneration: Long, activityRequired: Boolean) =
+        synchronized(lifecycleLock) {
+            if (activeServiceGeneration() != serviceGeneration) return@synchronized
+            serviceStartup.beginIfAbsent(serviceGeneration, activityRequired)
+            state = BackgroundLocationState.STARTING
+        }
+
+    internal fun serviceProviderDidRegister(serviceGeneration: Long) =
+        serviceStartup.providerRegistered(serviceGeneration).also { ready ->
+            if (ready) markServiceRunning(serviceGeneration)
+        }
+
+    internal fun serviceActivityDidRegister(serviceGeneration: Long) =
+        serviceStartup.activityProviderRegistered(serviceGeneration).also { ready ->
+            if (ready) markServiceRunning(serviceGeneration)
+        }
+
+    fun getStatus(): BackgroundLocationStatus = readBackgroundLocationStatus(
+            appContext,
+            prefs,
+            store,
+            permissions,
             state,
-            prefs.getBoolean("running", false),
-            config != null || prefs.getBoolean("configured", false),
-            permissions.foregroundPermission(),
-            permissions.backgroundPermission(),
-            permissions.accuracyAuthorization(),
-            providerEnabled,
-            null,
-            storeSnapshot.storedLocationCount,
-            storeSnapshot.storedEventCount,
-            storeSnapshot.lastLocationAt,
-            storeSnapshot.lastEventAt,
-            storeSnapshot.geofenceCount,
-            AndroidBackgroundLocationStatus(
-                prefs.getBoolean("running", false),
-                null,
-                permissions.notificationPermission()
-            ),
-            null,
-            currentLastError()
+            config != null,
+            errorState.current()
         )
-    }
 
-    internal fun recordError(code: Int, message: String, throwable: Throwable? = null) {
-        val error = LocationError(code.toDouble(), message)
-        lastError = error
-        prefs.edit()
-            .putInt("lastErrorCode", code)
-            .putString("lastErrorMessage", message)
-            .putLong("lastErrorAt", System.currentTimeMillis())
-            .apply()
+    internal fun recordError(
+        code: Int,
+        message: String,
+        throwable: Throwable? = null,
+        expectedServiceGeneration: Long? = null
+    ) {
+        val dispatch = synchronized(lifecycleLock) {
+            if (expectedServiceGeneration != null &&
+                activeServiceGeneration() != expectedServiceGeneration) return
+            runGeneration to errorState.store(code, message)
+        }
         NitroGeoLog.e("background location error [$code]: $message", throwable)
         runCatching {
             dispatchEvent(
-                BackgroundEventEnvelope(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    error,
-                    UUID.randomUUID().toString(),
-                    BackgroundEventType.ERROR,
-                    System.currentTimeMillis().toDouble(),
-                    false
-                )
+                dispatch.second,
+                dispatch.first,
+                expectedServiceGeneration
             )
         }
     }
 
-    internal fun recordError(message: String, throwable: Throwable) =
-        recordError(ERROR_CODE_POSITION_UNAVAILABLE, message, throwable)
-
-    private fun clearError() {
-        lastError = null
-        prefs.edit()
-            .remove("lastErrorCode")
-            .remove("lastErrorMessage")
-            .remove("lastErrorAt")
-            .apply()
+    internal fun failStartup(
+        serviceGeneration: Long,
+        code: Int,
+        message: String,
+        throwable: Throwable? = null
+    ) {
+        serviceStartup.fail(
+            serviceGeneration,
+            throwable ?: IllegalStateException(message)
+        )
+        val dispatch = synchronized(lifecycleLock) {
+            if (!shouldApplyStartupFailure(runningServiceGeneration(), serviceGeneration)) {
+                return
+            }
+            val errorDispatch = runGeneration to errorState.store(code, message)
+            prefs.edit().putBoolean("running", false).commit()
+            stopNativeLocationUpdates(serviceGeneration)
+            stopActivityRecognition(serviceGeneration)
+            appContext.stopService(Intent(appContext, NitroBackgroundLocationService::class.java))
+            state = BackgroundLocationState.ERROR
+            errorDispatch
+        }
+        NitroGeoLog.e("background location error [$code]: $message", throwable)
+        runCatching { dispatchEvent(dispatch.second, dispatch.first, serviceGeneration) }
     }
 
-    private fun currentLastError(): LocationError? {
-        lastError?.let { return it }
-        val message = prefs.getString("lastErrorMessage", null) ?: return null
-        return LocationError(prefs.getInt("lastErrorCode", 0).toDouble(), message)
-            .also { lastError = it }
-    }
+    internal fun recordError(
+        message: String,
+        throwable: Throwable,
+        expectedServiceGeneration: Long? = null
+    ) = recordError(
+        ERROR_CODE_POSITION_UNAVAILABLE,
+        message,
+        throwable,
+        expectedServiceGeneration
+    )
 
     @SuppressLint("MissingPermission")
-    fun startNativeLocationUpdates() {
-        val current = requireConfig()
-        if (current.android?.locationProvider == AndroidBackgroundProvider.ANDROID_PLATFORM) {
-            NitroGeoLog.d("startNativeLocationUpdates(): ANDROID_PLATFORM LocationManager path")
-            startPlatformLocationUpdates(current)
-            return
-        }
-        NitroGeoLog.d("startNativeLocationUpdates(): FUSED provider, registering broadcast PendingIntent")
-        val request = LocationRequest.Builder(
-            resolvePriority(current),
-            current.interval?.toLong() ?: 10_000L
-        )
-            .setMinUpdateIntervalMillis(current.fastestInterval?.toLong() ?: 5_000L)
-            .setMinUpdateDistanceMeters((current.distanceFilter ?: 0.0).toFloat())
-            .setWaitForAccurateLocation(current.waitForAccurateLocation == true)
-            .setMaxUpdateDelayMillis(current.maxUpdateDelay?.toLong() ?: 0L)
-            .build()
+    fun startNativeLocationUpdates(expectedGeneration: Long? = null) {
+        synchronized(lifecycleLock) {
+            val serviceGeneration = expectedGeneration ?: activeServiceGeneration() ?: return
+            if (activeServiceGeneration() != serviceGeneration) return
+            val current = requireConfig()
+            val callbackGeneration = runGeneration
+            val (previous, registration) = registrations.replaceLocation(serviceGeneration)
+            previous?.let {
+                removeLocationUpdates(pendingIntents.location(callbackGeneration, it.generation))
+            }
+            if (current.android?.locationProvider == AndroidBackgroundProvider.ANDROID_PLATFORM) {
+                NitroGeoLog.d("startNativeLocationUpdates(): ANDROID_PLATFORM LocationManager path")
+                startPlatformLocationUpdates(current, callbackGeneration, registration)
+                return
+            }
+            NitroGeoLog.d("startNativeLocationUpdates(): FUSED provider, registering broadcast PendingIntent")
+            val request = LocationRequest.Builder(
+                resolvePriority(current),
+                current.interval?.toLong() ?: 10_000L
+            )
+                .setMinUpdateIntervalMillis(current.fastestInterval?.toLong() ?: 5_000L)
+                .setMinUpdateDistanceMeters((current.distanceFilter ?: 0.0).toFloat())
+                .setWaitForAccurateLocation(current.waitForAccurateLocation == true)
+                .setMaxUpdateDelayMillis(current.maxUpdateDelay?.toLong() ?: 0L)
+                .build()
+            val callback = pendingIntents.location(callbackGeneration, registration.generation)
 
-        try {
-            fusedLocationClient.requestLocationUpdates(request, locationPendingIntent())
-                .addOnSuccessListener {
-                    NitroGeoLog.d("startNativeLocationUpdates(): fused registration accepted")
-                    state = BackgroundLocationState.RUNNING
-                    clearError()
-                }
-                .addOnFailureListener { error ->
-                    recordError(
-                        ERROR_CODE_POSITION_UNAVAILABLE,
-                        "Failed to register fused location updates: ${error.message}",
+            removeLegacyLocationUpdates()
+            try {
+                fusedLocationClient.requestLocationUpdates(request, callback)
+                    .addOnSuccessListener {
+                        synchronized(lifecycleLock) {
+                            if (!isActiveLocationRegistration(
+                                    callbackGeneration,
+                                    registration
+                                )) {
+                                removeLocationUpdates(callback)
+                                return@synchronized
+                            }
+                            NitroGeoLog.d("startNativeLocationUpdates(): fused registration accepted")
+                            serviceProviderDidRegister(serviceGeneration)
+                        }
+                    }
+                    .addOnFailureListener { error ->
+                        if (!isActiveLocationRegistration(
+                                callbackGeneration,
+                                registration
+                            )) return@addOnFailureListener
+                        failStartup(
+                            serviceGeneration,
+                            ERROR_CODE_POSITION_UNAVAILABLE,
+                            "Failed to register fused location updates: ${error.message}",
+                            error
+                        )
+                    }
+            } catch (error: SecurityException) {
+                if (isActiveLocationRegistration(callbackGeneration, registration)) {
+                    failStartup(
+                        serviceGeneration,
+                        ERROR_CODE_PERMISSION_DENIED,
+                        "Missing location permission for fused updates: ${error.message}",
                         error
                     )
                 }
-        } catch (error: SecurityException) {
-            recordError(
-                ERROR_CODE_PERMISSION_DENIED,
-                "Missing location permission for fused updates: ${error.message}",
-                error
-            )
+            }
         }
     }
 
-    fun stopNativeLocationUpdates() {
-        fusedLocationClient.removeLocationUpdates(locationPendingIntent())
-        runCatching { platformLocationManager.removeUpdates(locationPendingIntent()) }
+    fun stopNativeLocationUpdates(expectedGeneration: Long? = null) {
+        synchronized(lifecycleLock) {
+            registrations.removeLocation(expectedGeneration)?.let { registration ->
+                removeLocationUpdates(
+                    pendingIntents.location(runGeneration, registration.generation)
+                )
+            }
+            removeLegacyLocationUpdates()
+        }
     }
 
-    fun handleNativeLocation(location: Location, source: BackgroundLocationSource) {
+    fun handleNativeLocation(
+        location: Location,
+        source: BackgroundLocationSource,
+        callbackGeneration: Long,
+        registrationGeneration: Long
+    ) {
+        if (!isActiveLocationRegistration(callbackGeneration, registrationGeneration)) return
+        val serviceGeneration = activeServiceGeneration() ?: return
         NitroGeoLog.d("handleNativeLocation(): src=$source lat=${location.latitude} lng=${location.longitude}")
         val id = UUID.randomUUID().toString()
         val backgroundLocation = BackgroundLocation(
@@ -324,17 +479,30 @@ class NitroBackgroundLocationController private constructor(
             System.currentTimeMillis().toDouble(),
             false
         )
-        if (shouldPersist()) {
-            store.insertLocation(backgroundLocation)
-            store.pruneLocations(currentMaxStoredLocations())
-            store.insertEvent(event)
-            store.pruneEvents(currentMaxStoredEvents())
-        }
-        dispatchEvent(event)
-        scheduleSyncIfNeeded()
+        val current = configForGeneration(callbackGeneration)
+        if (!registrationDispatcher.dispatchLocation(
+                event,
+                callbackGeneration,
+                registrationGeneration
+            ) {
+                synchronized(storageLock) {
+                    if (!shouldPersist(current, callbackGeneration)) return@synchronized
+                store.insertLocation(backgroundLocation)
+                store.pruneLocations(maxStoredLocations(current))
+                store.insertEvent(event)
+                store.pruneEvents(maxStoredEvents(current))
+                }
+            }
+        ) return
+        scheduleSyncIfNeeded(
+            callbackGeneration,
+            registrationGeneration,
+            serviceGeneration
+        )
     }
 
-    fun handleGeofenceEvent(geofencingEvent: GeofencingEvent) {
+    fun handleGeofenceEvent(geofencingEvent: GeofencingEvent, callbackGeneration: Long) {
+        if (!isCurrentGeneration(callbackGeneration)) return
         val transition = when (geofencingEvent.geofenceTransition) {
             Geofence.GEOFENCE_TRANSITION_ENTER -> GeofenceTransition.ENTER
             Geofence.GEOFENCE_TRANSITION_EXIT -> GeofenceTransition.EXIT
@@ -357,31 +525,67 @@ class NitroBackgroundLocationController private constructor(
                 now,
                 false
             )
-            persistEventIfNeeded(event)
-            dispatchEvent(event)
+            persistEventIfNeeded(event, callbackGeneration, allowUnconfigured = true)
+            if (!isCurrentGeneration(callbackGeneration)) return
+            dispatchEvent(event, callbackGeneration)
         }
     }
 
     @SuppressLint("MissingPermission")
-    fun startActivityRecognition(options: ActivityRecognitionOptions?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
-            ContextCompat.checkSelfPermission(
-                appContext,
-                Manifest.permission.ACTIVITY_RECOGNITION
-            ) != PackageManager.PERMISSION_GRANTED) {
-            throw SecurityException("Activity recognition permission is required")
+    fun startActivityRecognition(
+        options: ActivityRecognitionOptions?,
+        expectedGeneration: Long? = null
+    ) {
+        if (expectedGeneration == null) {
+            serviceCommandLock.withLock {
+                val future = prepareActivityRecognition(options, null) ?: return@withLock
+                try {
+                    awaitActivityCommand(future)
+                } catch (error: Exception) {
+                    recordError(
+                        "Failed to register activity recognition: ${error.message}",
+                        error
+                    )
+                    throw error
+                }
+            }
+            return
         }
-        activityRecognitionClient.requestActivityUpdates(
-            (options?.interval ?: 10_000.0).toLong(),
-            activityPendingIntent()
-        )
+
+        val future = prepareActivityRecognition(options, expectedGeneration) ?: return
+        future.whenComplete { _, error ->
+            if (error == null && activeServiceGeneration() == expectedGeneration) {
+                serviceActivityDidRegister(expectedGeneration)
+            } else if (error == null) {
+                activityCoordinator.stop(expectedGeneration)
+            } else {
+                val cause = unwrapActivityCommandError(error)
+                failStartup(
+                    expectedGeneration,
+                    ERROR_CODE_POSITION_UNAVAILABLE,
+                    "Failed to register activity recognition: ${cause.message}",
+                    cause
+                )
+            }
+        }
     }
 
-    fun stopActivityRecognition() {
-        activityRecognitionClient.removeActivityUpdates(activityPendingIntent())
+    fun stopActivityRecognition(expectedGeneration: Long? = null) {
+        if (expectedGeneration == null) {
+            serviceCommandLock.withLock {
+                awaitActivityCommand(activityCoordinator.stop(null))
+            }
+        } else {
+            activityCoordinator.stop(expectedGeneration)
+        }
     }
 
-    fun handleActivityRecognition(intent: Intent) {
+    fun handleActivityRecognition(
+        intent: Intent,
+        callbackGeneration: Long,
+        registrationGeneration: Long
+    ) {
+        if (!isActiveActivityRegistration(callbackGeneration, registrationGeneration)) return
         val result = ActivityRecognitionResult.extractResult(intent) ?: return
         val activity = result.mostProbableActivity ?: return
         val detected = DetectedActivity(
@@ -401,84 +605,51 @@ class NitroBackgroundLocationController private constructor(
             detected.timestamp,
             false
         )
-        persistEventIfNeeded(event)
-        dispatchEvent(event)
-        applyActivityAwareTracking(detected)
-    }
-
-    fun addGeofences(regions: Array<GeofenceRegion>, options: GeofencingOptions?) {
-        if (permissions.backgroundPermission() != BackgroundPermissionStatus.GRANTED) {
-            throw SecurityException("Background location permission is required to register geofences")
-        }
-        val geofences = regions.map { region ->
-            Geofence.Builder()
-                .setRequestId(region.identifier)
-                .setCircularRegion(region.latitude, region.longitude, region.radius.toFloat())
-                .setTransitionTypes(region.toTransitionTypes())
-                .setLoiteringDelay(region.loiteringDelay?.toInt() ?: 0)
-                .setExpirationDuration(region.expirationDuration?.toLong() ?: Geofence.NEVER_EXPIRE)
-                .apply {
-                    options?.notificationResponsiveness?.toInt()?.takeIf { it >= 0 }?.let {
-                        setNotificationResponsiveness(it)
+        val current = configForGeneration(callbackGeneration)
+        if (!registrationDispatcher.dispatchActivity(
+                event,
+                callbackGeneration,
+                registrationGeneration
+            ) {
+                synchronized(storageLock) {
+                    if (!shouldPersist(current, callbackGeneration, allowUnconfigured = true)) {
+                        return@synchronized
                     }
+                    store.insertEvent(event)
+                    store.pruneEvents(maxStoredEvents(current))
                 }
-                .build()
-        }
-        if (geofences.isEmpty()) return
-
-        waitForTask(geofencingClient.addGeofences(
-            GeofencingRequest.Builder()
-                .setInitialTrigger(options.toInitialTrigger())
-                .addGeofences(geofences)
-                .build(),
-            geofencePendingIntent()
-        ))
-        store.saveGeofences(regions)
-    }
-
-    fun removeGeofences(identifiers: Array<String>?) {
-        waitForTask(if (identifiers == null) {
-            geofencingClient.removeGeofences(geofencePendingIntent())
-        } else {
-            geofencingClient.removeGeofences(identifiers.toList())
-        })
-        store.removeGeofences(identifiers)
-    }
-
-    fun registerPersistedGeofencesIfNeeded() {
-        val geofences = store.getGeofences()
-        if (geofences.isNotEmpty()) {
-            addGeofences(geofences, null)
+            }
+        ) return
+        synchronized(lifecycleLock) {
+            if (isActiveActivityRegistration(callbackGeneration, registrationGeneration)) {
+                applyActivityAwareTracking(detected)
+            }
         }
     }
+
+    fun addGeofences(regions: Array<GeofenceRegion>, options: GeofencingOptions?) =
+        geofenceCoordinator.add(regions, options)
+
+    fun removeGeofences(identifiers: Array<String>?) = geofenceCoordinator.remove(identifiers)
+
+    fun registerPersistedGeofencesIfNeeded(expectedGeneration: Long? = null) =
+        geofenceCoordinator.restore(expectedGeneration)
+
+    internal fun registerPersistedGeofencesBlockingIfNeeded() =
+        geofenceCoordinator.restoreBlocking()
 
     fun syncStoredLocations(): BackgroundHttpSyncResult {
-        val sync = requireConfig().sync
-        val locations = store.getLocations(
-            GetStoredBackgroundLocationsOptions(
-                sync?.batchSize ?: 50.0,
-                null,
-                true,
-                false
-            )
-        )
-        val ids = locations.map { it.id }
-        if (ids.isEmpty()) {
-            return BackgroundHttpSyncResult(true, null, emptyArray(), emptyArray(), null)
-        }
-        if (sync == null) {
-            return BackgroundHttpSyncResult(true, null, emptyArray(), emptyArray(), null)
-        }
-        val result = httpSync.uploadLocationsWithRetry(sync, locations)
-        store.markSynced(result.syncedLocationIds.toList())
-        if (sync.autoClear == true) {
-            store.clearLocations(result.syncedLocationIds)
-        }
-        return result
+        val callbackGeneration = runGeneration
+        return syncCoordinator.syncManual(callbackGeneration)
     }
 
-    private fun scheduleSyncIfNeeded() {
-        val sync = getConfigOrNull()?.sync ?: return
+    private fun scheduleSyncIfNeeded(
+        callbackGeneration: Long,
+        registrationGeneration: Long,
+        serviceGeneration: Long
+    ) {
+        if (!isActiveLocationRegistration(callbackGeneration, registrationGeneration)) return
+        val sync = configForGeneration(callbackGeneration)?.sync ?: return
         val threshold = sync.syncThreshold?.toInt()?.takeIf { it > 0 } ?: 1
         val unsynced = store.getLocations(
             GetStoredBackgroundLocationsOptions(
@@ -490,67 +661,116 @@ class NitroBackgroundLocationController private constructor(
         )
         if (unsynced.size < threshold) return
 
-        val now = System.currentTimeMillis()
-        val interval = sync.syncInterval?.toLong()?.takeIf { it > 0 } ?: 0L
-        val lastSyncAt = prefs.getLong("lastSyncAt", 0L)
-        if (interval > 0 && now - lastSyncAt < interval) return
-        prefs.edit().putLong("lastSyncAt", now).apply()
-
-        syncExecutor.execute {
-            val result = runCatching { syncStoredLocations() }.getOrElse { error ->
-                BackgroundHttpSyncResult(
-                    false,
+        syncCoordinator.scheduleAutomatic(
+            callbackGeneration,
+            registrationGeneration,
+            serviceGeneration,
+            onResult = { result ->
+                val event = BackgroundEventEnvelope(
                     null,
-                    emptyArray(),
-                    unsynced.map { it.id }.toTypedArray(),
-                    error.message ?: "HTTP sync failed"
+                    null,
+                    null,
+                    null,
+                    result,
+                    null,
+                    UUID.randomUUID().toString(),
+                    BackgroundEventType.HTTPSYNC,
+                    System.currentTimeMillis().toDouble(),
+                    false
+                )
+                val current = configForGeneration(callbackGeneration)
+                registrationDispatcher.dispatchLocation(
+                    event,
+                    callbackGeneration,
+                    registrationGeneration
+                ) {
+                    synchronized(storageLock) {
+                        if (!shouldPersist(current, callbackGeneration)) return@synchronized
+                        store.insertEvent(event)
+                        store.pruneEvents(maxStoredEvents(current))
+                    }
+                }
+            },
+            onFailure = { error ->
+                recordError(
+                    "Automatic background HTTP sync failed: ${error.message}",
+                    error,
+                    serviceGeneration
                 )
             }
-            val event = BackgroundEventEnvelope(
-                null,
-                null,
-                null,
-                null,
-                result,
-                null,
-                UUID.randomUUID().toString(),
-                BackgroundEventType.HTTPSYNC,
-                System.currentTimeMillis().toDouble(),
-                false
-            )
-            persistEventIfNeeded(event)
-            dispatchEvent(event)
+        )
+    }
+
+    private fun isCurrentGeneration(callbackGeneration: Long): Boolean =
+        runGeneration == callbackGeneration
+
+    private fun isActiveLocationRegistration(
+        callbackGeneration: Long,
+        registration: BackgroundRegistration
+    ): Boolean = isActiveLocationRegistration(callbackGeneration, registration.generation)
+
+    private fun isActiveLocationRegistration(
+        callbackGeneration: Long,
+        registrationGeneration: Long
+    ): Boolean = synchronized(lifecycleLock) {
+        val serviceGeneration = activeServiceGeneration() ?: return@synchronized false
+        isCurrentGeneration(callbackGeneration) &&
+            registrations.isCurrentLocation(registrationGeneration, serviceGeneration)
+    }
+
+    private fun isActiveActivityRegistration(
+        callbackGeneration: Long,
+        registrationGeneration: Long
+    ): Boolean = synchronized(lifecycleLock) {
+        if (!isCurrentGeneration(callbackGeneration)) return@synchronized false
+        registrations.isCurrentActivity(
+            registrationGeneration,
+            activeServiceGeneration()
+        )
+    }
+
+    private fun configForGeneration(callbackGeneration: Long): BackgroundLocationOptions? {
+        if (!isCurrentGeneration(callbackGeneration)) return null
+        return getConfigOrNull()
+    }
+
+    private fun shouldPersist(
+        current: BackgroundLocationOptions?,
+        callbackGeneration: Long,
+        allowUnconfigured: Boolean = false
+    ): Boolean {
+        return shouldPersistForGeneration(
+            current != null,
+            current?.persist,
+            runGeneration,
+            callbackGeneration,
+            allowUnconfigured
+        )
+    }
+
+    private fun persistEventIfNeeded(
+        event: BackgroundEventEnvelope,
+        callbackGeneration: Long,
+        allowUnconfigured: Boolean = false
+    ) {
+        val current = configForGeneration(callbackGeneration)
+        synchronized(storageLock) {
+            if (!shouldPersist(current, callbackGeneration, allowUnconfigured)) return
+            store.insertEvent(event)
+            store.pruneEvents(maxStoredEvents(current))
         }
     }
 
-    private fun shouldPersist(): Boolean {
-        return getConfigOrNull()?.persist != false
-    }
-
-    private fun persistEventIfNeeded(event: BackgroundEventEnvelope) {
-        if (!shouldPersist()) return
-        store.insertEvent(event)
-        store.pruneEvents(currentMaxStoredEvents())
-    }
-
-    private fun currentMaxStoredLocations(): Int {
-        return resolveMaxStored(
-            getConfigOrNull()?.maxStoredLocations?.toInt(),
-            DEFAULT_MAX_STORED_LOCATIONS
-        )
-    }
-
-    private fun currentMaxStoredEvents(): Int {
-        return resolveMaxStored(
-            getConfigOrNull()?.maxStoredEvents?.toInt(),
-            DEFAULT_MAX_STORED_EVENTS
-        )
-    }
-
     @SuppressLint("MissingPermission")
-    private fun startPlatformLocationUpdates(options: BackgroundLocationOptions) {
+    private fun startPlatformLocationUpdates(
+        options: BackgroundLocationOptions,
+        callbackGeneration: Long,
+        registration: BackgroundRegistration
+    ) {
         val interval = options.interval?.toLong() ?: 10_000L
         val distance = (options.distanceFilter ?: 0.0).toFloat()
+        val callback = pendingIntents.location(callbackGeneration, registration.generation)
+        removeLegacyLocationUpdates()
         val providers = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
             .filter { provider -> runCatching { platformLocationManager.isProviderEnabled(provider) }.getOrDefault(false) }
             .ifEmpty { listOf(LocationManager.GPS_PROVIDER) }
@@ -561,273 +781,80 @@ class NitroBackgroundLocationController private constructor(
                     provider,
                     interval,
                     distance,
-                    locationPendingIntent()
+                    callback
                 )
                 registered = true
             } catch (error: SecurityException) {
                 recordError(
                     ERROR_CODE_PERMISSION_DENIED,
                     "Missing location permission for $provider updates: ${error.message}",
-                    error
+                    error,
+                    registration.ownerServiceGeneration
                 )
             }
         }
         if (registered) {
-            state = BackgroundLocationState.RUNNING
+            registration.ownerServiceGeneration?.let(::serviceProviderDidRegister)
+        } else {
+            failStartup(
+                registration.ownerServiceGeneration
+                    ?: registrations.currentServiceGeneration(),
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "No Android location provider accepted background updates"
+            )
         }
     }
 
     private fun applyActivityAwareTracking(activity: DetectedActivity) {
         val current = getConfigOrNull() ?: return
-        val options = current.activityRecognition
-        if (current.trackingMode != BackgroundTrackingMode.ACTIVITYAWARE &&
-            options?.stopOnStill != true) {
-            return
-        }
-        val stopOnStill = options?.stopOnStill ?: (current.trackingMode == BackgroundTrackingMode.ACTIVITYAWARE)
-        val minimumConfidence = options?.minimumConfidence ?: 0.0
-        if (activity.confidence < minimumConfidence) return
-        if (activity.type == DetectedActivityType.STILL && stopOnStill) {
-            stopNativeLocationUpdates()
-            return
-        }
-        if (activity.type != DetectedActivityType.STILL &&
-            activity.type != DetectedActivityType.UNKNOWN &&
-            prefs.getBoolean("running", false)) {
-            runCatching { startNativeLocationUpdates() }
+        when (activityTrackingAction(current, activity, prefs.getBoolean("running", false))) {
+            ActivityTrackingAction.STOP -> stopNativeLocationUpdates()
+            ActivityTrackingAction.START -> runCatching { startNativeLocationUpdates() }
+            ActivityTrackingAction.NONE -> Unit
         }
     }
 
-    private fun validate(options: BackgroundLocationOptions) {
-        if (options.android?.foregroundService == null) {
-            throw IllegalArgumentException(
-                "Android background tracking requires android.foregroundService notification options"
-            )
+    private fun markServiceRunning(serviceGeneration: Long) = synchronized(lifecycleLock) {
+        if (activeServiceGeneration() == serviceGeneration &&
+            state == BackgroundLocationState.STARTING) {
+            state = BackgroundLocationState.RUNNING
+            errorState.clear()
         }
     }
 
-    private fun dispatchEvent(event: BackgroundEventEnvelope) {
-        val deliveredToInProcessListener = eventHub.emit(event)
-        if (!shouldDispatchHeadlessTask(deliveredToInProcessListener)) return
-        // The in-process eventHub already delivered to any live JS listeners; the headless task is
-        // the fallback for when JS is dead. Guard its start: startService from the background can be
-        // rejected (ForegroundServiceStartNotAllowed / IllegalState), which must not crash the
-        // broadcast receiver thread that drives delivery.
-        runCatching {
-            val intent = Intent(appContext, NitroBackgroundHeadlessTaskService::class.java)
-                .putExtra("event", event.toJson().toString())
-            appContext.startService(intent)
-            HeadlessJsTaskService.acquireWakeLockNow(appContext)
-        }.onFailure { NitroGeoLog.w("dispatchEvent: headless task dispatch failed", it) }
-    }
-
-    private fun waitForTask(task: Task<Void>) {
-        val latch = CountDownLatch(1)
-        var failure: Exception? = null
-        task.addOnCompleteListener(taskExecutor) {
-            failure = it.exception
-            latch.countDown()
+    @SuppressLint("MissingPermission")
+    private fun prepareActivityRecognition(
+        options: ActivityRecognitionOptions?,
+        expectedGeneration: Long?
+    ): CompletableFuture<Void>? = synchronized(lifecycleLock) {
+        if (expectedGeneration != null && activeServiceGeneration() != expectedGeneration) {
+            return@synchronized null
         }
-        latch.await(30, TimeUnit.SECONDS)
-        failure?.let { throw it }
-        if (!task.isSuccessful) {
-            throw IllegalStateException("Google Play services task failed")
-        }
-    }
-
-    private fun persistConfig(options: BackgroundLocationOptions) {
-        val service = options.android?.foregroundService
-        prefs.edit()
-            .putBoolean("configured", true)
-            .putBoolean("running", prefs.getBoolean("running", false))
-            .putBoolean("startOnBoot", options.startOnBoot == true)
-            .putBoolean("stopOnTerminate", options.stopOnTerminate != false)
-            .putString("trackingMode", options.trackingMode?.name)
-            .putString("accuracyAndroid", options.accuracy?.android?.name)
-            .putString("accuracyIos", options.accuracy?.ios?.name)
-            .putString("granularity", options.granularity?.name)
-            .putString("androidLocationProvider", options.android?.locationProvider?.name)
-            .putBoolean(
-                "androidRequestNotificationPermission",
-                options.android?.requestNotificationPermission != false
-            )
-            .putBoolean(
-                "androidRequestIgnoreBatteryOptimizations",
-                options.android?.requestIgnoreBatteryOptimizations == true
-            )
-            .putFloat("interval", (options.interval ?: 10_000.0).toFloat())
-            .putFloat("fastestInterval", (options.fastestInterval ?: 5_000.0).toFloat())
-            .putFloat("distanceFilter", (options.distanceFilter ?: 0.0).toFloat())
-            .putFloat("maxUpdateDelay", (options.maxUpdateDelay ?: 0.0).toFloat())
-            .putBoolean("waitForAccurateLocation", options.waitForAccurateLocation == true)
-            .putBoolean("persist", options.persist != false)
-            .putFloat("maxStoredLocations", (options.maxStoredLocations ?: 0.0).toFloat())
-            .putFloat("maxStoredEvents", (options.maxStoredEvents ?: 0.0).toFloat())
-            .putBoolean("activityConfigured", options.activityRecognition != null)
-            .putBoolean("activityEnabled", options.activityRecognition?.enabled == true)
-            .putFloat("activityInterval", (options.activityRecognition?.interval ?: 10_000.0).toFloat())
-            .putBoolean("activityStopOnStill", options.activityRecognition?.stopOnStill == true)
-            .putFloat(
-                "activityMinimumConfidence",
-                (options.activityRecognition?.minimumConfidence ?: 0.0).toFloat()
-            )
-            .putFloat("notificationId", (service?.notificationId ?: 9471.0).toFloat())
-            .putString("notificationTitle", service?.notificationTitle)
-            .putString("notificationText", service?.notificationText)
-            .putString("notificationChannelId", service?.notificationChannelId)
-            .putString("notificationChannelName", service?.notificationChannelName)
-            .putString("notificationChannelDescription", service?.notificationChannelDescription)
-            .putString("notificationIcon", service?.notificationIcon)
-            .putString("notificationColor", service?.notificationColor)
-            .putString("stopActionTitle", service?.stopActionTitle)
-            .putString("syncUrl", options.sync?.url)
-            .putString("syncMethod", options.sync?.method?.name)
-            .putString("syncHeaders", options.sync?.headers?.let(::stringMapToJson))
-            .putString("syncBodyTemplate", options.sync?.bodyTemplate?.let(::variantMapToJson))
-            .putBoolean("syncBatchConfigured", options.sync?.batch != null)
-            .putFloat("syncBatchSize", (options.sync?.batchSize ?: 50.0).toFloat())
-            .putFloat("syncThreshold", (options.sync?.syncThreshold ?: 1.0).toFloat())
-            .putFloat("syncInterval", (options.sync?.syncInterval ?: 0.0).toFloat())
-            .putBoolean("syncBatch", options.sync?.batch == true)
-            .putBoolean("syncRetry", options.sync?.retry == true)
-            .putFloat("syncMaxRetries", (options.sync?.maxRetries ?: 3.0).toFloat())
-            .putBoolean("syncAutoClear", options.sync?.autoClear == true)
-            .apply()
-    }
-
-    private fun restoreConfig(): BackgroundLocationOptions? {
-        if (!prefs.getBoolean("configured", false)) return null
-        val title = prefs.getString("notificationTitle", null) ?: return null
-        val text = prefs.getString("notificationText", null) ?: return null
-        val service = AndroidForegroundServiceOptions(
-            prefs.getFloat("notificationId", 9471f).toDouble(),
-            title,
-            text,
-            prefs.getString("notificationChannelId", null),
-            prefs.getString("notificationChannelName", null),
-            prefs.getString("notificationChannelDescription", null),
-            prefs.getString("notificationIcon", null),
-            prefs.getString("notificationColor", null),
-            prefs.getString("stopActionTitle", null)
-        )
-        val sync = prefs.getString("syncUrl", null)?.let { url ->
-            BackgroundHttpSyncOptions(
-                url,
-                prefs.getString("syncMethod", null)?.let {
-                    runCatching { enumValueOf<BackgroundHttpMethod>(it) }.getOrNull()
-                },
-                prefs.getString("syncHeaders", null)?.let(::jsonToStringMap),
-                if (prefs.getBoolean("syncBatchConfigured", false)) {
-                    prefs.getBoolean("syncBatch", false)
-                } else {
-                    null
-                },
-                prefs.getFloat("syncBatchSize", 50f).toDouble(),
-                prefs.getFloat("syncThreshold", 1f).toDouble(),
-                prefs.getFloat("syncInterval", 0f).toDouble(),
-                prefs.getBoolean("syncRetry", false),
-                prefs.getFloat("syncMaxRetries", 3f).toDouble(),
-                prefs.getString("syncBodyTemplate", null)?.let(::jsonToVariantMap),
-                prefs.getBoolean("syncAutoClear", false)
-            )
-        }
-        val accuracyAndroid = prefs.getString("accuracyAndroid", null)?.let {
-            runCatching { enumValueOf<AndroidAccuracyPreset>(it) }.getOrNull()
-        }
-        val accuracyIos = prefs.getString("accuracyIos", null)?.let {
-            runCatching { enumValueOf<IOSAccuracyPreset>(it) }.getOrNull()
-        }
-        val accuracy = if (accuracyAndroid != null || accuracyIos != null) {
-            LocationAccuracyOptions(accuracyAndroid, accuracyIos)
-        } else {
-            null
-        }
-        val activityRecognition = if (prefs.getBoolean("activityConfigured", false)) {
-            ActivityRecognitionOptions(
-                prefs.getBoolean("activityEnabled", false),
-                prefs.getFloat("activityInterval", 10_000f).toDouble(),
-                prefs.getBoolean("activityStopOnStill", false),
-                prefs.getFloat("activityMinimumConfidence", 0f).toDouble()
-            )
-        } else {
-            null
-        }
-        return BackgroundLocationOptions(
-            prefs.getString("trackingMode", null)?.let {
-                runCatching { enumValueOf<BackgroundTrackingMode>(it) }.getOrNull()
-            },
-            accuracy,
-            prefs.getString("granularity", null)?.let {
-                runCatching { enumValueOf<AndroidGranularity>(it) }.getOrNull()
-            },
-            prefs.getFloat("interval", 10_000f).toDouble(),
-            prefs.getFloat("fastestInterval", 5_000f).toDouble(),
-            prefs.getFloat("distanceFilter", 0f).toDouble(),
-            prefs.getFloat("maxUpdateDelay", 0f).toDouble(),
-            prefs.getBoolean("waitForAccurateLocation", false),
-            prefs.getBoolean("persist", true),
-            prefs.getFloat("maxStoredLocations", 0f).toDouble().takeIf { it > 0 },
-            prefs.getFloat("maxStoredEvents", 0f).toDouble().takeIf { it > 0 },
-            prefs.getBoolean("stopOnTerminate", true),
-            prefs.getBoolean("startOnBoot", false),
-            AndroidBackgroundLocationOptions(
-                prefs.getString("androidLocationProvider", null)?.let {
-                    runCatching { enumValueOf<AndroidBackgroundProvider>(it) }.getOrNull()
-                } ?: AndroidBackgroundProvider.AUTO,
-                service,
-                prefs.getBoolean("androidRequestNotificationPermission", true),
-                prefs.getBoolean("androidRequestIgnoreBatteryOptimizations", false)
-            ),
-            null,
-            null,
-            activityRecognition,
-            sync
+        requireActivityRecognitionPermission(appContext)
+        activityCoordinator.start(
+            (options?.interval ?: 10_000.0).toLong(),
+            expectedGeneration
         )
     }
 
-    private fun locationPendingIntent(): PendingIntent {
-        val intent = Intent(appContext, NitroLocationUpdateReceiver::class.java)
-            .setAction(ACTION_LOCATION_UPDATE)
-        return PendingIntent.getBroadcast(
-            appContext,
-            1001,
-            intent,
-            mutablePendingIntentFlags(Build.VERSION.SDK_INT)
-        )
+    private fun dispatchEvent(
+        event: BackgroundEventEnvelope,
+        callbackGeneration: Long,
+        callbackServiceGeneration: Long? = null
+    ) = eventDispatcher.dispatch(event, callbackGeneration, callbackServiceGeneration)
+
+    private fun removeLocationUpdates(callback: PendingIntent) {
+        runCatching { platformLocationManager.removeUpdates(callback) }
+        fusedLocationClient.removeLocationUpdates(callback)
+            .addOnCompleteListener { callback.cancel() }
     }
 
-    private fun geofencePendingIntent(): PendingIntent {
-        val intent = Intent(appContext, NitroGeofenceReceiver::class.java)
-            .setAction(ACTION_GEOFENCE_UPDATE)
-        return PendingIntent.getBroadcast(
-            appContext,
-            1002,
-            intent,
-            mutablePendingIntentFlags(Build.VERSION.SDK_INT)
-        )
-    }
-
-    private fun activityPendingIntent(): PendingIntent {
-        val intent = Intent(appContext, NitroActivityRecognitionReceiver::class.java)
-            .setAction(ACTION_ACTIVITY_UPDATE)
-        return PendingIntent.getBroadcast(
-            appContext,
-            1003,
-            intent,
-            mutablePendingIntentFlags(Build.VERSION.SDK_INT)
-        )
-    }
-
-    private fun resolvePriority(options: BackgroundLocationOptions): Int {
-        return when (options.accuracy?.android) {
-            AndroidAccuracyPreset.HIGH -> Priority.PRIORITY_HIGH_ACCURACY
-            AndroidAccuracyPreset.LOW -> Priority.PRIORITY_LOW_POWER
-            AndroidAccuracyPreset.PASSIVE -> Priority.PRIORITY_PASSIVE
-            else -> Priority.PRIORITY_BALANCED_POWER_ACCURACY
-        }
-    }
+    private fun removeLegacyLocationUpdates() =
+        pendingIntents.legacyLocation()?.let(::removeLocationUpdates)
 
     companion object {
+        private const val SERVICE_START_TIMEOUT_MS = 10_000L
+
         @Volatile
         private var instance: NitroBackgroundLocationController? = null
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
@@ -7,62 +7,132 @@ import android.os.IBinder
 import androidx.core.app.ServiceCompat
 
 class NitroBackgroundLocationService : Service() {
+    private var serviceGeneration: Long? = null
     private val controller by lazy {
         NitroBackgroundLocationController.getInstance(applicationContext)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val config = controller.requireConfig()
-        val foregroundService = config.android?.foregroundService
-            ?: throw IllegalStateException("Android foreground service options are required")
-        val notification = NitroBackgroundNotificationFactory.create(this, foregroundService)
-        val notificationId = foregroundService.notificationId?.toInt() ?: 9471
-        NitroGeoLog.d("Service.onStartCommand(): startForeground id=$notificationId type=location")
+        val requestedGeneration = intent?.backgroundServiceGeneration()
+        val foregroundService = intent?.backgroundNotificationOptions()
+            ?: persistedBackgroundNotificationOptions(applicationContext)
+            ?: fallbackBackgroundNotificationOptions()
         try {
+            val notification = NitroBackgroundNotificationFactory.create(this, foregroundService)
+            val notificationId = foregroundService.notificationId?.toInt() ?: 9471
+            NitroGeoLog.d("Service.onStartCommand(): startForeground id=$notificationId type=location")
             ServiceCompat.startForeground(
                 this,
                 notificationId,
                 notification,
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
             )
+            NitroBackgroundServiceState.promoted()
         } catch (error: Exception) {
+            NitroBackgroundServiceState.stopped()
             // Android 14+ rejects a "location" foreground service if location permission is not
             // held at start time (SecurityException), and Android 12+ rejects background starts
             // (ForegroundServiceStartNotAllowedException, an IllegalStateException). Record and stop
             // cleanly instead of letting the service crash.
-            controller.recordError("Failed to start foreground location service: ${error.message}", error)
-            stopSelf()
+            val failedGeneration = runCatching {
+                resolveBackgroundServiceGeneration(
+                    requestedGeneration,
+                    controller.runningServiceGeneration()
+                )
+            }.getOrNull()
+            failedGeneration?.let {
+                controller.failStartup(
+                    it,
+                    ERROR_CODE_POSITION_UNAVAILABLE,
+                    "Failed to start foreground location service: ${error.message}",
+                    error
+                )
+            }
+            stopSelf(startId)
             return START_NOT_STICKY
         }
+        val activeGeneration = controller.runningServiceGeneration()
+        val generation = resolveBackgroundServiceGeneration(requestedGeneration, activeGeneration)
+        if (generation == null) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+        if (generation != activeGeneration) {
+            controller.failStartup(
+                generation,
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "Foreground service start was superseded"
+            )
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+        val config = controller.getConfigOrNull()
+        if (config == null) {
+            controller.failStartup(
+                generation,
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "Background location configuration is unavailable"
+            )
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+        controller.prepareRecoveredService(
+            generation,
+            requiresActivityRecognition(config)
+        )
+        controller.serviceForegroundDidPromote(generation)
+        serviceGeneration = generation
         NitroGeoLog.d("Service.onStartCommand(): starting native location updates")
-        controller.startNativeLocationUpdates()
+        try {
+            controller.startNativeLocationUpdates(generation)
+        } catch (error: Exception) {
+            controller.failStartup(
+                generation,
+                ERROR_CODE_POSITION_UNAVAILABLE,
+                "Failed to register native location updates: ${error.message}",
+                error
+            )
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
         if (config.trackingMode == com.margelo.nitro.nitrogeolocation.BackgroundTrackingMode.ACTIVITYAWARE ||
             config.activityRecognition?.enabled == true) {
-            runCatching {
-                controller.startActivityRecognition(config.activityRecognition)
-            }.onFailure {
-                controller.recordError("Failed to start activity recognition: ${it.message}", it)
+            try {
+                controller.startActivityRecognition(config.activityRecognition, generation)
+            } catch (error: Exception) {
+                controller.failStartup(
+                    generation,
+                    ERROR_CODE_POSITION_UNAVAILABLE,
+                    "Failed to start activity recognition: ${error.message}",
+                    error
+                )
+                stopSelf(startId)
+                return START_NOT_STICKY
             }
         }
-        runCatching { controller.registerPersistedGeofencesIfNeeded() }
-            .onFailure {
-                controller.recordError("Failed to register persisted geofences: ${it.message}", it)
-            }
+        controller.registerPersistedGeofencesIfNeeded(generation)
+        if (controller.activeServiceGeneration() != generation) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
         return if (config.stopOnTerminate == false) START_STICKY else START_NOT_STICKY
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         val config = controller.getConfigOrNull()
         if (config?.stopOnTerminate != false) {
-            controller.stop()
+            serviceGeneration?.let(controller::stopFromService)
             stopSelf()
         }
         super.onTaskRemoved(rootIntent)
     }
 
     override fun onDestroy() {
-        controller.stopNativeLocationUpdates()
-        controller.stopActivityRecognition()
+        NitroBackgroundServiceState.stopped()
+        serviceGeneration?.let {
+            controller.stopNativeLocationUpdates(it)
+            controller.stopActivityRecognition(it)
+        }
         super.onDestroy()
     }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundPendingIntents.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundPendingIntents.kt
@@ -1,0 +1,109 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+
+internal const val EXTRA_RUN_GENERATION =
+    "com.margelo.nitro.nitrogeolocation.background.RUN_GENERATION"
+internal const val MISSING_RUN_GENERATION = Long.MIN_VALUE
+internal const val EXTRA_REGISTRATION_GENERATION =
+    "com.margelo.nitro.nitrogeolocation.background.REGISTRATION_GENERATION"
+internal const val MISSING_REGISTRATION_GENERATION = Long.MIN_VALUE
+internal const val EXTRA_SERVICE_GENERATION =
+    "com.margelo.nitro.nitrogeolocation.background.SERVICE_GENERATION"
+
+private const val ACTION_LOCATION_UPDATE =
+    "com.margelo.nitro.nitrogeolocation.background.LOCATION_UPDATE"
+private const val ACTION_GEOFENCE_UPDATE =
+    "com.margelo.nitro.nitrogeolocation.background.GEOFENCE_UPDATE"
+private const val ACTION_ACTIVITY_UPDATE =
+    "com.margelo.nitro.nitrogeolocation.background.ACTIVITY_UPDATE"
+
+internal fun pendingIntentIdentityUri(kind: String, generation: Long): String =
+    "nitro-geolocation://background/$kind/$generation"
+
+internal class NitroBackgroundPendingIntents(private val context: Context) {
+    fun location(runGeneration: Long, registrationGeneration: Long): PendingIntent = create(
+        NitroLocationUpdateReceiver::class.java,
+        ACTION_LOCATION_UPDATE,
+        "location",
+        1001,
+        runGeneration,
+        registrationGeneration
+    )
+
+    fun geofence(runGeneration: Long): PendingIntent = create(
+        NitroGeofenceReceiver::class.java,
+        ACTION_GEOFENCE_UPDATE,
+        "geofence",
+        1002,
+        runGeneration,
+        null
+    )
+
+    fun activity(runGeneration: Long, registrationGeneration: Long): PendingIntent = create(
+        NitroActivityRecognitionReceiver::class.java,
+        ACTION_ACTIVITY_UPDATE,
+        "activity",
+        1003,
+        runGeneration,
+        registrationGeneration
+    )
+
+    fun legacyLocation(): PendingIntent? = legacy(
+        NitroLocationUpdateReceiver::class.java,
+        ACTION_LOCATION_UPDATE,
+        1001
+    )
+
+    fun legacyGeofence(): PendingIntent? = legacy(
+        NitroGeofenceReceiver::class.java,
+        ACTION_GEOFENCE_UPDATE,
+        1002
+    )
+
+    fun legacyActivity(): PendingIntent? = legacy(
+        NitroActivityRecognitionReceiver::class.java,
+        ACTION_ACTIVITY_UPDATE,
+        1003
+    )
+
+    private fun create(
+        receiver: Class<out BroadcastReceiver>,
+        action: String,
+        kind: String,
+        requestCode: Int,
+        runGeneration: Long,
+        registrationGeneration: Long?
+    ): PendingIntent {
+        val identityGeneration = registrationGeneration ?: runGeneration
+        val intent = Intent(context, receiver)
+            .setAction(action)
+            .setData(Uri.parse(pendingIntentIdentityUri(kind, identityGeneration)))
+            .putExtra(EXTRA_RUN_GENERATION, runGeneration)
+        registrationGeneration?.let {
+            intent.putExtra(EXTRA_REGISTRATION_GENERATION, it)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            mutablePendingIntentFlags(Build.VERSION.SDK_INT)
+        )
+    }
+
+    private fun legacy(
+        receiver: Class<out BroadcastReceiver>,
+        action: String,
+        requestCode: Int
+    ): PendingIntent? {
+        val intent = Intent(context, receiver).setAction(action)
+        val flags = PendingIntent.FLAG_NO_CREATE or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        return PendingIntent.getBroadcast(context, requestCode, intent, flags)
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrationDispatcher.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrationDispatcher.kt
@@ -1,0 +1,37 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.margelo.nitro.nitrogeolocation.BackgroundEventEnvelope
+
+internal class NitroBackgroundRegistrationDispatcher(
+    private val registrations: NitroBackgroundRegistrations,
+    private val eventDispatcher: NitroBackgroundEventDispatcher,
+    private val activeServiceGeneration: () -> Long?
+) {
+    fun dispatchLocation(
+        event: BackgroundEventEnvelope,
+        callbackGeneration: Long,
+        registrationGeneration: Long,
+        beforeDispatch: () -> Unit
+    ): Boolean {
+        val owner = activeServiceGeneration() ?: return false
+        return registrations.withCurrentLocation(registrationGeneration, owner) {
+            beforeDispatch()
+            eventDispatcher.dispatch(event, callbackGeneration, owner)
+            true
+        } ?: false
+    }
+
+    fun dispatchActivity(
+        event: BackgroundEventEnvelope,
+        callbackGeneration: Long,
+        registrationGeneration: Long,
+        beforeDispatch: () -> Unit
+    ): Boolean {
+        val activeService = activeServiceGeneration()
+        return registrations.withCurrentActivity(registrationGeneration, activeService) { owner ->
+            beforeDispatch()
+            eventDispatcher.dispatch(event, callbackGeneration, owner)
+            true
+        } ?: false
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrations.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrations.kt
@@ -1,0 +1,272 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.SharedPreferences
+
+internal const val PREF_SERVICE_GENERATION = "serviceGeneration"
+private const val PREF_LOCATION_REGISTRATION_GENERATION = "locationRegistrationGeneration"
+private const val PREF_LOCATION_REGISTRATION_ACTIVE = "locationRegistrationActive"
+private const val PREF_LOCATION_REGISTRATION_OWNER = "locationRegistrationOwner"
+private const val PREF_ACTIVITY_REGISTRATION_GENERATION = "activityRegistrationGeneration"
+private const val PREF_ACTIVITY_CONFIRMED_GENERATION = "activityConfirmedGeneration"
+private const val PREF_ACTIVITY_REGISTRATION_ACTIVE = "activityRegistrationActive"
+private const val PREF_ACTIVITY_REGISTRATION_OWNER = "activityRegistrationOwner"
+private const val PREF_ACTIVITY_STANDALONE_REQUESTED = "activityStandaloneRequested"
+private const val NO_SERVICE_OWNER = Long.MIN_VALUE
+
+internal data class BackgroundRegistration(
+    val generation: Long,
+    val ownerServiceGeneration: Long?
+)
+
+internal data class BackgroundActivityRegistration(
+    val generation: Long,
+    val backgroundOwner: Long?,
+    val standaloneRequested: Boolean
+)
+
+internal data class BackgroundActivityRequest(
+    val generation: Long,
+    val owner: Long?,
+    val ownerVersion: Long,
+    val introducedOwner: Boolean
+)
+
+internal data class BackgroundActivityConfirmation(
+    val accepted: Boolean,
+    val previous: BackgroundActivityRegistration?
+)
+
+/** Registration identities survive process restarts and change on every provider registration. */
+internal class NitroBackgroundRegistrations(private val prefs: SharedPreferences) {
+    @Volatile
+    private var serviceGeneration = prefs.getLong(PREF_SERVICE_GENERATION, 0L)
+    private var locationGeneration = prefs.getLong(PREF_LOCATION_REGISTRATION_GENERATION, 0L)
+    private var locationActive = prefs.getBoolean(PREF_LOCATION_REGISTRATION_ACTIVE, false)
+    private var locationOwner = prefs.owner(PREF_LOCATION_REGISTRATION_OWNER)
+    private var activityGeneration = prefs.getLong(PREF_ACTIVITY_REGISTRATION_GENERATION, 0L)
+    private var activityConfirmedGeneration = prefs.getLong(
+        PREF_ACTIVITY_CONFIRMED_GENERATION,
+        activityGeneration
+    )
+    private var latestActivityRequestGeneration = 0L
+    private var activityActive = prefs.getBoolean(PREF_ACTIVITY_REGISTRATION_ACTIVE, false)
+    private var activityBackgroundOwner = prefs.owner(PREF_ACTIVITY_REGISTRATION_OWNER)
+    private var activityStandaloneRequested = prefs.getBoolean(
+        PREF_ACTIVITY_STANDALONE_REQUESTED,
+        activityActive && activityBackgroundOwner == null
+    )
+    private var activityBackgroundOwnerVersion = 0L
+    private var activityStandaloneOwnerVersion = 0L
+
+    @Synchronized
+    fun nextServiceGeneration(): Long {
+        serviceGeneration = nextRegistrationGeneration(serviceGeneration)
+        prefs.edit().putLong(PREF_SERVICE_GENERATION, serviceGeneration).commit()
+        return serviceGeneration
+    }
+
+    fun currentServiceGeneration(): Long = serviceGeneration
+
+    @Synchronized
+    fun replaceLocation(owner: Long): Pair<BackgroundRegistration?, BackgroundRegistration> {
+        val previous = currentLocation()
+        locationGeneration = nextRegistrationGeneration(locationGeneration)
+        locationActive = true
+        locationOwner = owner
+        persistLocation()
+        return previous to BackgroundRegistration(locationGeneration, owner)
+    }
+
+    @Synchronized
+    fun removeLocation(
+        expectedOwner: Long? = null,
+        expectedGeneration: Long? = null
+    ): BackgroundRegistration? {
+        val current = currentLocation() ?: return null
+        if (expectedOwner != null && current.ownerServiceGeneration != expectedOwner) return null
+        if (expectedGeneration != null && current.generation != expectedGeneration) return null
+        locationActive = false
+        locationOwner = null
+        persistLocation()
+        return current
+    }
+
+    @Synchronized
+    fun isCurrentLocation(generation: Long, owner: Long): Boolean =
+        locationActive && locationGeneration == generation && locationOwner == owner
+
+    @Synchronized
+    fun <T> withCurrentLocation(generation: Long, owner: Long, work: () -> T): T? {
+        if (!isCurrentLocation(generation, owner)) return null
+        return work()
+    }
+
+    @Synchronized
+    fun requestActivity(owner: Long?): BackgroundActivityRequest {
+        activityGeneration = nextRegistrationGeneration(activityGeneration)
+        latestActivityRequestGeneration = activityGeneration
+        val ownerVersion: Long
+        val introducedOwner: Boolean
+        if (owner == null) {
+            introducedOwner = !activityStandaloneRequested
+            activityStandaloneRequested = true
+            activityStandaloneOwnerVersion += 1L
+            ownerVersion = activityStandaloneOwnerVersion
+        } else {
+            introducedOwner = activityBackgroundOwner != owner
+            activityBackgroundOwner = owner
+            activityBackgroundOwnerVersion += 1L
+            ownerVersion = activityBackgroundOwnerVersion
+        }
+        persistActivity()
+        return BackgroundActivityRequest(
+            activityGeneration,
+            owner,
+            ownerVersion,
+            introducedOwner
+        )
+    }
+
+    @Synchronized
+    fun confirmActivity(request: BackgroundActivityRequest): BackgroundActivityConfirmation {
+        val requesterIsCurrent = if (request.owner == null) {
+            activityStandaloneRequested &&
+                activityStandaloneOwnerVersion == request.ownerVersion
+        } else {
+            activityBackgroundOwner == request.owner &&
+                activityBackgroundOwnerVersion == request.ownerVersion
+        }
+        if (latestActivityRequestGeneration != request.generation || !requesterIsCurrent) {
+            return BackgroundActivityConfirmation(false, null)
+        }
+        val previous = currentActivity()
+        activityConfirmedGeneration = request.generation
+        activityActive = true
+        latestActivityRequestGeneration = 0L
+        persistActivity()
+        return BackgroundActivityConfirmation(true, previous)
+    }
+
+    @Synchronized
+    fun removeActivity(
+        expectedOwner: Long? = null
+    ): BackgroundActivityRegistration? {
+        val current = currentActivity()
+        if (expectedOwner == null) {
+            if (!activityStandaloneRequested) return null
+            activityStandaloneRequested = false
+            activityStandaloneOwnerVersion += 1L
+        } else {
+            if (activityBackgroundOwner != expectedOwner) return null
+            activityBackgroundOwner = null
+            activityBackgroundOwnerVersion += 1L
+        }
+        if (hasActivityOwner()) {
+            persistActivity()
+            return null
+        }
+        activityActive = false
+        persistActivity()
+        return current
+    }
+
+    @Synchronized
+    fun failActivity(request: BackgroundActivityRequest): BackgroundActivityRegistration? {
+        if (request.owner == null) {
+            if (request.introducedOwner &&
+                activityStandaloneOwnerVersion == request.ownerVersion) {
+                activityStandaloneRequested = false
+                activityStandaloneOwnerVersion += 1L
+            }
+        } else if (request.introducedOwner &&
+            activityBackgroundOwnerVersion == request.ownerVersion &&
+            activityBackgroundOwner == request.owner) {
+            activityBackgroundOwner = null
+            activityBackgroundOwnerVersion += 1L
+        }
+        if (latestActivityRequestGeneration == request.generation) {
+            latestActivityRequestGeneration = 0L
+        }
+        val remove = currentActivity()?.takeUnless { hasActivityOwner() }
+        if (remove != null) activityActive = false
+        persistActivity()
+        return remove
+    }
+
+    @Synchronized
+    fun isCurrentActivity(generation: Long, activeServiceGeneration: Long?): Boolean =
+        activityActive &&
+            activityConfirmedGeneration == generation &&
+            (activityStandaloneRequested || activityBackgroundOwner == activeServiceGeneration)
+
+    @Synchronized
+    fun <T> withCurrentActivity(
+        generation: Long,
+        activeServiceGeneration: Long?,
+        work: (ownerServiceGeneration: Long?) -> T
+    ): T? {
+        if (!isCurrentActivity(generation, activeServiceGeneration)) return null
+        val activeOwner = activityBackgroundOwner?.takeIf { it == activeServiceGeneration }
+        return work(activeOwner)
+    }
+
+    @Synchronized
+    fun invalidateForReset(editor: SharedPreferences.Editor) {
+        locationActive = false
+        locationOwner = null
+        activityActive = false
+        activityBackgroundOwner = null
+        activityStandaloneRequested = false
+        latestActivityRequestGeneration = 0L
+        activityBackgroundOwnerVersion += 1L
+        activityStandaloneOwnerVersion += 1L
+        editor
+            .putLong(PREF_SERVICE_GENERATION, serviceGeneration)
+            .putLong(PREF_LOCATION_REGISTRATION_GENERATION, locationGeneration)
+            .putBoolean(PREF_LOCATION_REGISTRATION_ACTIVE, false)
+            .putLong(PREF_LOCATION_REGISTRATION_OWNER, NO_SERVICE_OWNER)
+            .putLong(PREF_ACTIVITY_REGISTRATION_GENERATION, activityGeneration)
+            .putLong(PREF_ACTIVITY_CONFIRMED_GENERATION, activityConfirmedGeneration)
+            .putBoolean(PREF_ACTIVITY_REGISTRATION_ACTIVE, false)
+            .putLong(PREF_ACTIVITY_REGISTRATION_OWNER, NO_SERVICE_OWNER)
+            .putBoolean(PREF_ACTIVITY_STANDALONE_REQUESTED, false)
+    }
+
+    private fun currentLocation(): BackgroundRegistration? =
+        if (locationActive) BackgroundRegistration(locationGeneration, locationOwner) else null
+
+    private fun currentActivity(): BackgroundActivityRegistration? =
+        if (activityActive) {
+            BackgroundActivityRegistration(
+                activityConfirmedGeneration,
+                activityBackgroundOwner,
+                activityStandaloneRequested
+            )
+        } else {
+            null
+        }
+
+    private fun persistLocation() {
+        prefs.edit()
+            .putLong(PREF_LOCATION_REGISTRATION_GENERATION, locationGeneration)
+            .putBoolean(PREF_LOCATION_REGISTRATION_ACTIVE, locationActive)
+            .putLong(PREF_LOCATION_REGISTRATION_OWNER, locationOwner ?: NO_SERVICE_OWNER)
+            .apply()
+    }
+
+    private fun persistActivity() {
+        prefs.edit()
+            .putLong(PREF_ACTIVITY_REGISTRATION_GENERATION, activityGeneration)
+            .putLong(PREF_ACTIVITY_CONFIRMED_GENERATION, activityConfirmedGeneration)
+            .putBoolean(PREF_ACTIVITY_REGISTRATION_ACTIVE, activityActive)
+            .putLong(PREF_ACTIVITY_REGISTRATION_OWNER, activityBackgroundOwner ?: NO_SERVICE_OWNER)
+            .putBoolean(PREF_ACTIVITY_STANDALONE_REQUESTED, activityStandaloneRequested)
+            .apply()
+    }
+
+    private fun hasActivityOwner(): Boolean =
+        activityStandaloneRequested || activityBackgroundOwner != null
+
+    private fun SharedPreferences.owner(key: String): Long? =
+        getLong(key, NO_SERVICE_OWNER).takeUnless { it == NO_SERVICE_OWNER }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntent.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntent.kt
@@ -1,0 +1,75 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.Context
+import android.content.Intent
+import com.margelo.nitro.nitrogeolocation.AndroidForegroundServiceOptions
+
+private const val EXTRA_NOTIFICATION_ID = "nitro.background.notificationId"
+private const val EXTRA_NOTIFICATION_TITLE = "nitro.background.notificationTitle"
+private const val EXTRA_NOTIFICATION_TEXT = "nitro.background.notificationText"
+private const val EXTRA_NOTIFICATION_CHANNEL_ID = "nitro.background.notificationChannelId"
+private const val EXTRA_NOTIFICATION_CHANNEL_NAME = "nitro.background.notificationChannelName"
+private const val EXTRA_NOTIFICATION_CHANNEL_DESCRIPTION = "nitro.background.notificationChannelDescription"
+private const val EXTRA_NOTIFICATION_ICON = "nitro.background.notificationIcon"
+private const val EXTRA_NOTIFICATION_COLOR = "nitro.background.notificationColor"
+private const val EXTRA_STOP_ACTION_TITLE = "nitro.background.stopActionTitle"
+
+internal fun backgroundServiceIntent(
+    context: Context,
+    serviceGeneration: Long,
+    options: AndroidForegroundServiceOptions
+): Intent = Intent(context, NitroBackgroundLocationService::class.java)
+    .putExtra(EXTRA_SERVICE_GENERATION, serviceGeneration)
+    .apply {
+        options.notificationId?.let { putExtra(EXTRA_NOTIFICATION_ID, it) }
+        putExtra(EXTRA_NOTIFICATION_TITLE, options.notificationTitle)
+        putExtra(EXTRA_NOTIFICATION_TEXT, options.notificationText)
+        putExtra(EXTRA_NOTIFICATION_CHANNEL_ID, options.notificationChannelId)
+        putExtra(EXTRA_NOTIFICATION_CHANNEL_NAME, options.notificationChannelName)
+        putExtra(EXTRA_NOTIFICATION_CHANNEL_DESCRIPTION, options.notificationChannelDescription)
+        putExtra(EXTRA_NOTIFICATION_ICON, options.notificationIcon)
+        putExtra(EXTRA_NOTIFICATION_COLOR, options.notificationColor)
+        putExtra(EXTRA_STOP_ACTION_TITLE, options.stopActionTitle)
+    }
+
+internal fun Intent.backgroundServiceGeneration(): Long? = takeIf {
+    it.hasExtra(EXTRA_SERVICE_GENERATION)
+}?.getLongExtra(EXTRA_SERVICE_GENERATION, MISSING_RUN_GENERATION)
+
+internal fun resolveBackgroundServiceGeneration(
+    requestedGeneration: Long?,
+    durableRunningGeneration: Long?
+): Long? = requestedGeneration ?: durableRunningGeneration
+
+internal fun Intent.backgroundNotificationOptions(): AndroidForegroundServiceOptions? {
+    val title = getStringExtra(EXTRA_NOTIFICATION_TITLE) ?: return null
+    val text = getStringExtra(EXTRA_NOTIFICATION_TEXT) ?: return null
+    return AndroidForegroundServiceOptions(
+        takeIf { hasExtra(EXTRA_NOTIFICATION_ID) }?.getDoubleExtra(EXTRA_NOTIFICATION_ID, 0.0),
+        title,
+        text,
+        getStringExtra(EXTRA_NOTIFICATION_CHANNEL_ID),
+        getStringExtra(EXTRA_NOTIFICATION_CHANNEL_NAME),
+        getStringExtra(EXTRA_NOTIFICATION_CHANNEL_DESCRIPTION),
+        getStringExtra(EXTRA_NOTIFICATION_ICON),
+        getStringExtra(EXTRA_NOTIFICATION_COLOR),
+        getStringExtra(EXTRA_STOP_ACTION_TITLE)
+    )
+}
+
+internal fun persistedBackgroundNotificationOptions(context: Context): AndroidForegroundServiceOptions? =
+    NitroBackgroundConfigStore(
+        context.getSharedPreferences(BACKGROUND_LOCATION_PREFS, Context.MODE_PRIVATE)
+    ).restore()?.android?.foregroundService
+
+internal fun fallbackBackgroundNotificationOptions() = AndroidForegroundServiceOptions(
+    null,
+    "Background location",
+    "Location tracking is active",
+    "nitro-background-location",
+    "Background Location",
+    null,
+    null,
+    null,
+    null
+)

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceStartup.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceStartup.kt
@@ -1,0 +1,93 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+internal class NitroBackgroundServiceStartup {
+    private data class Attempt(
+        val completion: CompletableFuture<Throwable?> = CompletableFuture(),
+        val activityRequired: Boolean,
+        @Volatile var foregroundPromoted: Boolean = false,
+        @Volatile var locationProviderRegistered: Boolean = false,
+        @Volatile var activityProviderRegistered: Boolean = false
+    )
+
+    private val attempts = ConcurrentHashMap<Long, Attempt>()
+
+    fun begin(serviceGeneration: Long, activityRequired: Boolean = false) {
+        check(beginIfAbsent(serviceGeneration, activityRequired)) {
+            "Service generation $serviceGeneration is already starting"
+        }
+    }
+
+    fun beginIfAbsent(serviceGeneration: Long, activityRequired: Boolean = false): Boolean =
+        attempts.putIfAbsent(
+            serviceGeneration,
+            Attempt(activityRequired = activityRequired)
+        ) == null
+
+    fun foregroundPromoted(serviceGeneration: Long) {
+        attempts[serviceGeneration]?.let { attempt ->
+            attempt.foregroundPromoted = true
+            completeIfReady(attempt)
+        }
+    }
+
+    fun providerRegistered(serviceGeneration: Long): Boolean {
+        val attempt = attempts[serviceGeneration] ?: return false
+        check(attempt.foregroundPromoted) {
+            "Service generation $serviceGeneration registered before foreground promotion"
+        }
+        attempt.locationProviderRegistered = true
+        return completeIfReady(attempt)
+    }
+
+    fun activityProviderRegistered(serviceGeneration: Long): Boolean {
+        val attempt = attempts[serviceGeneration] ?: return false
+        check(attempt.foregroundPromoted) {
+            "Service generation $serviceGeneration registered activity before foreground promotion"
+        }
+        attempt.activityProviderRegistered = true
+        return completeIfReady(attempt)
+    }
+
+    fun fail(serviceGeneration: Long, failure: Throwable) {
+        attempts[serviceGeneration]?.completion?.complete(failure)
+    }
+
+    fun stopped(serviceGeneration: Long) {
+        fail(
+            serviceGeneration,
+            IllegalStateException("Foreground service stopped before provider registration")
+        )
+    }
+
+    fun isComplete(serviceGeneration: Long): Boolean {
+        return attempts[serviceGeneration]?.completion?.isDone == true
+    }
+
+    fun await(serviceGeneration: Long, timeoutMs: Long): Throwable? {
+        val attempt = checkNotNull(attempts[serviceGeneration]) {
+            "Service generation $serviceGeneration was not prepared"
+        }
+        return try {
+            attempt.completion.get(timeoutMs, TimeUnit.MILLISECONDS)
+        } finally {
+            attempts.remove(serviceGeneration, attempt)
+        }
+    }
+
+    fun discard(serviceGeneration: Long) {
+        attempts.remove(serviceGeneration)
+    }
+
+    private fun completeIfReady(attempt: Attempt): Boolean {
+        if (attempt.foregroundPromoted &&
+            attempt.locationProviderRegistered &&
+            (!attempt.activityRequired || attempt.activityProviderRegistered)) {
+            return attempt.completion.complete(null)
+        }
+        return false
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceState.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceState.kt
@@ -1,0 +1,16 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+/** Process-local observation of the actual Android foreground-service lifecycle. */
+internal object NitroBackgroundServiceState {
+    @Volatile
+    var isForeground: Boolean = false
+        private set
+
+    fun promoted() {
+        isForeground = true
+    }
+
+    fun stopped() {
+        isForeground = false
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStatusReader.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStatusReader.kt
@@ -1,0 +1,50 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.location.LocationManager
+import com.margelo.nitro.nitrogeolocation.AndroidBackgroundLocationStatus
+import com.margelo.nitro.nitrogeolocation.BackgroundLocationState
+import com.margelo.nitro.nitrogeolocation.BackgroundLocationStatus
+import com.margelo.nitro.nitrogeolocation.LocationError
+
+internal fun readBackgroundLocationStatus(
+    context: Context,
+    prefs: SharedPreferences,
+    store: NitroBackgroundStore,
+    permissions: AndroidBackgroundPermissions,
+    state: BackgroundLocationState,
+    hasInMemoryConfig: Boolean,
+    lastError: LocationError?
+): BackgroundLocationStatus {
+    val providerEnabled = runCatching {
+        val manager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        manager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
+            manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+    }.getOrDefault(false)
+    val storeSnapshot = store.snapshot()
+    val running = prefs.getBoolean("running", false)
+
+    return BackgroundLocationStatus(
+        state,
+        running,
+        hasInMemoryConfig || prefs.getBoolean("configured", false),
+        permissions.foregroundPermission(),
+        permissions.backgroundPermission(),
+        permissions.accuracyAuthorization(),
+        providerEnabled,
+        null,
+        storeSnapshot.storedLocationCount,
+        storeSnapshot.storedEventCount,
+        storeSnapshot.lastLocationAt,
+        storeSnapshot.lastEventAt,
+        storeSnapshot.geofenceCount,
+        AndroidBackgroundLocationStatus(
+            NitroBackgroundServiceState.isForeground,
+            null,
+            permissions.notificationPermission()
+        ),
+        null,
+        lastError
+    )
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
@@ -26,6 +26,14 @@ import com.margelo.nitro.core.NullType
 import org.json.JSONArray
 import org.json.JSONObject
 
+internal data class NitroBackgroundStoreSnapshot(
+    val storedLocationCount: Double,
+    val storedEventCount: Double,
+    val lastLocationAt: Double?,
+    val lastEventAt: Double?,
+    val geofenceCount: Double
+)
+
 class NitroBackgroundStore(context: Context) :
     SQLiteOpenHelper(context, "nitro_background_location.db", null, 3) {
 
@@ -335,15 +343,29 @@ class NitroBackgroundStore(context: Context) :
         }
     }
 
-    fun count(table: String): Double {
-        val cursor = readableDatabase.rawQuery("SELECT COUNT(*) FROM $table", null)
+    internal fun snapshot(): NitroBackgroundStoreSnapshot {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT
+              (SELECT COUNT(*) FROM background_locations),
+              (SELECT COUNT(*) FROM background_events),
+              (SELECT MAX(recorded_at) FROM background_locations),
+              (SELECT MAX(timestamp) FROM background_events),
+              (SELECT COUNT(*) FROM geofences)
+            """.trimIndent(),
+            null
+        )
         return cursor.use {
-            if (it.moveToFirst()) it.getLong(0).toDouble() else 0.0
+            check(it.moveToFirst()) { "Failed to read background store snapshot" }
+            NitroBackgroundStoreSnapshot(
+                it.getLong(0).toDouble(),
+                it.getLong(1).toDouble(),
+                if (it.isNull(2)) null else it.getDouble(2),
+                if (it.isNull(3)) null else it.getDouble(3),
+                it.getLong(4).toDouble()
+            )
         }
     }
-
-    fun lastLocationAt(): Double? = maxValue("background_locations", "recorded_at")
-    fun lastEventAt(): Double? = maxValue("background_events", "timestamp")
 
     fun markSynced(ids: List<String>) {
         if (ids.isEmpty()) return
@@ -368,13 +390,6 @@ class NitroBackgroundStore(context: Context) :
             """.trimIndent(),
             arrayOf(limit.toString())
         )
-    }
-
-    private fun maxValue(table: String, column: String): Double? {
-        val cursor = readableDatabase.rawQuery("SELECT MAX($column) FROM $table", null)
-        return cursor.use {
-            if (it.moveToFirst() && !it.isNull(0)) it.getDouble(0) else null
-        }
     }
 
     private fun getLocationById(id: String): StoredBackgroundLocation? {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
@@ -342,6 +342,9 @@ class NitroBackgroundStore(context: Context) :
         }
     }
 
+    fun lastLocationAt(): Double? = maxValue("background_locations", "recorded_at")
+    fun lastEventAt(): Double? = maxValue("background_events", "timestamp")
+
     fun markSynced(ids: List<String>) {
         if (ids.isEmpty()) return
         val placeholders = ids.joinToString(",") { "?" }
@@ -365,6 +368,13 @@ class NitroBackgroundStore(context: Context) :
             """.trimIndent(),
             arrayOf(limit.toString())
         )
+    }
+
+    private fun maxValue(table: String, column: String): Double? {
+        val cursor = readableDatabase.rawQuery("SELECT MAX($column) FROM $table", null)
+        return cursor.use {
+            if (it.moveToFirst() && !it.isNull(0)) it.getDouble(0) else null
+        }
     }
 
     private fun getLocationById(id: String): StoredBackgroundLocation? {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncCoordinator.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncCoordinator.kt
@@ -1,0 +1,208 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.margelo.nitro.nitrogeolocation.BackgroundHttpSyncOptions
+import com.margelo.nitro.nitrogeolocation.BackgroundHttpSyncResult
+import com.margelo.nitro.nitrogeolocation.GetStoredBackgroundLocationsOptions
+import com.margelo.nitro.nitrogeolocation.StoredBackgroundLocation
+
+private data class NitroBackgroundSyncBatch(
+    val runGeneration: Long,
+    val configRevision: Long,
+    val sync: BackgroundHttpSyncOptions,
+    val locations: Array<StoredBackgroundLocation>
+)
+
+internal fun shouldEnforceSyncInterval(
+    continuationConfigRevision: Long?,
+    currentConfigRevision: Long
+): Boolean = continuationConfigRevision != currentConfigRevision
+
+/** Snapshots storage before entering the registration/throttle gate to keep lock order acyclic. */
+internal class NitroBackgroundSyncAdmission {
+    fun <T : Any> reserve(
+        snapshot: () -> T?,
+        reserveGate: () -> Boolean
+    ): T? {
+        val candidate = snapshot() ?: return null
+        return candidate.takeIf { reserveGate() }
+    }
+}
+
+/** Owns serial HTTP-sync admission, upload, and result persistence. */
+internal class NitroBackgroundSyncCoordinator(
+    private val store: NitroBackgroundStore,
+    private val httpSync: AndroidBackgroundHttpSync,
+    private val gate: NitroBackgroundSyncGate,
+    private val lifecycleLock: Any,
+    private val storageLock: Any,
+    private val currentRunGeneration: () -> Long,
+    private val currentConfigRevision: () -> Long,
+    private val manualSyncConfig: () -> BackgroundHttpSyncOptions?,
+    private val automaticSyncConfig: (Long) -> BackgroundHttpSyncOptions?,
+    private val isActiveRegistration: (Long, Long) -> Boolean
+) {
+    private val queue = NitroBackgroundSyncQueue()
+    private val admission = NitroBackgroundSyncAdmission()
+
+    fun syncManual(callbackGeneration: Long): BackgroundHttpSyncResult =
+        queue.runManual {
+            val batch = synchronized(lifecycleLock) {
+                check(currentRunGeneration() == callbackGeneration) {
+                    "Background location run was reset"
+                }
+                val sync = manualSyncConfig() ?: return@synchronized null
+                synchronized(storageLock) {
+                    selectBatch(callbackGeneration, sync)
+                }
+            } ?: return@runManual emptySyncResult()
+            perform(batch)
+        }
+
+    fun scheduleAutomatic(
+        callbackGeneration: Long,
+        registrationGeneration: Long,
+        serviceGeneration: Long,
+        onResult: (BackgroundHttpSyncResult) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        val scheduledConfigRevision = currentConfigRevision()
+        var continuationConfigRevision: Long? = null
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(
+                callbackGeneration,
+                registrationGeneration,
+                serviceGeneration,
+                scheduledConfigRevision
+            ),
+            reserve = {
+                reserveAutomatic(
+                    callbackGeneration,
+                    registrationGeneration,
+                    serviceGeneration,
+                    continuationConfigRevision
+                )
+            },
+            perform = { batch ->
+                val result = runCatching { perform(batch) }.getOrElse { error ->
+                    BackgroundHttpSyncResult(
+                        false,
+                        null,
+                        emptyArray(),
+                        batch.locations.map { it.id }.toTypedArray(),
+                        error.message ?: "HTTP sync failed"
+                    )
+                }
+                onResult(result)
+                val shouldContinue = result.success && result.syncedLocationIds.isNotEmpty()
+                if (shouldContinue) continuationConfigRevision = batch.configRevision
+                shouldContinue
+            },
+            continuationKey = { batch ->
+                NitroBackgroundSyncKey(
+                    callbackGeneration,
+                    registrationGeneration,
+                    serviceGeneration,
+                    batch.configRevision
+                )
+            },
+            onFailure = onFailure
+        )
+    }
+
+    private fun reserveAutomatic(
+        callbackGeneration: Long,
+        registrationGeneration: Long,
+        serviceGeneration: Long,
+        continuationConfigRevision: Long?
+    ): NitroBackgroundSyncBatch? = synchronized(lifecycleLock) {
+        if (!isActiveRegistration(
+                callbackGeneration,
+                registrationGeneration
+            )) return@synchronized null
+        val sync = automaticSyncConfig(callbackGeneration)
+            ?: return@synchronized null
+        val configRevision = currentConfigRevision()
+        val interval = if (shouldEnforceSyncInterval(
+                continuationConfigRevision,
+                configRevision
+            )) {
+            sync.syncInterval?.toLong()?.takeIf { it > 0 } ?: 0L
+        } else {
+            0L
+        }
+        admission.reserve(
+            snapshot = {
+                synchronized(storageLock) {
+                    val threshold = sync.syncThreshold?.toInt()
+                        ?.takeIf { it > 0 } ?: 1
+                    val batchSize = sync.batchSize?.toInt()
+                        ?.takeIf { it > 0 } ?: 50
+                    val candidates = store.getLocations(
+                        GetStoredBackgroundLocationsOptions(
+                            maxOf(threshold, batchSize).toDouble(),
+                            null,
+                            true,
+                            false
+                        )
+                    )
+                    if (candidates.size < threshold) {
+                        null
+                    } else {
+                        NitroBackgroundSyncBatch(
+                            callbackGeneration,
+                            configRevision,
+                            sync,
+                            candidates.take(batchSize).toTypedArray()
+                        )
+                    }
+                }
+            },
+            reserveGate = {
+                gate.reserve(
+                    registrationGeneration,
+                    serviceGeneration,
+                    interval,
+                    System.currentTimeMillis()
+                )
+            }
+        )
+    }
+
+    private fun selectBatch(
+        callbackGeneration: Long,
+        sync: BackgroundHttpSyncOptions
+    ): NitroBackgroundSyncBatch? {
+        val locations = store.getLocations(
+            GetStoredBackgroundLocationsOptions(
+                sync.batchSize ?: 50.0,
+                null,
+                true,
+                false
+            )
+        )
+        return locations.takeIf { it.isNotEmpty() }?.let {
+            NitroBackgroundSyncBatch(
+                callbackGeneration,
+                currentConfigRevision(),
+                sync,
+                it
+            )
+        }
+    }
+
+    private fun perform(batch: NitroBackgroundSyncBatch): BackgroundHttpSyncResult {
+        val result = httpSync.uploadLocationsWithRetry(batch.sync, batch.locations)
+        synchronized(storageLock) {
+            if (currentRunGeneration() == batch.runGeneration) {
+                store.markSynced(result.syncedLocationIds.toList())
+                if (batch.sync.autoClear == true) {
+                    store.clearLocations(result.syncedLocationIds)
+                }
+            }
+        }
+        return result
+    }
+
+    private fun emptySyncResult() =
+        BackgroundHttpSyncResult(true, null, emptyArray(), emptyArray(), null)
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncGate.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncGate.kt
@@ -1,0 +1,27 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.SharedPreferences
+
+/** Reserves an automatic sync only while the scheduling provider still owns registration. */
+internal class NitroBackgroundSyncGate(
+    private val registrations: NitroBackgroundRegistrations,
+    private val prefs: SharedPreferences
+) {
+    fun reserve(
+        registrationGeneration: Long,
+        serviceGeneration: Long,
+        intervalMs: Long,
+        nowMs: Long
+    ): Boolean = registrations.withCurrentLocation(
+        registrationGeneration,
+        serviceGeneration
+    ) {
+        val lastSyncAt = prefs.getLong("lastSyncAt", 0L)
+        if (intervalMs > 0L && nowMs - lastSyncAt < intervalMs) {
+            false
+        } else {
+            prefs.edit().putLong("lastSyncAt", nowMs).apply()
+            true
+        }
+    } == true
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncQueue.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncQueue.kt
@@ -1,0 +1,128 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+internal data class NitroBackgroundSyncKey(
+    val runGeneration: Long,
+    val registrationGeneration: Long,
+    val serviceGeneration: Long,
+    val configRevision: Long = 0
+) : Comparable<NitroBackgroundSyncKey> {
+    override fun compareTo(other: NitroBackgroundSyncKey): Int {
+        val runOrder = runGeneration.compareTo(other.runGeneration)
+        if (runOrder != 0) return runOrder
+        val registrationOrder = registrationGeneration.compareTo(other.registrationGeneration)
+        if (registrationOrder != 0) return registrationOrder
+        val serviceOrder = serviceGeneration.compareTo(other.serviceGeneration)
+        if (serviceOrder != 0) return serviceOrder
+        return configRevision.compareTo(other.configRevision)
+    }
+
+    companion object {
+        val DEFAULT = NitroBackgroundSyncKey(0, 0, 0, 0)
+    }
+}
+
+/** Gives manual and automatic HTTP sync one serial admission and upload boundary. */
+internal class NitroBackgroundSyncQueue(
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+) {
+    private data class AutomaticWork(
+        val key: NitroBackgroundSyncKey,
+        val runOnce: () -> NitroBackgroundSyncKey?
+    )
+
+    private val pendingAutomatic = AtomicReference<AutomaticWork?>(null)
+    private val automaticDrainScheduled = AtomicBoolean(false)
+
+    fun <T> runManual(work: () -> T): T {
+        return try {
+            executor.submit(Callable { work() }).get()
+        } catch (error: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw error
+        } catch (error: ExecutionException) {
+            throw error.cause ?: error
+        }
+    }
+
+    fun <T : Any> scheduleAutomatic(
+        key: NitroBackgroundSyncKey = NitroBackgroundSyncKey.DEFAULT,
+        reserve: () -> T?,
+        perform: (T) -> Boolean,
+        continuationKey: (T) -> NitroBackgroundSyncKey = { key },
+        onSkipped: () -> Unit = {},
+        onFailure: (Exception) -> Unit = {
+            NitroGeoLog.e("Automatic background HTTP sync failed", it)
+        }
+    ) {
+        val work = AutomaticWork(
+            key = key,
+            runOnce = {
+                try {
+                    val reservation = reserve()
+                    if (reservation == null) {
+                        onSkipped()
+                        null
+                    } else {
+                        if (perform(reservation)) continuationKey(reservation) else null
+                    }
+                } catch (error: Exception) {
+                    if (error is InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                    runCatching { onFailure(error) }.onFailure {
+                        NitroGeoLog.e("Failed to report automatic HTTP sync error", it)
+                    }
+                    null
+                }
+            }
+        )
+        offerAutomatic(work, replaceSameKey = false)
+        scheduleAutomaticDrainIfNeeded()
+    }
+
+    private fun offerAutomatic(work: AutomaticWork, replaceSameKey: Boolean) {
+        while (true) {
+            val current = pendingAutomatic.get()
+            if (current != null) {
+                val order = work.key.compareTo(current.key)
+                if (order < 0 || (order == 0 && !replaceSameKey)) return
+            }
+            if (pendingAutomatic.compareAndSet(current, work)) return
+        }
+    }
+
+    private fun scheduleAutomaticDrainIfNeeded() {
+        if (!automaticDrainScheduled.compareAndSet(false, true)) return
+        executor.execute {
+            try {
+                val work = pendingAutomatic.getAndSet(null)
+                val continuationKey = work?.runOnce()
+                if (work != null && continuationKey != null) {
+                    // A successful batch gets the same priority as its run so a late stale
+                    // callback cannot displace the follow-up. A newer run always wins.
+                    offerAutomatic(
+                        work.copy(key = continuationKey),
+                        replaceSameKey = true
+                    )
+                }
+            } finally {
+                automaticDrainScheduled.set(false)
+                if (pendingAutomatic.get() != null) {
+                    scheduleAutomaticDrainIfNeeded()
+                }
+            }
+        }
+    }
+
+    internal fun close() {
+        pendingAutomatic.set(null)
+        executor.shutdownNow()
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBootReceiver.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBootReceiver.kt
@@ -13,25 +13,20 @@ class NitroBootReceiver : BroadcastReceiver() {
             return
         }
 
-        // registerPersistedGeofencesIfNeeded() blocks (waitForTask, up to 30s) and start() does
-        // disk I/O; running them inline would block the broadcast's main thread and risk an ANR.
-        // Hand off to a worker thread and keep the broadcast alive with goAsync() until it finishes.
-        val appContext = context.applicationContext
-        val pendingResult = goAsync()
-        Thread {
-            try {
-                val prefs = appContext.getSharedPreferences(
-                    "nitro_background_location",
-                    Context.MODE_PRIVATE
-                )
-                val controller = NitroBackgroundLocationController.getInstance(appContext)
-                runCatching { controller.registerPersistedGeofencesIfNeeded() }
-                if (prefs.getBoolean("startOnBoot", false)) {
-                    runCatching { controller.start(null) }
-                }
-            } finally {
-                pendingResult.finish()
+        if (!NitroBootRestoreJobService.schedule(context.applicationContext)) {
+            NitroGeoLog.e("Failed to schedule background restoration after boot")
+        }
+        val prefs = context.getSharedPreferences(
+            BACKGROUND_LOCATION_PREFS,
+            Context.MODE_PRIVATE
+        )
+        if (prefs.getBoolean("startOnBoot", false)) {
+            runCatching {
+                NitroBackgroundLocationController.getInstance(context.applicationContext)
+                    .startFromBoot()
+            }.onFailure { error ->
+                NitroGeoLog.e("Failed to request background tracking after boot", error)
             }
-        }.start()
+        }
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBootRestoreJobService.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBootRestoreJobService.kt
@@ -1,0 +1,90 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.job.JobInfo
+import android.app.job.JobParameters
+import android.app.job.JobScheduler
+import android.app.job.JobService
+import android.content.ComponentName
+import android.content.Context
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+internal class NitroBootRestoreWork(
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+) {
+    @Volatile
+    private var future: Future<*>? = null
+
+    fun start(restore: () -> Unit, complete: (failed: Boolean) -> Unit) {
+        future?.cancel(true)
+        future = executor.submit {
+            val failure = runCatching(restore).exceptionOrNull()
+            if (failure is InterruptedException || Thread.currentThread().isInterrupted) return@submit
+            complete(failure != null)
+        }
+    }
+
+    fun cancel() {
+        future?.cancel(true)
+        future = null
+    }
+
+    fun shutdown() {
+        cancel()
+        executor.shutdownNow()
+    }
+}
+
+/** Runs boot restoration under an OS-owned lifetime instead of a broadcast deadline. */
+class NitroBootRestoreJobService : JobService() {
+    private val work = NitroBootRestoreWork()
+
+    @Volatile
+    private var activeParameters: JobParameters? = null
+
+    override fun onStartJob(params: JobParameters): Boolean {
+        activeParameters = params
+        work.start(
+            restore = {
+                NitroBackgroundLocationController.getInstance(applicationContext)
+                    .registerPersistedGeofencesBlockingIfNeeded()
+            },
+            complete = { restoreFailed ->
+                if (activeParameters === params) {
+                    activeParameters = null
+                    jobFinished(params, restoreFailed)
+                }
+            }
+        )
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters): Boolean {
+        if (activeParameters === params) {
+            activeParameters = null
+            work.cancel()
+        }
+        return true
+    }
+
+    override fun onDestroy() {
+        work.shutdown()
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val JOB_ID = 0x4E47424F
+
+        fun schedule(context: Context): Boolean {
+            val scheduler = context.getSystemService(JobScheduler::class.java)
+            val job = JobInfo.Builder(
+                JOB_ID,
+                ComponentName(context, NitroBootRestoreJobService::class.java)
+            )
+                .setBackoffCriteria(30_000L, JobInfo.BACKOFF_POLICY_EXPONENTIAL)
+                .build()
+            return scheduler.schedule(job) == JobScheduler.RESULT_SUCCESS
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroGeofenceReceiver.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroGeofenceReceiver.kt
@@ -9,6 +9,10 @@ class NitroGeofenceReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val event = GeofencingEvent.fromIntent(intent) ?: return
         if (event.hasError()) return
-        NitroBackgroundLocationController.getInstance(context).handleGeofenceEvent(event)
+        val controller = NitroBackgroundLocationController.getInstance(context)
+        controller.handleGeofenceEvent(
+            event,
+            intent.getLongExtra(EXTRA_RUN_GENERATION, MISSING_RUN_GENERATION)
+        )
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroLocationUpdateReceiver.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroLocationUpdateReceiver.kt
@@ -13,6 +13,14 @@ class NitroLocationUpdateReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         NitroGeoLog.d("LocationUpdateReceiver.onReceive(): action=${intent.action}")
         val controller = NitroBackgroundLocationController.getInstance(context)
+        val generation = intent.getLongExtra(
+            EXTRA_RUN_GENERATION,
+            MISSING_RUN_GENERATION
+        )
+        val registrationGeneration = intent.getLongExtra(
+            EXTRA_REGISTRATION_GENERATION,
+            MISSING_REGISTRATION_GENERATION
+        )
         val platformLocation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.getParcelableExtra(LocationManager.KEY_LOCATION_CHANGED, Location::class.java)
         } else {
@@ -22,7 +30,9 @@ class NitroLocationUpdateReceiver : BroadcastReceiver() {
         if (platformLocation != null) {
             controller.handleNativeLocation(
                 platformLocation,
-                BackgroundLocationSource.FOREGROUNDSERVICE
+                BackgroundLocationSource.FOREGROUNDSERVICE,
+                generation,
+                registrationGeneration
             )
             return
         }
@@ -40,7 +50,9 @@ class NitroLocationUpdateReceiver : BroadcastReceiver() {
         for (location in result.locations) {
             controller.handleNativeLocation(
                 location,
-                BackgroundLocationSource.FOREGROUNDSERVICE
+                BackgroundLocationSource.FOREGROUNDSERVICE,
+                generation,
+                registrationGeneration
             )
         }
     }

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
@@ -35,6 +35,14 @@ class BackgroundDecisionsTest {
     }
 
     @Test
+    fun pendingIntentIdentityChangesBetweenRuns() {
+        assertFalse(
+            pendingIntentIdentityUri("location", 7L) ==
+                pendingIntentIdentityUri("location", 8L)
+        )
+    }
+
+    @Test
     fun backoffGrowsExponentiallyThenCaps() {
         assertEquals(1_000L, backoffBaseDelayMs(0, 1_000L, 30_000L))
         assertEquals(2_000L, backoffBaseDelayMs(1, 1_000L, 30_000L))
@@ -74,4 +82,49 @@ class BackgroundDecisionsTest {
     fun headlessTaskRunsWhenNoInProcessListenerReceivedEvent() {
         assertTrue(shouldDispatchHeadlessTask(false))
     }
+
+    @Test
+    fun persistenceRejectsCallbacksFromAnInvalidatedRun() {
+        assertFalse(shouldPersistForGeneration(true, true, 2L, 1L))
+    }
+
+    @Test
+    fun persistenceRejectsAnUnconfiguredRun() {
+        assertFalse(shouldPersistForGeneration(false, null, 1L, 1L))
+    }
+
+    @Test
+    fun persistenceKeepsTheConfiguredDefault() {
+        assertTrue(shouldPersistForGeneration(true, null, 1L, 1L))
+    }
+
+    @Test
+    fun standalonePersistenceKeepsTheDefaultWithoutLocationConfiguration() {
+        assertTrue(shouldPersistForGeneration(false, null, 1L, 1L, true))
+    }
+
+    @Test
+    fun standalonePersistenceStillHonorsAnExplicitOptOut() {
+        assertFalse(shouldPersistForGeneration(true, false, 1L, 1L, true))
+    }
+
+    @Test
+    fun registrationGenerationAdvancesWithinTheSameResetRun() {
+        assertEquals(8L, nextRegistrationGeneration(7L))
+    }
+
+    @Test
+    fun registrationCallbackRequiresTheCurrentRunAndRegistration() {
+        assertTrue(isCurrentRegistration(3L, 9L, 3L, 9L))
+        assertFalse(isCurrentRegistration(3L, 9L, 2L, 9L))
+        assertFalse(isCurrentRegistration(3L, 9L, 3L, 8L))
+    }
+
+    @Test
+    fun startupFailureOnlyAppliesToTheFailingActiveService() {
+        assertTrue(shouldApplyStartupFailure(9L, 9L))
+        assertFalse(shouldApplyStartupFailure(10L, 9L))
+        assertFalse(shouldApplyStartupFailure(null, 9L))
+    }
+
 }

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundActivityCoordinatorTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundActivityCoordinatorTest.kt
@@ -1,0 +1,162 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.PendingIntent
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.android.gms.tasks.Tasks
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundActivityCoordinatorTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun failedBackgroundReplacementKeepsConfirmedStandaloneRegistration() {
+        val registrations = registrations("activity-coordinator-replacement")
+        val requestCount = AtomicInteger()
+        val coordinator = coordinator(registrations) { _, _ ->
+            if (requestCount.incrementAndGet() == 1) {
+                Tasks.forResult<Void>(null)
+            } else {
+                Tasks.forException(IllegalStateException("provider rejected replacement"))
+            }
+        }
+
+        coordinator.start(1_000L, null).get(2, TimeUnit.SECONDS)
+        val service = registrations.nextServiceGeneration()
+        assertThrows(ExecutionException::class.java) {
+            coordinator.start(1_000L, service).get(2, TimeUnit.SECONDS)
+        }
+
+        assertTrue(registrations.isCurrentActivity(1L, null))
+        assertFalse(registrations.isCurrentActivity(2L, service))
+    }
+
+    @Test
+    fun stopDuringProviderRequestPreventsLateConfirmation() {
+        val registrations = registrations("activity-coordinator-stop")
+        val providerRequest = TaskCompletionSource<Void>()
+        val coordinator = coordinator(registrations) { _, _ -> providerRequest.task }
+        val start = coordinator.start(1_000L, null)
+
+        val stop = coordinator.stop(null)
+        providerRequest.setResult(null)
+
+        assertThrows(Exception::class.java) { start.get(2, TimeUnit.SECONDS) }
+        stop.get(2, TimeUnit.SECONDS)
+        assertFalse(registrations.isCurrentActivity(1L, null))
+    }
+
+    @Test
+    fun laterRequestCannotBeRolledBackByEarlierCompletion() {
+        val registrations = registrations("activity-coordinator-order")
+        val firstProviderRequest = TaskCompletionSource<Void>()
+        val requestCount = AtomicInteger()
+        val coordinator = coordinator(registrations) { _, _ ->
+            if (requestCount.incrementAndGet() == 1) {
+                firstProviderRequest.task
+            } else {
+                Tasks.forException(IllegalStateException("latest request failed"))
+            }
+        }
+        val service = registrations.nextServiceGeneration()
+        val first = coordinator.start(1_000L, service)
+        val replacement = coordinator.start(2_000L, service)
+
+        firstProviderRequest.setResult(null)
+
+        assertThrows(Exception::class.java) { first.get(2, TimeUnit.SECONDS) }
+        assertThrows(ExecutionException::class.java) {
+            replacement.get(2, TimeUnit.SECONDS)
+        }
+        assertFalse(registrations.isCurrentActivity(1L, service))
+        assertFalse(registrations.isCurrentActivity(2L, service))
+    }
+
+    @Test
+    fun confirmedReplacementSurvivesFailureToRemoveTheOldCallback() {
+        val registrations = registrations("activity-coordinator-cleanup")
+        val coordinator = NitroBackgroundActivityCoordinator(
+            NitroBackgroundPendingIntents(context),
+            registrations,
+            { 0L },
+            { _, _ -> Tasks.forResult<Void>(null) },
+            { Tasks.forException(IllegalStateException("old callback removal failed")) }
+        )
+        coordinator.start(1_000L, null).get(2, TimeUnit.SECONDS)
+        val service = registrations.nextServiceGeneration()
+
+        coordinator.start(1_000L, service).get(2, TimeUnit.SECONDS)
+
+        assertTrue(registrations.isCurrentActivity(2L, service))
+        assertTrue(registrations.isCurrentActivity(2L, null))
+    }
+
+    @Test
+    fun confirmedProviderCompletesBeforeStaleCallbackCleanup() {
+        val registrations = registrations("activity-coordinator-readiness")
+        val cleanup = TaskCompletionSource<Void>()
+        val coordinator = NitroBackgroundActivityCoordinator(
+            NitroBackgroundPendingIntents(context),
+            registrations,
+            { 0L },
+            { _, _ -> Tasks.forResult<Void>(null) },
+            { cleanup.task }
+        )
+        coordinator.start(1_000L, null).get(2, TimeUnit.SECONDS)
+        val service = registrations.nextServiceGeneration()
+        val replacement = coordinator.start(1_000L, service)
+
+        try {
+            replacement.get(200, TimeUnit.MILLISECONDS)
+        } finally {
+            cleanup.trySetResult(null)
+        }
+        assertTrue(registrations.isCurrentActivity(2L, service))
+    }
+
+    @Test
+    fun providerTimeoutRejectsWithoutLeavingTheOwnerActive() {
+        val registrations = registrations("activity-coordinator-timeout")
+        val coordinator = NitroBackgroundActivityCoordinator(
+            NitroBackgroundPendingIntents(context),
+            registrations,
+            { 0L },
+            { _, _ -> TaskCompletionSource<Void>().task },
+            { Tasks.forResult<Void>(null) },
+            TimeUnit.MILLISECONDS.toNanos(10L)
+        )
+
+        assertThrows(ExecutionException::class.java) {
+            coordinator.start(1_000L, null).get(2, TimeUnit.SECONDS)
+        }
+        assertFalse(registrations.isCurrentActivity(1L, null))
+    }
+
+    private fun registrations(name: String): NitroBackgroundRegistrations {
+        val prefs = context.getSharedPreferences(name, 0)
+        prefs.edit().clear().commit()
+        return NitroBackgroundRegistrations(prefs)
+    }
+
+    private fun coordinator(
+        registrations: NitroBackgroundRegistrations,
+        requestUpdates: (Long, PendingIntent) -> com.google.android.gms.tasks.Task<Void>
+    ) = NitroBackgroundActivityCoordinator(
+        NitroBackgroundPendingIntents(context),
+        registrations,
+        { 0L },
+        requestUpdates,
+        { Tasks.forResult<Void>(null) }
+    )
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundErrorStateTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundErrorStateTest.kt
@@ -1,0 +1,44 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import androidx.test.core.app.ApplicationProvider
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundErrorStateTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun resetBarrierSerializesAConcurrentPersistedErrorRestore() {
+        val prefs = context.getSharedPreferences("background-error-state-test", 0)
+        prefs.edit().clear().putInt("lastErrorCode", 2)
+            .putString("lastErrorMessage", "old error").commit()
+        val state = NitroBackgroundErrorState(prefs)
+        val started = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        synchronized(state) {
+            executor.execute {
+                started.countDown()
+                state.current()
+                finished.countDown()
+            }
+            assertTrue(started.await(1, TimeUnit.SECONDS))
+            assertFalse(finished.await(100, TimeUnit.MILLISECONDS))
+        }
+        assertTrue(finished.await(1, TimeUnit.SECONDS))
+        state.clear()
+        assertNull(state.current())
+        executor.shutdownNow()
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHubTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundEventHubTest.kt
@@ -1,0 +1,54 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.margelo.nitro.nitrogeolocation.BackgroundEventEnvelope
+import com.margelo.nitro.nitrogeolocation.BackgroundEventType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class NitroBackgroundEventHubTest {
+    @Test
+    fun removeWaitsForAnActiveListenerAndPreventsFutureDelivery() {
+        val hub = NitroBackgroundEventHub()
+        val callbackStarted = CountDownLatch(1)
+        val releaseCallback = CountDownLatch(1)
+        val removeStarted = CountDownLatch(1)
+        val removeFinished = CountDownLatch(1)
+        val token = hub.addEventListener {
+            callbackStarted.countDown()
+            releaseCallback.await(1, TimeUnit.SECONDS)
+        }
+
+        val emitter = thread { hub.emit(event()) }
+        assertTrue(callbackStarted.await(1, TimeUnit.SECONDS))
+        val remover = thread {
+            removeStarted.countDown()
+            hub.removeEventListener(token)
+            removeFinished.countDown()
+        }
+
+        assertTrue(removeStarted.await(1, TimeUnit.SECONDS))
+        assertFalse(removeFinished.await(100, TimeUnit.MILLISECONDS))
+        releaseCallback.countDown()
+        assertTrue(removeFinished.await(1, TimeUnit.SECONDS))
+        emitter.join()
+        remover.join()
+        assertFalse(hub.emit(event()))
+    }
+
+    private fun event() = BackgroundEventEnvelope(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        "event-id",
+        BackgroundEventType.PROVIDERCHANGE,
+        1.0,
+        false
+    )
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrationsTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundRegistrationsTest.kt
@@ -1,0 +1,172 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.PendingIntent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundRegistrationsTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun delayedOldRemovalCannotCancelTheReplacementPendingIntent() {
+        val pendingIntents = NitroBackgroundPendingIntents(context)
+        val old = pendingIntents.location(3L, 7L)
+        val replacement = pendingIntents.location(3L, 8L)
+
+        assertFalse(old == replacement)
+        old.cancel()
+        replacement.send()
+    }
+
+    @Test
+    fun staleServiceCannotRemoveTheReplacementRegistration() {
+        val prefs = context.getSharedPreferences("registration-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val firstService = registrations.nextServiceGeneration()
+        registrations.replaceLocation(firstService)
+        val secondService = registrations.nextServiceGeneration()
+        val replacement = registrations.replaceLocation(secondService).second
+
+        assertNull(registrations.removeLocation(firstService))
+        assertNull(registrations.removeLocation(secondService + 1L))
+        assertTrue(registrations.isCurrentLocation(replacement.generation, secondService))
+    }
+
+    @Test(expected = PendingIntent.CanceledException::class)
+    fun cancelledOldIdentityStaysCancelled() {
+        val pendingIntents = NitroBackgroundPendingIntents(context)
+        val old = pendingIntents.location(4L, 11L)
+        pendingIntents.location(4L, 12L)
+
+        old.cancel()
+        old.send()
+    }
+
+    @Test
+    fun replacementWaitsForAnInFlightCurrentRegistrationDispatch() {
+        val prefs = context.getSharedPreferences("registration-dispatch-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val service = registrations.nextServiceGeneration()
+        val registration = registrations.replaceLocation(service).second
+        val dispatchEntered = CountDownLatch(1)
+        val releaseDispatch = CountDownLatch(1)
+        val replacementStarted = CountDownLatch(1)
+        val replacementFinished = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        executor.execute {
+            registrations.withCurrentLocation(registration.generation, service) {
+                dispatchEntered.countDown()
+                releaseDispatch.await(1, TimeUnit.SECONDS)
+            }
+        }
+        assertTrue(dispatchEntered.await(1, TimeUnit.SECONDS))
+        executor.execute {
+            replacementStarted.countDown()
+            registrations.replaceLocation(service)
+            replacementFinished.countDown()
+        }
+
+        assertTrue(replacementStarted.await(1, TimeUnit.SECONDS))
+        assertFalse(replacementFinished.await(50, TimeUnit.MILLISECONDS))
+        releaseDispatch.countDown()
+        assertTrue(replacementFinished.await(1, TimeUnit.SECONDS))
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun serviceGenerationReadDoesNotInvertTheDispatchLockOrder() {
+        val prefs = context.getSharedPreferences("registration-generation-lock-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val service = registrations.nextServiceGeneration()
+        val finished = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        synchronized(registrations) {
+            executor.execute {
+                registrations.currentServiceGeneration()
+                finished.countDown()
+            }
+            assertTrue(finished.await(250, TimeUnit.MILLISECONDS))
+        }
+        assertEquals(service, registrations.currentServiceGeneration())
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun standaloneAndBackgroundActivityOwnersReleaseIndependently() {
+        val prefs = context.getSharedPreferences("registration-activity-owner-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val service = registrations.nextServiceGeneration()
+        val standalone = registrations.requestActivity(null)
+        assertTrue(registrations.confirmActivity(standalone).accepted)
+        val background = registrations.requestActivity(service)
+        assertTrue(registrations.confirmActivity(background).accepted)
+
+        assertNull(registrations.removeActivity(service))
+        assertTrue(registrations.isCurrentActivity(background.generation, null))
+        val removed = registrations.removeActivity(null)
+        assertEquals(background.generation, removed?.generation)
+        assertFalse(registrations.isCurrentActivity(background.generation, null))
+    }
+
+    @Test
+    fun stoppedActivityOwnerCannotBeConfirmedByAnInFlightRequest() {
+        val prefs = context.getSharedPreferences("registration-activity-stop-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val request = registrations.requestActivity(null)
+
+        registrations.removeActivity(null)
+
+        assertFalse(registrations.confirmActivity(request).accepted)
+        assertFalse(registrations.isCurrentActivity(request.generation, null))
+    }
+
+    @Test
+    fun failedReplacementDoesNotResurrectOrRemoveAnotherOwner() {
+        val prefs = context.getSharedPreferences("registration-activity-failure-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val standalone = registrations.requestActivity(null)
+        assertTrue(registrations.confirmActivity(standalone).accepted)
+        val service = registrations.nextServiceGeneration()
+        val replacement = registrations.requestActivity(service)
+
+        assertNull(registrations.failActivity(replacement))
+
+        assertTrue(registrations.isCurrentActivity(standalone.generation, null))
+        assertFalse(registrations.isCurrentActivity(replacement.generation, service))
+    }
+
+    @Test
+    fun failedSameOwnerReplacementKeepsTheConfirmedRegistration() {
+        val prefs = context.getSharedPreferences("registration-same-owner-failure-test", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val confirmed = registrations.requestActivity(null)
+        assertTrue(registrations.confirmActivity(confirmed).accepted)
+        val replacement = registrations.requestActivity(null)
+
+        assertNull(registrations.failActivity(replacement))
+
+        assertTrue(registrations.isCurrentActivity(confirmed.generation, null))
+        assertFalse(registrations.isCurrentActivity(replacement.generation, null))
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntentTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntentTest.kt
@@ -1,0 +1,42 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import androidx.test.core.app.ApplicationProvider
+import com.margelo.nitro.nitrogeolocation.AndroidForegroundServiceOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundServiceIntentTest {
+    @Test
+    fun stickyRestartFallsBackToTheDurableRunningGeneration() {
+        assertEquals(12L, resolveBackgroundServiceGeneration(null, 12L))
+        assertEquals(13L, resolveBackgroundServiceGeneration(13L, 12L))
+        assertNull(resolveBackgroundServiceGeneration(null, null))
+    }
+
+    @Test
+    fun serviceIntentCarriesTheNotificationSnapshotNeededBeforeControllerLocks() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val options = AndroidForegroundServiceOptions(
+            42.0,
+            "Tracking",
+            "Waiting for provider registration",
+            "background-test",
+            "Background test",
+            "Description",
+            "location_icon",
+            "#123456",
+            "Stop"
+        )
+
+        val intent = backgroundServiceIntent(context, 9L, options)
+
+        assertEquals(9L, intent.backgroundServiceGeneration())
+        assertEquals(options, intent.backgroundNotificationOptions())
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceStartupTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceStartupTest.kt
@@ -1,0 +1,61 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NitroBackgroundServiceStartupTest {
+    @Test
+    fun completionIsMatchedToItsServiceGeneration() {
+        val startup = NitroBackgroundServiceStartup()
+        val failure = IllegalStateException("foreground promotion failed")
+        startup.begin(7L)
+        startup.begin(8L)
+
+        startup.foregroundPromoted(8L)
+        assertFalse(startup.isComplete(8L))
+        startup.providerRegistered(8L)
+        startup.fail(7L, failure)
+
+        assertNull(startup.await(8L, 10L))
+        assertSame(failure, startup.await(7L, 10L))
+    }
+
+    @Test
+    fun activityAwareStartupWaitsForBothProviders() {
+        val startup = NitroBackgroundServiceStartup()
+        startup.begin(9L, activityRequired = true)
+
+        startup.foregroundPromoted(9L)
+        startup.providerRegistered(9L)
+        assertFalse(startup.isComplete(9L))
+
+        startup.activityProviderRegistered(9L)
+        assertTrue(startup.isComplete(9L))
+        assertNull(startup.await(9L, 10L))
+    }
+
+    @Test
+    fun continuousStartupOnlyWaitsForLocationProvider() {
+        val startup = NitroBackgroundServiceStartup()
+        startup.begin(10L)
+
+        startup.foregroundPromoted(10L)
+        startup.providerRegistered(10L)
+
+        assertTrue(startup.isComplete(10L))
+        assertNull(startup.await(10L, 10L))
+    }
+
+    @Test
+    fun recoveredServiceCanRebuildReadinessWithoutAWaitingCaller() {
+        val startup = NitroBackgroundServiceStartup()
+        startup.beginIfAbsent(11L, activityRequired = true)
+
+        startup.foregroundPromoted(11L)
+        assertFalse(startup.providerRegistered(11L))
+        assertTrue(startup.activityProviderRegistered(11L))
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncAdmissionTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncAdmissionTest.kt
@@ -1,0 +1,33 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NitroBackgroundSyncAdmissionTest {
+    @Test
+    fun releasesTheStorageSnapshotLockBeforeReservingTheRegistrationGate() {
+        val storageLock = Any()
+        var gateSawStorageLocked = true
+        val admission = NitroBackgroundSyncAdmission()
+
+        val result = admission.reserve(
+            snapshot = { synchronized(storageLock) { "batch" } },
+            reserveGate = {
+                gateSawStorageLocked = Thread.holdsLock(storageLock)
+                true
+            }
+        )
+
+        assertEquals("batch", result)
+        assertFalse(gateSawStorageLocked)
+    }
+
+    @Test
+    fun continuationBypassesTheIntervalOnlyForTheSameConfigRevision() {
+        assertFalse(shouldEnforceSyncInterval(7, 7))
+        assertTrue(shouldEnforceSyncInterval(7, 8))
+        assertTrue(shouldEnforceSyncInterval(null, 8))
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncGateTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncGateTest.kt
@@ -1,0 +1,44 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundSyncGateTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun stoppedRegistrationCannotConsumeThrottleWindow() {
+        val prefs = context.getSharedPreferences("sync-gate-stopped", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val owner = registrations.nextServiceGeneration()
+        val registration = registrations.replaceLocation(owner).second
+        val gate = NitroBackgroundSyncGate(registrations, prefs)
+        registrations.removeLocation(owner)
+
+        assertFalse(gate.reserve(registration.generation, owner, 60_000L, 75_000L))
+        assertEquals(0L, prefs.getLong("lastSyncAt", 0L))
+    }
+
+    @Test
+    fun activeRegistrationReservesOncePerInterval() {
+        val prefs = context.getSharedPreferences("sync-gate-active", 0)
+        prefs.edit().clear().commit()
+        val registrations = NitroBackgroundRegistrations(prefs)
+        val owner = registrations.nextServiceGeneration()
+        val registration = registrations.replaceLocation(owner).second
+        val gate = NitroBackgroundSyncGate(registrations, prefs)
+
+        assertTrue(gate.reserve(registration.generation, owner, 60_000L, 75_000L))
+        assertFalse(gate.reserve(registration.generation, owner, 60_000L, 80_000L))
+        assertEquals(75_000L, prefs.getLong("lastSyncAt", 0L))
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncQueueTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncQueueTest.kt
@@ -1,0 +1,303 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import java.util.Collections
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NitroBackgroundSyncQueueTest {
+    @Test
+    fun manualSyncsShareTheAutomaticSyncSerialBoundary() {
+        val queue = NitroBackgroundSyncQueue()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val automaticFinished = CountDownLatch(1)
+        val secondStarted = CountDownLatch(1)
+        val order = Collections.synchronizedList(mutableListOf<String>())
+
+        val first = CompletableFuture.supplyAsync {
+            queue.runManual {
+                order += "first-start"
+                firstStarted.countDown()
+                assertTrue(releaseFirst.await(5, TimeUnit.SECONDS))
+                order += "first-end"
+                "first"
+            }
+        }
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS))
+
+        queue.scheduleAutomatic(
+            reserve = { "automatic" },
+            perform = {
+                order += it
+                automaticFinished.countDown()
+                false
+            }
+        )
+        val second = CompletableFuture.supplyAsync {
+            queue.runManual {
+                secondStarted.countDown()
+                order += "second"
+                "second"
+            }
+        }
+
+        assertFalse(secondStarted.await(100, TimeUnit.MILLISECONDS))
+        releaseFirst.countDown()
+
+        assertEquals("first", first.get(5, TimeUnit.SECONDS))
+        assertTrue(automaticFinished.await(5, TimeUnit.SECONDS))
+        assertEquals("second", second.get(5, TimeUnit.SECONDS))
+        assertEquals(
+            listOf("first-start", "first-end", "automatic", "second"),
+            order
+        )
+        queue.close()
+    }
+
+    @Test
+    fun automaticSyncRechecksAdmissionWhenItsTurnBegins() {
+        val queue = NitroBackgroundSyncQueue()
+        val blockerStarted = CountDownLatch(1)
+        val releaseBlocker = CountDownLatch(1)
+        val automaticFinished = CountDownLatch(1)
+        val thresholdMet = AtomicBoolean(true)
+        val uploaded = AtomicBoolean(false)
+
+        val blocker = CompletableFuture.runAsync {
+            queue.runManual {
+                blockerStarted.countDown()
+                assertTrue(releaseBlocker.await(5, TimeUnit.SECONDS))
+            }
+        }
+        assertTrue(blockerStarted.await(5, TimeUnit.SECONDS))
+
+        queue.scheduleAutomatic(
+            reserve = { if (thresholdMet.get()) "batch" else null },
+            perform = {
+                uploaded.set(true)
+                automaticFinished.countDown()
+                false
+            },
+            onSkipped = automaticFinished::countDown
+        )
+        thresholdMet.set(false)
+        releaseBlocker.countDown()
+
+        blocker.get(5, TimeUnit.SECONDS)
+        assertTrue(automaticFinished.await(5, TimeUnit.SECONDS))
+        assertFalse(uploaded.get())
+        queue.close()
+    }
+
+    @Test
+    fun automaticFailureIsReportedAndDoesNotPoisonLaterSyncs() {
+        val queue = NitroBackgroundSyncQueue()
+        val failed = CountDownLatch(1)
+
+        queue.scheduleAutomatic(
+            reserve = { throw IllegalStateException("storage unavailable") },
+            perform = { _: String -> error("perform must not run") },
+            onFailure = { error ->
+                assertEquals("storage unavailable", error.message)
+                failed.countDown()
+            }
+        )
+
+        assertTrue(failed.await(5, TimeUnit.SECONDS))
+        assertEquals("next", queue.runManual { "next" })
+        queue.close()
+    }
+
+    @Test
+    fun automaticBurstKeepsOnlyOneFollowUpWhileAnUploadIsRunning() {
+        val queue = NitroBackgroundSyncQueue()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val followUpFinished = CountDownLatch(1)
+        val uploads = AtomicInteger(0)
+
+        fun schedule() {
+            queue.scheduleAutomatic(
+                reserve = { "batch" },
+                perform = {
+                    if (uploads.incrementAndGet() == 1) {
+                        firstStarted.countDown()
+                        assertTrue(releaseFirst.await(5, TimeUnit.SECONDS))
+                    } else {
+                        followUpFinished.countDown()
+                    }
+                    false
+                }
+            )
+        }
+
+        schedule()
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS))
+        repeat(20) { schedule() }
+        releaseFirst.countDown()
+
+        assertTrue(followUpFinished.await(5, TimeUnit.SECONDS))
+        queue.runManual { }
+        assertEquals(2, uploads.get())
+        queue.close()
+    }
+
+    @Test
+    fun staleAutomaticWorkCannotReplaceANewerRun() {
+        val queue = NitroBackgroundSyncQueue()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val newerFinished = CountDownLatch(1)
+        val staleRan = AtomicBoolean(false)
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1),
+            reserve = { "first" },
+            perform = {
+                firstStarted.countDown()
+                assertTrue(releaseFirst.await(5, TimeUnit.SECONDS))
+                false
+            }
+        )
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS))
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(2, 1, 2),
+            reserve = { "newer" },
+            perform = {
+                newerFinished.countDown()
+                false
+            }
+        )
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 2, 1),
+            reserve = { "stale" },
+            perform = {
+                staleRan.set(true)
+                false
+            }
+        )
+        releaseFirst.countDown()
+
+        assertTrue(newerFinished.await(5, TimeUnit.SECONDS))
+        queue.runManual { }
+        assertFalse(staleRan.get())
+        queue.close()
+    }
+
+    @Test
+    fun staleConfigWorkCannotReplaceANewerConfigInTheSameRun() {
+        val queue = NitroBackgroundSyncQueue()
+        val blockerStarted = CountDownLatch(1)
+        val releaseBlocker = CountDownLatch(1)
+        val newerFinished = CountDownLatch(1)
+        val staleRan = AtomicBoolean(false)
+
+        val blocker = CompletableFuture.runAsync {
+            queue.runManual {
+                blockerStarted.countDown()
+                assertTrue(releaseBlocker.await(5, TimeUnit.SECONDS))
+            }
+        }
+        assertTrue(blockerStarted.await(5, TimeUnit.SECONDS))
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1, 2),
+            reserve = { "newer-config" },
+            perform = {
+                newerFinished.countDown()
+                false
+            }
+        )
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1, 1),
+            reserve = { "stale-config" },
+            perform = {
+                staleRan.set(true)
+                false
+            }
+        )
+        releaseBlocker.countDown()
+
+        blocker.get(5, TimeUnit.SECONDS)
+        assertTrue(newerFinished.await(5, TimeUnit.SECONDS))
+        queue.runManual { }
+        assertFalse(staleRan.get())
+        queue.close()
+    }
+
+    @Test
+    fun continuationUsesTheRevisionOfTheBatchThatActuallyRan() {
+        val queue = NitroBackgroundSyncQueue()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val continuationFinished = CountDownLatch(1)
+        val runs = AtomicInteger(0)
+        val ordinaryRevisionTwoRan = AtomicBoolean(false)
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1, 1),
+            reserve = { "revision-two-batch" },
+            perform = {
+                if (runs.incrementAndGet() == 1) {
+                    firstStarted.countDown()
+                    assertTrue(releaseFirst.await(5, TimeUnit.SECONDS))
+                    true
+                } else {
+                    continuationFinished.countDown()
+                    false
+                }
+            },
+            continuationKey = { NitroBackgroundSyncKey(1, 1, 1, 2) }
+        )
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS))
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1, 2),
+            reserve = { "ordinary-revision-two" },
+            perform = {
+                ordinaryRevisionTwoRan.set(true)
+                false
+            }
+        )
+        releaseFirst.countDown()
+
+        assertTrue(continuationFinished.await(5, TimeUnit.SECONDS))
+        queue.runManual { }
+        assertEquals(2, runs.get())
+        assertFalse(ordinaryRevisionTwoRan.get())
+        queue.close()
+    }
+
+    @Test
+    fun successfulAutomaticWorkContinuesUntilTheBacklogIsBelowThreshold() {
+        val queue = NitroBackgroundSyncQueue()
+        val remaining = AtomicInteger(4)
+        val uploads = AtomicInteger(0)
+        val drained = CountDownLatch(1)
+
+        queue.scheduleAutomatic(
+            key = NitroBackgroundSyncKey(1, 1, 1),
+            reserve = { remaining.get().takeIf { it > 0 } },
+            perform = {
+                uploads.incrementAndGet()
+                if (remaining.decrementAndGet() == 0) {
+                    drained.countDown()
+                }
+                remaining.get() > 0
+            }
+        )
+
+        assertTrue(drained.await(5, TimeUnit.SECONDS))
+        queue.runManual { }
+        assertEquals(4, uploads.get())
+        queue.close()
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBootRestoreJobServiceTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBootRestoreJobServiceTest.kt
@@ -1,0 +1,59 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.job.JobScheduler
+import androidx.test.core.app.ApplicationProvider
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBootRestoreJobServiceTest {
+    @Test
+    fun bootRestoreIsDelegatedToTheJobScheduler() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val scheduler = context.getSystemService(JobScheduler::class.java)
+
+        assertTrue(NitroBootRestoreJobService.schedule(context))
+
+        val job = scheduler.allPendingJobs.single()
+        assertEquals(
+            NitroBootRestoreJobService::class.java.name,
+            job.service.className
+        )
+    }
+
+    @Test
+    fun stoppingBootWorkInterruptsTheRestoreItOwns() {
+        val started = CountDownLatch(1)
+        val interrupted = CountDownLatch(1)
+        val completed = AtomicBoolean(false)
+        val work = NitroBootRestoreWork()
+        work.start(
+            restore = {
+                started.countDown()
+                try {
+                    CountDownLatch(1).await()
+                } catch (error: InterruptedException) {
+                    interrupted.countDown()
+                    throw error
+                }
+            },
+            complete = { completed.set(true) }
+        )
+
+        assertTrue(started.await(1, TimeUnit.SECONDS))
+        work.cancel()
+
+        assertTrue(interrupted.await(1, TimeUnit.SECONDS))
+        assertFalse(completed.get())
+        work.shutdown()
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundLocationDelegate.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundLocationDelegate.swift
@@ -3,34 +3,60 @@ import Foundation
 
 final class NitroBackgroundLocationDelegate: NSObject, CLLocationManagerDelegate {
     weak var owner: NitroBackgroundLocation?
+    private let runGeneration: UInt64
+    private let locationSessionGeneration: UInt64
 
-    init(owner: NitroBackgroundLocation) {
+    init(
+        owner: NitroBackgroundLocation,
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64
+    ) {
         self.owner = owner
+        self.runGeneration = runGeneration
+        self.locationSessionGeneration = locationSessionGeneration
         super.init()
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        owner?.handleLocations(locations)
-        owner?.applyDeferredUpdatesIfNeeded(manager)
+        owner?.handleLocations(
+            locations,
+            runGeneration: runGeneration,
+            locationSessionGeneration: locationSessionGeneration
+        )
+        owner?.applyDeferredUpdatesIfNeeded(
+            manager,
+            runGeneration: runGeneration,
+            locationSessionGeneration: locationSessionGeneration
+        )
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        owner?.handleError(error)
+        owner?.handleError(
+            error,
+            runGeneration: runGeneration,
+            locationSessionGeneration: locationSessionGeneration
+        )
     }
 
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        owner?.handleRegion(region, transition: .enter)
+        owner?.handleRegion(region, transition: .enter, runGeneration: runGeneration)
     }
 
     func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
-        owner?.handleRegion(region, transition: .exit)
+        owner?.handleRegion(region, transition: .exit, runGeneration: runGeneration)
     }
 
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        owner?.handleAuthorizationChange()
+        owner?.handleAuthorizationChange(
+            runGeneration: runGeneration,
+            status: manager.authorizationStatus
+        )
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        owner?.handleAuthorizationChange()
+        owner?.handleAuthorizationChange(
+            runGeneration: runGeneration,
+            status: status
+        )
     }
 }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
@@ -1,6 +1,7 @@
 import CoreLocation
 import CoreMotion
 import Foundation
+import NitroModules
 
 internal func motionActivityType(_ activity: CMMotionActivity) -> DetectedActivityType {
     if activity.automotive {
@@ -51,5 +52,149 @@ internal func mapActivityType(_ activityType: IOSBackgroundActivityType?) -> CLA
         return .other
     @unknown default:
         return .other
+    }
+}
+
+extension NitroBackgroundLocation {
+    func validateMotionAccessBeforeStarting() throws {
+        guard CMMotionActivityManager.isActivityAvailable() else {
+            throw RuntimeError.error(withMessage: "Core Motion activity recognition is not available")
+        }
+        switch CMMotionActivityManager.authorizationStatus() {
+        case .denied:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is denied")
+        case .restricted:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is restricted")
+        case .authorized, .notDetermined:
+            return
+        @unknown default:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is unavailable")
+        }
+    }
+
+    func awaitMotionAuthorization(timeout: TimeInterval = 60) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var status = CMMotionActivityManager.authorizationStatus()
+        while status == .notDetermined && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+            status = CMMotionActivityManager.authorizationStatus()
+        }
+        switch status {
+        case .authorized:
+            return
+        case .denied:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is denied")
+        case .restricted:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is restricted")
+        case .notDetermined:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission request timed out")
+        @unknown default:
+            throw RuntimeError.error(withMessage: "Core Motion activity permission is unavailable")
+        }
+    }
+
+    func settleMotionAuthorization() throws {
+        try validateMotionAccessBeforeStarting()
+        guard CMMotionActivityManager.authorizationStatus() == .notDetermined else { return }
+
+        let authorizationManager = CMMotionActivityManager()
+        let authorizationQueue = OperationQueue()
+        authorizationManager.startActivityUpdates(to: authorizationQueue) { _ in }
+        defer { authorizationManager.stopActivityUpdates() }
+        try awaitMotionAuthorization()
+    }
+
+    func startMotionUpdatesIfAvailable() {
+        guard CMMotionActivityManager.isActivityAvailable(), !isMotionUpdatesRunning else { return }
+        let generations = withStoreLock {
+            motionRegistrationGeneration &+= 1
+            motionRegistrationActive = true
+            return (storeGeneration, motionRegistrationGeneration)
+        }
+        motionManager.startActivityUpdates(to: motionQueue) { [weak self] activity in
+            guard let self, let activity else { return }
+            self.handleMotionActivity(
+                activity,
+                runGeneration: generations.0,
+                motionRegistrationGeneration: generations.1
+            )
+        }
+        isMotionUpdatesRunning = true
+    }
+
+    func stopMotionUpdatesIfRunning() {
+        guard isMotionUpdatesRunning else { return }
+        withStoreLock {
+            motionRegistrationActive = false
+            motionRegistrationGeneration &+= 1
+        }
+        motionManager.stopActivityUpdates()
+        isMotionUpdatesRunning = false
+    }
+
+    func updateMotionUpdates() {
+        if backgroundMotionRequested || standaloneMotionRequested {
+            startMotionUpdatesIfAvailable()
+        } else {
+            stopMotionUpdatesIfRunning()
+        }
+    }
+
+    private func handleMotionActivity(
+        _ activity: CMMotionActivity,
+        runGeneration: UInt64,
+        motionRegistrationGeneration: UInt64
+    ) {
+        guard isCurrentMotionRegistration(
+            runGeneration,
+            motionRegistrationGeneration
+        ) else { return }
+        let detected = DetectedActivity(
+            type: motionActivityType(activity),
+            confidence: motionConfidence(activity.confidence),
+            timestamp: activity.startDate.timeIntervalSince1970 * 1000
+        )
+        let event = BackgroundEventEnvelope(
+            location: nil,
+            geofence: nil,
+            activity: detected,
+            providerStatus: nil,
+            result: nil,
+            error: nil,
+            id: UUID().uuidString,
+            type: .activity,
+            timestamp: Date().timeIntervalSince1970 * 1000,
+            deliveredToJS: false
+        )
+        let storedForRun: Bool = withStoreLock {
+            guard runGeneration == storeGeneration,
+                self.motionRegistrationGeneration == motionRegistrationGeneration,
+                motionRegistrationActive
+            else { return false }
+            appendStoredEvent(
+                StoredBackgroundEventEnvelope(
+                    event: event,
+                    createdAt: Date().timeIntervalSince1970 * 1000,
+                    id: event.id,
+                    type: event.type,
+                    timestamp: event.timestamp,
+                    deliveredToJS: false
+                ),
+                allowUnconfigured: true
+            )
+            persistStore()
+            return true
+        }
+        guard storedForRun else { return }
+        dispatchInProcess(
+            event: event,
+            runGeneration: runGeneration,
+            motionRegistrationGeneration: motionRegistrationGeneration
+        )
+        applyActivityAwareTracking(
+            detected,
+            runGeneration: runGeneration,
+            motionRegistrationGeneration: motionRegistrationGeneration
+        )
     }
 }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundPermission.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundPermission.swift
@@ -1,45 +1,85 @@
 import CoreLocation
+import Foundation
+
+final class IOSBackgroundPermissionRequest {
+    let semaphore = DispatchSemaphore(value: 0)
+    private var completed = false
+
+    func authorizationDidChange(to status: CLAuthorizationStatus) {
+        guard !completed, status != .notDetermined else { return }
+        completed = true
+        semaphore.signal()
+    }
+}
 
 extension NitroBackgroundLocation {
+    func requestBackgroundPermissionResult() -> BackgroundPermissionResult {
+        return withLifecycleLock {
+            let status = CLLocationManager.authorizationStatus()
+            let request = status == .notDetermined ? IOSBackgroundPermissionRequest() : nil
+            withStoreLock { permissionRequest = request }
+            ensureManager()
+            runOnMainSync {
+                self.manager?.requestAlwaysAuthorization()
+            }
+            withStoreLock {
+                request?.authorizationDidChange(
+                    to: CLLocationManager.authorizationStatus()
+                )
+            }
+            if Thread.isMainThread == false {
+                _ = request?.semaphore.wait(timeout: .now() + 60)
+            }
+            withStoreLock {
+                if permissionRequest === request {
+                    permissionRequest = nil
+                }
+            }
+            return permissionResult()
+        }
+    }
+
     func permissionResult() -> BackgroundPermissionResult {
-        ensureManager()
-        let status = CLLocationManager.authorizationStatus()
-        let foreground: PermissionStatus
-        let background: BackgroundPermissionStatus
-        switch status {
-        case .authorizedAlways:
-            foreground = .granted
-            background = .granted
-        case .authorizedWhenInUse:
-            foreground = .granted
-            background = .denied
-        case .denied:
-            foreground = .denied
-            background = .denied
-        case .restricted:
-            foreground = .restricted
-            background = .restricted
-        case .notDetermined:
-            foreground = .undetermined
-            background = .undetermined
-        @unknown default:
-            foreground = .undetermined
-            background = .undetermined
-        }
+        return withLifecycleLock {
+            ensureManager()
+            let status = CLLocationManager.authorizationStatus()
+            let foreground: PermissionStatus
+            let background: BackgroundPermissionStatus
+            switch status {
+            case .authorizedAlways:
+                foreground = .granted
+                background = .granted
+            case .authorizedWhenInUse:
+                foreground = .granted
+                background = .denied
+            case .denied:
+                foreground = .denied
+                background = .denied
+            case .restricted:
+                foreground = .restricted
+                background = .restricted
+            case .notDetermined:
+                foreground = .undetermined
+                background = .undetermined
+            @unknown default:
+                foreground = .undetermined
+                background = .undetermined
+            }
 
-        let accuracy: AccuracyAuthorization
-        if #available(iOS 14.0, *) {
-            accuracy = manager?.accuracyAuthorization == .fullAccuracy ? .full : .reduced
-        } else {
-            accuracy = .unknown
-        }
+            let accuracy: AccuracyAuthorization
+            if #available(iOS 14.0, *) {
+                accuracy = manager?.accuracyAuthorization == .fullAccuracy ? .full : .reduced
+            } else {
+                accuracy = .unknown
+            }
 
-        return BackgroundPermissionResult(
-            foreground: foreground,
-            background: background,
-            accuracyAuthorization: accuracy,
-            canRequestBackgroundInline: true,
-            needsSettingsRedirect: background != .granted
-        )
+            return BackgroundPermissionResult(
+                foreground: foreground,
+                background: background,
+                accuracyAuthorization: accuracy,
+                canRequestBackgroundInline: true,
+                needsSettingsRedirect: background != .granted
+            )
+        }
     }
 }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundPermission.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundPermission.swift
@@ -1,0 +1,45 @@
+import CoreLocation
+
+extension NitroBackgroundLocation {
+    func permissionResult() -> BackgroundPermissionResult {
+        ensureManager()
+        let status = CLLocationManager.authorizationStatus()
+        let foreground: PermissionStatus
+        let background: BackgroundPermissionStatus
+        switch status {
+        case .authorizedAlways:
+            foreground = .granted
+            background = .granted
+        case .authorizedWhenInUse:
+            foreground = .granted
+            background = .denied
+        case .denied:
+            foreground = .denied
+            background = .denied
+        case .restricted:
+            foreground = .restricted
+            background = .restricted
+        case .notDetermined:
+            foreground = .undetermined
+            background = .undetermined
+        @unknown default:
+            foreground = .undetermined
+            background = .undetermined
+        }
+
+        let accuracy: AccuracyAuthorization
+        if #available(iOS 14.0, *) {
+            accuracy = manager?.accuracyAuthorization == .fullAccuracy ? .full : .reduced
+        } else {
+            accuracy = .unknown
+        }
+
+        return BackgroundPermissionResult(
+            foreground: foreground,
+            background: background,
+            accuracyAuthorization: accuracy,
+            canRequestBackgroundInline: true,
+            needsSettingsRedirect: background != .granted
+        )
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
@@ -1,0 +1,241 @@
+import CoreLocation
+import Foundation
+
+extension NitroBackgroundLocation {
+    func addBackgroundEventListener(listener: @escaping (BackgroundEventEnvelope) -> Void) throws -> String {
+        let token = UUID().uuidString
+        withListenerLock { eventListeners[token] = listener }
+        return token
+    }
+
+    func removeBackgroundEventListener(token: String) throws {
+        _ = withListenerLock { eventListeners.removeValue(forKey: token) }
+    }
+
+    func addBackgroundLocationListener(listener: @escaping (BackgroundLocation) -> Void) throws -> String {
+        let token = UUID().uuidString
+        withListenerLock { locationListeners[token] = listener }
+        return token
+    }
+
+    func removeBackgroundLocationListener(token: String) throws {
+        _ = withListenerLock { locationListeners.removeValue(forKey: token) }
+    }
+
+    func addBackgroundErrorListener(listener: @escaping (LocationError) -> Void) throws -> String {
+        let token = UUID().uuidString
+        withListenerLock { errorListeners[token] = listener }
+        return token
+    }
+
+    func removeBackgroundErrorListener(token: String) throws {
+        _ = withListenerLock { errorListeners.removeValue(forKey: token) }
+    }
+
+    func handleAuthorizationChange(
+        runGeneration: UInt64,
+        status: CLAuthorizationStatus
+    ) {
+        withStoreLock {
+            guard runGeneration == storeGeneration else { return }
+            permissionRequest?.authorizationDidChange(to: status)
+        }
+    }
+
+    func handleError(
+        _ error: Error,
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64
+    ) {
+        // Location unknown is transient and Core Location continues trying.
+        if let clError = error as? CLError, clError.code == .locationUnknown {
+            return
+        }
+        let locationError = LocationError(code: -1, message: error.localizedDescription)
+        withListenerLock {
+            guard withStoreLock({
+                isCurrentLocationSession(runGeneration, locationSessionGeneration)
+            }) else { return }
+            Array(errorListeners.keys).forEach { errorListeners[$0]?(locationError) }
+        }
+    }
+
+    func dispatchInProcess(
+        event: BackgroundEventEnvelope,
+        location: BackgroundLocation? = nil,
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64? = nil,
+        motionRegistrationGeneration: UInt64? = nil
+    ) {
+        withListenerLock {
+            guard withStoreLock({
+                guard runGeneration == storeGeneration else { return false }
+                if let locationSessionGeneration {
+                    guard isCurrentLocationSession(
+                        runGeneration,
+                        locationSessionGeneration
+                    ) else { return false }
+                }
+                if let motionRegistrationGeneration {
+                    guard isCurrentMotionRegistration(
+                        runGeneration,
+                        motionRegistrationGeneration
+                    ) else { return false }
+                }
+                return true
+            }) else { return }
+            Array(eventListeners.keys).forEach { eventListeners[$0]?(event) }
+            if let location {
+                Array(locationListeners.keys).forEach { locationListeners[$0]?(location) }
+            }
+        }
+    }
+
+    func applyActivityAwareTracking(
+        _ activity: DetectedActivity,
+        runGeneration: UInt64,
+        motionRegistrationGeneration: UInt64
+    ) {
+        withLifecycleLock {
+            guard isCurrentMotionRegistration(
+                runGeneration,
+                motionRegistrationGeneration
+            ) else { return }
+            let snapshot = withStoreLock { (options, isRunning) }
+            guard let options = snapshot.0 else { return }
+            let activityOptions = options.activityRecognition
+            guard options.trackingMode == .activityaware ||
+                activityOptions?.stopOnStill == true else { return }
+            guard activity.confidence >= (activityOptions?.minimumConfidence ?? 0) else { return }
+            let stopOnStill = activityOptions?.stopOnStill ?? (options.trackingMode == .activityaware)
+            if activity.type == .still && stopOnStill {
+                runOnMainSync {
+                    self.manager?.disallowDeferredLocationUpdates()
+                    self.manager?.stopUpdatingLocation()
+                    self.manager?.stopMonitoringSignificantLocationChanges()
+                }
+                return
+            }
+            if activity.type != .still && activity.type != .unknown && snapshot.1 {
+                runOnMainSync {
+                    if options.trackingMode == .significantchanges ||
+                        options.ios?.useSignificantChanges == true {
+                        self.manager?.startMonitoringSignificantLocationChanges()
+                    } else {
+                        self.manager?.startUpdatingLocation()
+                    }
+                }
+            }
+        }
+    }
+
+    func ensureManager() {
+        if manager != nil { return }
+        if Thread.isMainThread == false {
+            DispatchQueue.main.sync {
+                self.ensureManager()
+            }
+            return
+        }
+        let manager = CLLocationManager()
+        let generation = withStoreLock { storeGeneration }
+        let delegate = NitroBackgroundLocationDelegate(
+            owner: self,
+            runGeneration: generation,
+            locationSessionGeneration: 0
+        )
+        manager.delegate = delegate
+        self.manager = manager
+        self.delegate = delegate
+    }
+
+    func applyDeferredUpdatesIfNeeded(
+        _ manager: CLLocationManager,
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64
+    ) {
+        guard let options = withStoreLock({ () -> BackgroundLocationOptions? in
+            guard isCurrentLocationSession(
+                runGeneration,
+                locationSessionGeneration
+            ) else { return nil }
+            return self.options
+        }),
+            let distance = options.ios?.deferredUpdatesDistance,
+            let interval = options.ios?.deferredUpdatesInterval
+        else {
+            return
+        }
+        manager.allowDeferredLocationUpdates(
+            untilTraveled: distance,
+            timeout: interval / 1000
+        )
+    }
+
+    func replaceLocationSession() -> UInt64 {
+        let generations = withStoreLock {
+            locationSessionGeneration &+= 1
+            locationSessionActive = true
+            return (storeGeneration, locationSessionGeneration)
+        }
+        runOnMainSync {
+            self.manager?.disallowDeferredLocationUpdates()
+            self.manager?.stopUpdatingLocation()
+            self.manager?.stopMonitoringSignificantLocationChanges()
+            let delegate = NitroBackgroundLocationDelegate(
+                owner: self,
+                runGeneration: generations.0,
+                locationSessionGeneration: generations.1
+            )
+            self.manager?.delegate = delegate
+            self.delegate = delegate
+        }
+        return generations.1
+    }
+
+    func stopLocationSession(expectedGeneration: UInt64? = nil) {
+        let shouldStop = withStoreLock {
+            if let expectedGeneration,
+                locationSessionGeneration != expectedGeneration {
+                return false
+            }
+            locationSessionActive = false
+            locationSessionGeneration &+= 1
+            return true
+        }
+        guard shouldStop else { return }
+        runOnMainSync {
+            self.manager?.disallowDeferredLocationUpdates()
+            self.manager?.stopUpdatingLocation()
+            self.manager?.stopMonitoringSignificantLocationChanges()
+        }
+    }
+
+    func isCurrentLocationSession(
+        _ runGeneration: UInt64,
+        _ locationSessionGeneration: UInt64
+    ) -> Bool {
+        withStoreLock {
+            runGeneration == storeGeneration &&
+                self.locationSessionGeneration == locationSessionGeneration &&
+                locationSessionActive
+        }
+    }
+
+    func isCurrentMotionRegistration(
+        _ runGeneration: UInt64,
+        _ motionRegistrationGeneration: UInt64
+    ) -> Bool {
+        withStoreLock {
+            runGeneration == storeGeneration &&
+                self.motionRegistrationGeneration == motionRegistrationGeneration &&
+                motionRegistrationActive
+        }
+    }
+
+    func withLifecycleLock<T>(_ work: () throws -> T) rethrows -> T {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        return try work()
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+private struct IOSBackgroundSyncBatch {
+    let locations: [StoredBackgroundLocation]
+    let sync: BackgroundHttpSyncOptions
+    let configRevision: UInt64
+}
+
+extension NitroBackgroundLocation {
+    func scheduleSyncIfNeeded(
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64
+    ) {
+        let scheduledConfigRevision = withStoreLock { () -> UInt64? in
+            guard runGeneration == storeGeneration,
+                self.locationSessionGeneration == locationSessionGeneration,
+                locationSessionActive,
+                let sync = options?.sync
+            else { return nil }
+            let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
+            guard storedLocations.filter({ !$0.synced }).count >= threshold else { return nil }
+            return syncConfigRevision
+        }
+        guard let scheduledConfigRevision else { return }
+
+        var continuationConfigRevision: UInt64?
+        syncScheduler.scheduleAutomatic(
+            key: IOSBackgroundSyncKey(
+                runGeneration: runGeneration,
+                locationSessionGeneration: locationSessionGeneration,
+                configRevision: scheduledConfigRevision
+            )
+        ) {
+            guard let batch = self.reserveAutomaticSyncBatch(
+                runGeneration: runGeneration,
+                locationSessionGeneration: locationSessionGeneration,
+                continuationConfigRevision: continuationConfigRevision
+            ) else { return nil }
+            let result = self.performSyncBatch(batch, runGeneration: runGeneration)
+            let event = BackgroundEventEnvelope(
+                location: nil,
+                geofence: nil,
+                activity: nil,
+                providerStatus: nil,
+                result: result,
+                error: nil,
+                id: UUID().uuidString,
+                type: .httpsync,
+                timestamp: Date().timeIntervalSince1970 * 1000,
+                deliveredToJS: false
+            )
+            let storedForRun: Bool = self.withStoreLock {
+                guard runGeneration == self.storeGeneration,
+                    self.locationSessionGeneration == locationSessionGeneration,
+                    self.locationSessionActive,
+                    self.options != nil
+                else { return false }
+                self.appendStoredEvent(
+                    StoredBackgroundEventEnvelope(
+                        event: event,
+                        createdAt: Date().timeIntervalSince1970 * 1000,
+                        id: event.id,
+                        type: event.type,
+                        timestamp: event.timestamp,
+                        deliveredToJS: false
+                    )
+                )
+                self.persistStore()
+                return true
+            }
+            guard storedForRun else { return nil }
+            self.dispatchInProcess(
+                event: event,
+                runGeneration: runGeneration,
+                locationSessionGeneration: locationSessionGeneration
+            )
+            let shouldContinue = result.success && !result.syncedLocationIds.isEmpty
+            if shouldContinue {
+                continuationConfigRevision = batch.configRevision
+                return IOSBackgroundSyncKey(
+                    runGeneration: runGeneration,
+                    locationSessionGeneration: locationSessionGeneration,
+                    configRevision: batch.configRevision
+                )
+            }
+            return nil
+        }
+    }
+
+    func performSyncStoredLocations(runGeneration: UInt64) -> BackgroundHttpSyncResult {
+        guard let batch = withStoreLock({ syncBatch(runGeneration: runGeneration) }) else {
+            return emptySyncResult()
+        }
+        return performSyncBatch(batch, runGeneration: runGeneration)
+    }
+
+    private func reserveAutomaticSyncBatch(
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64,
+        continuationConfigRevision: UInt64?
+    ) -> IOSBackgroundSyncBatch? {
+        return withStoreLock {
+            guard runGeneration == storeGeneration,
+                self.locationSessionGeneration == locationSessionGeneration,
+                locationSessionActive,
+                let sync = options?.sync
+            else { return nil }
+            let allUnsynced = storedLocations.filter { !$0.synced }
+            let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
+            guard allUnsynced.count >= threshold else { return nil }
+            let now = Date().timeIntervalSince1970 * 1000
+            let interval = sync.syncInterval ?? 0
+            let sameConfigContinuation = continuationConfigRevision == syncConfigRevision
+            guard sameConfigContinuation || interval <= 0 || now - lastSyncAt >= interval else {
+                return nil
+            }
+            let count = safePrefixCount(
+                sync.batchSize,
+                defaultValue: 50,
+                upperBound: allUnsynced.count
+            )
+            guard count > 0 else { return nil }
+            lastSyncAt = now
+            return IOSBackgroundSyncBatch(
+                locations: Array(allUnsynced.prefix(count)),
+                sync: sync,
+                configRevision: syncConfigRevision
+            )
+        }
+    }
+
+    private func syncBatch(runGeneration: UInt64) -> IOSBackgroundSyncBatch? {
+        guard runGeneration == storeGeneration, let sync = options?.sync else { return nil }
+        let allUnsynced = storedLocations.filter { !$0.synced }
+        let count = safePrefixCount(
+            sync.batchSize,
+            defaultValue: 50,
+            upperBound: allUnsynced.count
+        )
+        guard count > 0 else { return nil }
+        return IOSBackgroundSyncBatch(
+            locations: Array(allUnsynced.prefix(count)),
+            sync: sync,
+            configRevision: syncConfigRevision
+        )
+    }
+
+    private func performSyncBatch(
+        _ batch: IOSBackgroundSyncBatch,
+        runGeneration: UInt64
+    ) -> BackgroundHttpSyncResult {
+        let result = httpSync.uploadWithRetry(locations: batch.locations, sync: batch.sync)
+        if !result.success && result.syncedLocationIds.isEmpty {
+            return result
+        }
+        let syncedIds = result.syncedLocationIds
+        withStoreLock {
+            guard runGeneration == storeGeneration else { return }
+            storedLocations = storedLocations.map { location in
+                syncedIds.contains(location.id)
+                    ? StoredBackgroundLocation(
+                        id: location.id,
+                        deliveredToJS: location.deliveredToJS,
+                        synced: true,
+                        createdAt: location.createdAt,
+                        source: location.source,
+                        isFromBackground: location.isFromBackground,
+                        provider: location.provider,
+                        mocked: location.mocked,
+                        recordedAt: location.recordedAt,
+                        activity: location.activity,
+                        battery: location.battery,
+                        coords: location.coords,
+                        timestamp: location.timestamp
+                    )
+                    : location
+            }
+            if batch.sync.autoClear == true {
+                storedLocations.removeAll { syncedIds.contains($0.id) }
+            }
+            persistStore()
+        }
+        return result
+    }
+
+    private func emptySyncResult() -> BackgroundHttpSyncResult {
+        return BackgroundHttpSyncResult(
+            success: true,
+            statusCode: nil,
+            syncedLocationIds: [],
+            failedLocationIds: [],
+            error: nil
+        )
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSyncScheduler.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSyncScheduler.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct IOSBackgroundSyncKey: Comparable {
+    let runGeneration: UInt64
+    let locationSessionGeneration: UInt64
+    let configRevision: UInt64
+
+    static func < (lhs: IOSBackgroundSyncKey, rhs: IOSBackgroundSyncKey) -> Bool {
+        if lhs.runGeneration != rhs.runGeneration {
+            return lhs.runGeneration < rhs.runGeneration
+        }
+        if lhs.locationSessionGeneration != rhs.locationSessionGeneration {
+            return lhs.locationSessionGeneration < rhs.locationSessionGeneration
+        }
+        return lhs.configRevision < rhs.configRevision
+    }
+}
+
+/// Coalesces automatic sync bursts to one running and one latest pending operation.
+final class IOSBackgroundSyncScheduler {
+    private final class AutomaticWork {
+        let key: IOSBackgroundSyncKey
+        let runOnce: () -> IOSBackgroundSyncKey?
+
+        init(key: IOSBackgroundSyncKey, runOnce: @escaping () -> IOSBackgroundSyncKey?) {
+            self.key = key
+            self.runOnce = runOnce
+        }
+    }
+
+    private let queue = DispatchQueue(label: "nitro.background.sync")
+    private let lock = NSLock()
+    private var pendingAutomatic: AutomaticWork?
+    private var automaticDrainScheduled = false
+
+    func scheduleAutomatic(
+        key: IOSBackgroundSyncKey,
+        _ runOnce: @escaping () -> IOSBackgroundSyncKey?
+    ) {
+        lock.lock()
+        let work = AutomaticWork(key: key, runOnce: runOnce)
+        if pendingAutomatic == nil || pendingAutomatic!.key < key {
+            pendingAutomatic = work
+        }
+        let shouldSchedule = !automaticDrainScheduled
+        if shouldSchedule {
+            automaticDrainScheduled = true
+        }
+        lock.unlock()
+
+        if shouldSchedule {
+            queue.async { self.drainOneAutomatic() }
+        }
+    }
+
+    func sync<T>(_ work: () -> T) -> T {
+        queue.sync(execute: work)
+    }
+
+    private func drainOneAutomatic() {
+        lock.lock()
+        let work = pendingAutomatic
+        pendingAutomatic = nil
+        lock.unlock()
+
+        let continuationKey = work?.runOnce()
+
+        lock.lock()
+        if let continuationKey, let work,
+            pendingAutomatic == nil || pendingAutomatic!.key <= continuationKey
+        {
+            // A continuation wins over work from the same run, while a newer run wins over both.
+            pendingAutomatic = AutomaticWork(
+                key: continuationKey,
+                runOnce: work.runOnce
+            )
+        }
+        automaticDrainScheduled = false
+        let shouldSchedule = pendingAutomatic != nil
+        if shouldSchedule {
+            automaticDrainScheduled = true
+        }
+        lock.unlock()
+
+        if shouldSchedule {
+            queue.async { self.drainOneAutomatic() }
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -155,6 +155,8 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 providerStatus: nil,
                 storedLocationCount: Double(self.storedLocations.count),
                 storedEventCount: Double(self.storedEvents.count),
+                lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
+                lastEventAt: self.storedEvents.map(\.timestamp).max(),
                 geofenceCount: Double(self.geofences.count),
                 android: nil,
                 ios: IOSBackgroundLocationStatus(

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -10,25 +10,35 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     private let eventsKey = "nitro.background.events"
     private let geofencesKey = "nitro.background.geofences"
     private let optionsKey = "nitro.background.options"
-    private var options: BackgroundLocationOptions?
+    var options: BackgroundLocationOptions?
     private var state: BackgroundLocationState = .idle
-    private var isRunning = false
-    private var eventListeners: [String: (BackgroundEventEnvelope) -> Void] = [:]
-    private var locationListeners: [String: (BackgroundLocation) -> Void] = [:]
-    private var errorListeners: [String: (LocationError) -> Void] = [:]
-    private var storedLocations: [StoredBackgroundLocation] = []
+    var isRunning = false
+    var eventListeners: [String: (BackgroundEventEnvelope) -> Void] = [:]
+    var locationListeners: [String: (BackgroundLocation) -> Void] = [:]
+    var errorListeners: [String: (LocationError) -> Void] = [:]
+    var storedLocations: [StoredBackgroundLocation] = []
     private var storedEvents: [StoredBackgroundEventEnvelope] = []
     private var geofences: [GeofenceRegion] = []
     private let storeLock = NSRecursiveLock()
+    private let listenerLock = NSRecursiveLock()
+    let lifecycleLock = NSRecursiveLock()
+    var storeGeneration: UInt64 = 0
+    var locationSessionGeneration: UInt64 = 0
+    var syncConfigRevision: UInt64 = 0
+    var locationSessionActive = false
     var manager: CLLocationManager?
-    private var delegate: NitroBackgroundLocationDelegate?
-    private let motionManager = CMMotionActivityManager()
-    private let motionQueue = OperationQueue()
-    private var isMotionUpdatesRunning = false
-    private let syncQueue = DispatchQueue(label: "nitro.background.sync")
-    private let httpSync = IOSBackgroundHttpSync()
-    private var permissionSemaphore: DispatchSemaphore?
-    private var lastSyncAt: TimeInterval = 0
+    var delegate: NitroBackgroundLocationDelegate?
+    let motionManager = CMMotionActivityManager()
+    let motionQueue = OperationQueue()
+    var isMotionUpdatesRunning = false
+    var motionRegistrationGeneration: UInt64 = 0
+    var motionRegistrationActive = false
+    var backgroundMotionRequested = false
+    var standaloneMotionRequested = false
+    let syncScheduler = IOSBackgroundSyncScheduler()
+    let httpSync = IOSBackgroundHttpSync()
+    var permissionRequest: IOSBackgroundPermissionRequest?
+    var lastSyncAt: TimeInterval = 0
 
     override init() {
         super.init()
@@ -43,19 +53,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func requestBackgroundPermission() throws -> Promise<BackgroundPermissionResult> {
         return Promise.async {
-            self.ensureManager()
-            let status = CLLocationManager.authorizationStatus()
-            let shouldWait = status == .notDetermined || status == .authorizedWhenInUse
-            let semaphore = shouldWait ? DispatchSemaphore(value: 0) : nil
-            self.permissionSemaphore = semaphore
-            DispatchQueue.main.async {
-                self.manager?.requestAlwaysAuthorization()
-            }
-            if Thread.isMainThread == false {
-                _ = semaphore?.wait(timeout: .now() + 60)
-            }
-            self.permissionSemaphore = nil
-            return self.permissionResult()
+            return self.requestBackgroundPermissionResult()
         }
     }
 
@@ -71,144 +69,164 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func configureBackgroundLocation(options: BackgroundLocationOptions) throws -> Promise<Void> {
         return Promise.async {
-            self.options = options
-            self.persistOptions(options)
+            self.withLifecycleLock {
+                self.withStoreLock {
+                    self.syncConfigRevision &+= 1
+                    self.options = options
+                    self.persistOptions(options)
+                }
+            }
         }
     }
 
     func getBackgroundConfiguration() throws -> Promise<BackgroundLocationOptions?> {
         return Promise.async {
-            return self.options
+            return self.withStoreLock { self.options }
         }
     }
 
     func startBackgroundLocation(options: BackgroundLocationOptions?) throws -> Promise<Void> {
         return Promise.async {
-            if let options {
-                self.options = options
-                self.persistOptions(options)
+            defer {
+                self.withListenerLock { /* Barrier for the location session that was replaced. */ }
             }
-            guard let current = self.options else {
-                throw RuntimeError.error(withMessage: "Background location is not configured")
+            try self.withLifecycleLock {
+                let current = self.withStoreLock { options ?? self.options }
+                guard let current else {
+                    throw RuntimeError.error(withMessage: "Background location is not configured")
+                }
+                self.ensureManager()
+                let permission = self.permissionResult()
+                guard permission.background == .granted else {
+                    self.withStoreLock { self.state = .error }
+                    throw RuntimeError.error(withMessage: "Background location permission is required")
+                }
+                try self.validateBackgroundLocationMode()
+                let motionRequested = current.trackingMode == .activityaware ||
+                    current.activityRecognition?.enabled == true
+                do {
+                    if motionRequested {
+                        try self.settleMotionAuthorization()
+                    }
+                } catch {
+                    self.withStoreLock {
+                        if !self.isRunning {
+                            self.state = .error
+                        }
+                    }
+                    throw error
+                }
+                self.withStoreLock {
+                    if let options {
+                        self.syncConfigRevision &+= 1
+                        self.options = options
+                        self.persistOptions(options)
+                    }
+                    self.state = .starting
+                }
+                _ = self.replaceLocationSession()
+                self.apply(current)
+                self.backgroundMotionRequested = motionRequested
+                self.updateMotionUpdates()
+                self.withStoreLock {
+                    self.isRunning = true
+                    self.state = .running
+                }
             }
-            self.ensureManager()
-            let permission = self.permissionResult()
-            guard permission.background == .granted else {
-                self.state = .error
-                throw RuntimeError.error(withMessage: "Background location permission is required")
-            }
-            self.state = .starting
-            try self.apply(current)
-            if current.trackingMode == .activityaware ||
-                current.activityRecognition?.enabled == true {
-                self.startMotionUpdatesIfAvailable()
-            }
-            self.isRunning = true
-            self.state = .running
         }
     }
 
     func stopBackgroundLocation() throws -> Promise<Void> {
         return Promise.async {
-            self.state = .stopping
-            self.runOnMainSync {
-                self.manager?.disallowDeferredLocationUpdates()
-                self.manager?.stopUpdatingLocation()
-                self.manager?.stopMonitoringSignificantLocationChanges()
+            self.withLifecycleLock {
+                self.withStoreLock { self.state = .stopping }
+                self.stopLocationSession()
+                self.backgroundMotionRequested = false
+                self.updateMotionUpdates()
+                self.withStoreLock {
+                    self.isRunning = false
+                    self.state = .stopped
+                }
             }
-            self.stopMotionUpdatesIfRunning()
-            self.isRunning = false
-            self.state = .stopped
+            self.withListenerLock { /* Stop resolves after prior-session delivery drains. */ }
         }
     }
 
     func resetBackgroundLocation() throws -> Promise<Void> {
         return Promise.async {
-            self.runOnMainSync {
-                self.manager?.disallowDeferredLocationUpdates()
-                self.manager?.stopUpdatingLocation()
-                self.manager?.stopMonitoringSignificantLocationChanges()
-                self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
+            self.withLifecycleLock {
+                self.stopLocationSession()
+                self.withStoreLock {
+                    self.storeGeneration &+= 1
+                    self.options = nil
+                    self.defaults.removeObject(forKey: self.optionsKey)
+                    self.lastSyncAt = 0
+                    self.isRunning = false
+                    self.state = .idle
+                    self.storedLocations.removeAll()
+                    self.storedEvents.removeAll()
+                    self.geofences.removeAll()
+                    self.persistStore()
+                }
+                self.runOnMainSync {
+                    self.manager?.disallowDeferredLocationUpdates()
+                    self.manager?.stopUpdatingLocation()
+                    self.manager?.stopMonitoringSignificantLocationChanges()
+                    self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
+                    self.manager?.delegate = nil
+                    self.manager = nil
+                    self.delegate = nil
+                }
+                self.backgroundMotionRequested = false
+                self.standaloneMotionRequested = false
+                self.updateMotionUpdates()
             }
-            self.stopMotionUpdatesIfRunning()
-            self.options = nil
-            self.defaults.removeObject(forKey: self.optionsKey)
-            self.isRunning = false
-            self.state = .idle
-            self.withStoreLock {
-                self.storedLocations.removeAll()
-                self.storedEvents.removeAll()
-                self.geofences.removeAll()
-                self.persistStore()
-            }
+            // Do not overlap listenerLock with lifecycleLock: callbacks may re-enter lifecycle APIs.
+            self.withListenerLock { /* Barrier for callbacks already dispatching at reset. */ }
         }
     }
 
     func getBackgroundLocationStatus() throws -> Promise<BackgroundLocationStatus> {
         return Promise.async {
-            let permission = self.permissionResult()
-            let store = self.withStoreLock {
-                (
-                    locationCount: Double(self.storedLocations.count),
-                    eventCount: Double(self.storedEvents.count),
-                    lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
-                    lastEventAt: self.storedEvents.map(\.timestamp).max(),
-                    geofenceCount: Double(self.geofences.count)
+            return self.withLifecycleLock {
+                let permission = self.permissionResult()
+                let snapshot = self.withStoreLock {
+                    (
+                        state: self.state,
+                        isRunning: self.isRunning,
+                        isConfigured: self.options != nil,
+                        significantChangesEnabled: self.options?.trackingMode == .significantchanges ||
+                            self.options?.ios?.useSignificantChanges == true,
+                        locationCount: Double(self.storedLocations.count),
+                        eventCount: Double(self.storedEvents.count),
+                        lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
+                        lastEventAt: self.storedEvents.map(\.timestamp).max(),
+                        geofenceCount: Double(self.geofences.count)
+                    )
+                }
+                return BackgroundLocationStatus(
+                    state: snapshot.state,
+                    isRunning: snapshot.isRunning,
+                    isConfigured: snapshot.isConfigured,
+                    foregroundPermission: permission.foreground,
+                    backgroundPermission: permission.background,
+                    accuracyAuthorization: permission.accuracyAuthorization,
+                    locationServicesEnabled: CLLocationManager.locationServicesEnabled(),
+                    providerStatus: nil,
+                    storedLocationCount: snapshot.locationCount,
+                    storedEventCount: snapshot.eventCount,
+                    lastLocationAt: snapshot.lastLocationAt,
+                    lastEventAt: snapshot.lastEventAt,
+                    geofenceCount: snapshot.geofenceCount,
+                    android: nil,
+                    ios: IOSBackgroundLocationStatus(
+                        allowsBackgroundLocationUpdates: self.manager?.allowsBackgroundLocationUpdates ?? false,
+                        significantChangesEnabled: snapshot.significantChangesEnabled
+                    ),
+                    lastError: nil
                 )
             }
-            return BackgroundLocationStatus(
-                state: self.state,
-                isRunning: self.isRunning,
-                isConfigured: self.options != nil,
-                foregroundPermission: permission.foreground,
-                backgroundPermission: permission.background,
-                accuracyAuthorization: permission.accuracyAuthorization,
-                locationServicesEnabled: CLLocationManager.locationServicesEnabled(),
-                providerStatus: nil,
-                storedLocationCount: store.locationCount,
-                storedEventCount: store.eventCount,
-                lastLocationAt: store.lastLocationAt,
-                lastEventAt: store.lastEventAt,
-                geofenceCount: store.geofenceCount,
-                android: nil,
-                ios: IOSBackgroundLocationStatus(
-                    allowsBackgroundLocationUpdates: self.manager?.allowsBackgroundLocationUpdates ?? false,
-                    significantChangesEnabled: self.options?.trackingMode == .significantchanges ||
-                        self.options?.ios?.useSignificantChanges == true
-                ),
-                lastError: nil
-            )
         }
-    }
-
-    func addBackgroundEventListener(listener: @escaping (BackgroundEventEnvelope) -> Void) throws -> String {
-        let token = UUID().uuidString
-        eventListeners[token] = listener
-        return token
-    }
-
-    func removeBackgroundEventListener(token: String) throws {
-        eventListeners.removeValue(forKey: token)
-    }
-
-    func addBackgroundLocationListener(listener: @escaping (BackgroundLocation) -> Void) throws -> String {
-        let token = UUID().uuidString
-        locationListeners[token] = listener
-        return token
-    }
-
-    func removeBackgroundLocationListener(token: String) throws {
-        locationListeners.removeValue(forKey: token)
-    }
-
-    func addBackgroundErrorListener(listener: @escaping (LocationError) -> Void) throws -> String {
-        let token = UUID().uuidString
-        errorListeners[token] = listener
-        return token
-    }
-
-    func removeBackgroundErrorListener(token: String) throws {
-        errorListeners.removeValue(forKey: token)
     }
 
     func getStoredBackgroundLocations(
@@ -334,56 +352,60 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func addGeofences(regions: [GeofenceRegion], options: GeofencingOptions?) throws -> Promise<Void> {
         return Promise.async {
-            self.ensureManager()
-            guard self.permissionResult().background == .granted else {
-                throw RuntimeError.error(withMessage: "Background location permission is required to register geofences")
-            }
-            let sanitized = regions.map(sanitizedGeofence)
-            self.runOnMainSync {
-                for region in sanitized {
-                    let circular = CLCircularRegion(
-                        center: CLLocationCoordinate2D(
-                            latitude: region.latitude,
-                            longitude: region.longitude
-                        ),
-                        radius: region.radius,
-                        identifier: region.identifier
-                    )
-                    circular.notifyOnEntry = region.notifyOnEntry ?? true
-                    circular.notifyOnExit = region.notifyOnExit ?? true
-                    self.manager?.startMonitoring(for: circular)
+            try self.withLifecycleLock {
+                self.ensureManager()
+                guard self.permissionResult().background == .granted else {
+                    throw RuntimeError.error(withMessage: "Background location permission is required to register geofences")
                 }
-            }
-            self.withStoreLock {
-                self.geofences.removeAll { existing in
-                    sanitized.contains { $0.identifier == existing.identifier }
+                let sanitized = regions.map(sanitizedGeofence)
+                self.runOnMainSync {
+                    for region in sanitized {
+                        let circular = CLCircularRegion(
+                            center: CLLocationCoordinate2D(
+                                latitude: region.latitude,
+                                longitude: region.longitude
+                            ),
+                            radius: region.radius,
+                            identifier: region.identifier
+                        )
+                        circular.notifyOnEntry = region.notifyOnEntry ?? true
+                        circular.notifyOnExit = region.notifyOnExit ?? true
+                        self.manager?.startMonitoring(for: circular)
+                    }
                 }
-                self.geofences.append(contentsOf: sanitized)
-                self.persistStore()
+                self.withStoreLock {
+                    self.geofences.removeAll { existing in
+                        sanitized.contains { $0.identifier == existing.identifier }
+                    }
+                    self.geofences.append(contentsOf: sanitized)
+                    self.persistStore()
+                }
             }
         }
     }
 
     func removeGeofences(identifiers: [String]?) throws -> Promise<Void> {
         return Promise.async {
-            guard let identifiers else {
+            self.withLifecycleLock {
+                guard let identifiers else {
+                    self.runOnMainSync {
+                        self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
+                    }
+                    self.withStoreLock {
+                        self.geofences.removeAll()
+                        self.persistStore()
+                    }
+                    return
+                }
                 self.runOnMainSync {
-                    self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
+                    self.manager?.monitoredRegions
+                        .filter { identifiers.contains($0.identifier) }
+                        .forEach { self.manager?.stopMonitoring(for: $0) }
                 }
                 self.withStoreLock {
-                    self.geofences.removeAll()
+                    self.geofences.removeAll { identifiers.contains($0.identifier) }
                     self.persistStore()
                 }
-                return
-            }
-            self.runOnMainSync {
-                self.manager?.monitoredRegions
-                    .filter { identifiers.contains($0.identifier) }
-                    .forEach { self.manager?.stopMonitoring(for: $0) }
-            }
-            self.withStoreLock {
-                self.geofences.removeAll { identifiers.contains($0.identifier) }
-                self.persistStore()
             }
         }
     }
@@ -398,26 +420,39 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func startActivityRecognition(options: ActivityRecognitionOptions?) throws -> Promise<Void> {
         return Promise.async {
-            guard CMMotionActivityManager.isActivityAvailable() else {
-                throw RuntimeError.error(withMessage: "Core Motion activity recognition is not available")
+            try self.withLifecycleLock {
+                try self.settleMotionAuthorization()
+                self.standaloneMotionRequested = true
+                self.updateMotionUpdates()
             }
-            self.startMotionUpdatesIfAvailable()
         }
     }
 
     func stopActivityRecognition() throws -> Promise<Void> {
         return Promise.async {
-            self.stopMotionUpdatesIfRunning()
+            self.withLifecycleLock {
+                self.standaloneMotionRequested = false
+                self.updateMotionUpdates()
+            }
+            self.withListenerLock { /* Drain delivery from a stopped physical registration. */ }
         }
     }
 
     func syncStoredLocations() throws -> Promise<BackgroundHttpSyncResult> {
         return Promise.async {
-            return self.performSyncStoredLocations()
+            let generation = self.withStoreLock { self.storeGeneration }
+            return self.syncScheduler.sync {
+                self.performSyncStoredLocations(runGeneration: generation)
+            }
         }
     }
 
-    func handleLocations(_ locations: [CLLocation]) {
+    func handleLocations(
+        _ locations: [CLLocation],
+        runGeneration: UInt64,
+        locationSessionGeneration: UInt64
+    ) {
+        guard isCurrentLocationSession(runGeneration, locationSessionGeneration) else { return }
         for location in locations {
             let id = UUID().uuidString
             let coords = GeolocationCoordinates(
@@ -468,7 +503,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 timestamp: Date().timeIntervalSince1970 * 1000,
                 deliveredToJS: false
             )
-            withStoreLock {
+            let storedForRun: Bool = withStoreLock {
+                guard runGeneration == storeGeneration,
+                    self.locationSessionGeneration == locationSessionGeneration,
+                    locationSessionActive,
+                    options != nil
+                else { return false }
                 appendStoredLocation(stored)
                 appendStoredEvent(
                     StoredBackgroundEventEnvelope(
@@ -481,16 +521,30 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     )
                 )
                 persistStore()
+                return true
             }
-            eventListeners.values.forEach { $0(event) }
-            locationListeners.values.forEach { $0(backgroundLocation) }
-            scheduleSyncIfNeeded()
+            guard storedForRun else { return }
+            dispatchInProcess(
+                event: event,
+                location: backgroundLocation,
+                runGeneration: runGeneration,
+                locationSessionGeneration: locationSessionGeneration
+            )
+            scheduleSyncIfNeeded(
+                runGeneration: runGeneration,
+                locationSessionGeneration: locationSessionGeneration
+            )
         }
     }
 
-    func handleRegion(_ region: CLRegion, transition: GeofenceTransition) {
-        guard let geofence = withStoreLock({
-            geofences.first(where: { $0.identifier == region.identifier })
+    func handleRegion(
+        _ region: CLRegion,
+        transition: GeofenceTransition,
+        runGeneration: UInt64
+    ) {
+        guard let geofence = withStoreLock({ () -> GeofenceRegion? in
+            guard runGeneration == storeGeneration else { return nil }
+            return geofences.first(where: { $0.identifier == region.identifier })
         }) else {
             return
         }
@@ -511,7 +565,8 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             timestamp: Date().timeIntervalSince1970 * 1000,
             deliveredToJS: false
         )
-        withStoreLock {
+        let storedForRun: Bool = withStoreLock {
+            guard runGeneration == storeGeneration else { return false }
             appendStoredEvent(
                 StoredBackgroundEventEnvelope(
                     event: event,
@@ -520,100 +575,26 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     type: event.type,
                     timestamp: event.timestamp,
                     deliveredToJS: false
-                )
+                ),
+                allowUnconfigured: true
             )
             persistStore()
+            return true
         }
-        eventListeners.values.forEach { $0(event) }
+        guard storedForRun else { return }
+        dispatchInProcess(event: event, runGeneration: runGeneration)
     }
 
-    private func startMotionUpdatesIfAvailable() {
-        guard CMMotionActivityManager.isActivityAvailable() else { return }
-        motionManager.startActivityUpdates(to: motionQueue) { [weak self] activity in
-            guard let self, let activity else { return }
-            self.handleMotionActivity(activity)
-        }
-        isMotionUpdatesRunning = true
-    }
-
-    private func stopMotionUpdatesIfRunning() {
-        guard isMotionUpdatesRunning else { return }
-        motionManager.stopActivityUpdates()
-        isMotionUpdatesRunning = false
-    }
-
-    private func handleMotionActivity(_ activity: CMMotionActivity) {
-        let detected = DetectedActivity(
-            type: motionActivityType(activity),
-            confidence: motionConfidence(activity.confidence),
-            timestamp: activity.startDate.timeIntervalSince1970 * 1000
-        )
-        let event = BackgroundEventEnvelope(
-            location: nil,
-            geofence: nil,
-            activity: detected,
-            providerStatus: nil,
-            result: nil,
-            error: nil,
-            id: UUID().uuidString,
-            type: .activity,
-            timestamp: Date().timeIntervalSince1970 * 1000,
-            deliveredToJS: false
-        )
-        withStoreLock {
-            appendStoredEvent(
-                StoredBackgroundEventEnvelope(
-                    event: event,
-                    createdAt: Date().timeIntervalSince1970 * 1000,
-                    id: event.id,
-                    type: event.type,
-                    timestamp: event.timestamp,
-                    deliveredToJS: false
-                )
-            )
-            persistStore()
-        }
-        eventListeners.values.forEach { $0(event) }
-        applyActivityAwareTracking(detected)
-    }
-
-    func handleAuthorizationChange() {
-        permissionSemaphore?.signal()
-    }
-
-    func handleError(_ error: Error) {
-        // kCLErrorLocationUnknown is transient — CoreLocation couldn't get a fix right now but keeps
-        // trying (very common on the Simulator and during brief GPS gaps). Apple's guidance is to
-        // ignore it; forwarding it would pollute the consumer's error stream with benign noise.
-        if let clError = error as? CLError, clError.code == .locationUnknown {
-            return
-        }
-        let locationError = LocationError(code: -1, message: error.localizedDescription)
-        errorListeners.values.forEach { $0(locationError) }
-    }
-
-    func ensureManager() {
-        if manager != nil { return }
-        if Thread.isMainThread == false {
-            DispatchQueue.main.sync {
-                self.ensureManager()
-            }
-            return
-        }
-        let manager = CLLocationManager()
-        let delegate = NitroBackgroundLocationDelegate(owner: self)
-        manager.delegate = delegate
-        self.manager = manager
-        self.delegate = delegate
-    }
-
-    private func apply(_ options: BackgroundLocationOptions) throws {
+    private func validateBackgroundLocationMode() throws {
         guard hasBackgroundLocationMode() else {
-            state = .error
+            withStoreLock { state = .error }
             throw RuntimeError.error(
                 withMessage: "UIBackgroundModes must include location for iOS background location"
             )
         }
+    }
+
+    private func apply(_ options: BackgroundLocationOptions) {
         runOnMainSync {
             guard let manager = self.manager else { return }
             manager.allowsBackgroundLocationUpdates = true
@@ -635,51 +616,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         }
     }
 
-    func applyDeferredUpdatesIfNeeded(_ manager: CLLocationManager) {
-        guard
-            let options,
-            let distance = options.ios?.deferredUpdatesDistance,
-            let interval = options.ios?.deferredUpdatesInterval
-        else {
-            return
-        }
-        manager.allowDeferredLocationUpdates(
-            untilTraveled: distance,
-            timeout: interval / 1000
-        )
-    }
-
-    private func applyActivityAwareTracking(_ activity: DetectedActivity) {
-        guard let options else { return }
-        let activityOptions = options.activityRecognition
-        guard options.trackingMode == .activityaware ||
-            activityOptions?.stopOnStill == true else {
-            return
-        }
-        let minimumConfidence = activityOptions?.minimumConfidence ?? 0
-        guard activity.confidence >= minimumConfidence else { return }
-        let stopOnStill = activityOptions?.stopOnStill ?? (options.trackingMode == .activityaware)
-        if activity.type == .still && stopOnStill {
-            runOnMainSync {
-                self.manager?.disallowDeferredLocationUpdates()
-                self.manager?.stopUpdatingLocation()
-                self.manager?.stopMonitoringSignificantLocationChanges()
-            }
-            return
-        }
-        if activity.type != .still && activity.type != .unknown && isRunning {
-            runOnMainSync {
-                if options.trackingMode == .significantchanges ||
-                    options.ios?.useSignificantChanges == true {
-                    self.manager?.startMonitoringSignificantLocationChanges()
-                } else {
-                    self.manager?.startUpdatingLocation()
-                }
-            }
-        }
-    }
-
-    private func runOnMainSync(_ work: @escaping () -> Void) {
+    func runOnMainSync(_ work: @escaping () -> Void) {
         if Thread.isMainThread {
             work()
         } else {
@@ -694,10 +631,20 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return modes.contains("location")
     }
 
-    private func withStoreLock<T>(_ work: () throws -> T) rethrows -> T {
+    func withStoreLock<T>(_ work: () throws -> T) rethrows -> T {
         storeLock.lock()
         defer { storeLock.unlock() }
         return try work()
+    }
+
+    func withListenerLock<T>(_ work: () throws -> T) rethrows -> T {
+        listenerLock.lock()
+        defer { listenerLock.unlock() }
+        return try work()
+    }
+
+    func isCurrentGeneration(_ generation: UInt64) -> Bool {
+        return withStoreLock { generation == storeGeneration }
     }
 
     private func loadPersistedStore() {
@@ -708,11 +655,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 .compactMap(makeGeofenceRegion)
             storedEvents = (defaults.array(forKey: eventsKey) as? [[String: Any]] ?? [])
                 .compactMap { makeStoredEvent($0, storedLocations: storedLocations) }
+            options = defaults.dictionary(forKey: optionsKey).flatMap(makeBackgroundOptions)
         }
-        options = defaults.dictionary(forKey: optionsKey).flatMap(makeBackgroundOptions)
     }
 
-    private func persistStore() {
+    func persistStore() {
         withStoreLock {
             defaults.set(storedLocations.map(storedLocationDictionary), forKey: locationsKey)
             defaults.set(storedEvents.map(storedEventDictionary), forKey: eventsKey)
@@ -720,11 +667,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         }
     }
 
-    private func shouldPersist() -> Bool {
-        return options?.persist != false
+    private func shouldPersist(allowUnconfigured: Bool = false) -> Bool {
+        guard let options else { return allowUnconfigured }
+        return options.persist != false
     }
 
-    private func safePrefixCount(
+    func safePrefixCount(
         _ value: Double?,
         defaultValue: Int,
         upperBound: Int
@@ -734,7 +682,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return Int(min(requested.rounded(.down), Double(upperBound)))
     }
 
-    private func positiveFiniteInt(_ value: Double?, defaultValue: Int) -> Int {
+    func positiveFiniteInt(_ value: Double?, defaultValue: Int) -> Int {
         guard let value, value.isFinite, value > 0 else {
             return defaultValue
         }
@@ -765,9 +713,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         }
     }
 
-    private func appendStoredEvent(_ event: StoredBackgroundEventEnvelope) {
+    func appendStoredEvent(
+        _ event: StoredBackgroundEventEnvelope,
+        allowUnconfigured: Bool = false
+    ) {
         withStoreLock {
-            guard shouldPersist() else { return }
+            guard shouldPersist(allowUnconfigured: allowUnconfigured) else { return }
             storedEvents.append(event)
             if let max = resolveMaxStored(options?.maxStoredEvents, default: Self.defaultMaxStoredRows),
                storedEvents.count > max {
@@ -778,111 +729,6 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     private func persistOptions(_ options: BackgroundLocationOptions) {
         defaults.set(backgroundOptionsDictionary(options), forKey: optionsKey)
-    }
-
-    private func scheduleSyncIfNeeded() {
-        guard let sync = options?.sync else { return }
-        let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
-        let unsyncedCount = withStoreLock {
-            storedLocations.filter { !$0.synced }.count
-        }
-        guard unsyncedCount >= threshold else { return }
-
-        let now = Date().timeIntervalSince1970 * 1000
-        let interval = sync.syncInterval ?? 0
-        guard interval <= 0 || now - lastSyncAt >= interval else { return }
-        lastSyncAt = now
-
-        syncQueue.async {
-            let result = self.performSyncStoredLocations()
-            let event = BackgroundEventEnvelope(
-                location: nil,
-                geofence: nil,
-                activity: nil,
-                providerStatus: nil,
-                result: result,
-                error: nil,
-                id: UUID().uuidString,
-                type: .httpsync,
-                timestamp: Date().timeIntervalSince1970 * 1000,
-                deliveredToJS: false
-            )
-            self.withStoreLock {
-                self.appendStoredEvent(
-                    StoredBackgroundEventEnvelope(
-                        event: event,
-                        createdAt: Date().timeIntervalSince1970 * 1000,
-                        id: event.id,
-                        type: event.type,
-                        timestamp: event.timestamp,
-                        deliveredToJS: false
-                    )
-                )
-                self.persistStore()
-            }
-            self.eventListeners.values.forEach { $0(event) }
-        }
-    }
-
-    private func performSyncStoredLocations() -> BackgroundHttpSyncResult {
-        let allUnsynced = withStoreLock {
-            storedLocations.filter { !$0.synced }
-        }
-        let unsynced = allUnsynced.prefix(safePrefixCount(
-            options?.sync?.batchSize,
-            defaultValue: 50,
-            upperBound: allUnsynced.count
-        ))
-        let ids = unsynced.map(\.id)
-        if ids.isEmpty {
-            return BackgroundHttpSyncResult(
-                success: true,
-                statusCode: nil,
-                syncedLocationIds: [],
-                failedLocationIds: [],
-                error: nil
-            )
-        }
-        guard let sync = options?.sync else {
-            return BackgroundHttpSyncResult(
-                success: true,
-                statusCode: nil,
-                syncedLocationIds: [],
-                failedLocationIds: [],
-                error: nil
-            )
-        }
-        let result = httpSync.uploadWithRetry(locations: Array(unsynced), sync: sync)
-        if !result.success && result.syncedLocationIds.isEmpty {
-            return result
-        }
-        let syncedIds = result.syncedLocationIds
-        withStoreLock {
-            storedLocations = storedLocations.map { location in
-                syncedIds.contains(location.id)
-                    ? StoredBackgroundLocation(
-                        id: location.id,
-                        deliveredToJS: location.deliveredToJS,
-                        synced: true,
-                        createdAt: location.createdAt,
-                        source: location.source,
-                        isFromBackground: location.isFromBackground,
-                        provider: location.provider,
-                        mocked: location.mocked,
-                        recordedAt: location.recordedAt,
-                        activity: location.activity,
-                        battery: location.battery,
-                        coords: location.coords,
-                        timestamp: location.timestamp
-                    )
-                    : location
-            }
-            if options?.sync?.autoClear == true {
-                storedLocations.removeAll { syncedIds.contains($0.id) }
-            }
-            persistStore()
-        }
-        return result
     }
 
 }

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -19,7 +19,8 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     private var storedLocations: [StoredBackgroundLocation] = []
     private var storedEvents: [StoredBackgroundEventEnvelope] = []
     private var geofences: [GeofenceRegion] = []
-    private var manager: CLLocationManager?
+    private let storeLock = NSRecursiveLock()
+    var manager: CLLocationManager?
     private var delegate: NitroBackgroundLocationDelegate?
     private let motionManager = CMMotionActivityManager()
     private let motionQueue = OperationQueue()
@@ -134,16 +135,27 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             self.defaults.removeObject(forKey: self.optionsKey)
             self.isRunning = false
             self.state = .idle
-            self.storedLocations.removeAll()
-            self.storedEvents.removeAll()
-            self.geofences.removeAll()
-            self.persistStore()
+            self.withStoreLock {
+                self.storedLocations.removeAll()
+                self.storedEvents.removeAll()
+                self.geofences.removeAll()
+                self.persistStore()
+            }
         }
     }
 
     func getBackgroundLocationStatus() throws -> Promise<BackgroundLocationStatus> {
         return Promise.async {
             let permission = self.permissionResult()
+            let store = self.withStoreLock {
+                (
+                    locationCount: Double(self.storedLocations.count),
+                    eventCount: Double(self.storedEvents.count),
+                    lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
+                    lastEventAt: self.storedEvents.map(\.timestamp).max(),
+                    geofenceCount: Double(self.geofences.count)
+                )
+            }
             return BackgroundLocationStatus(
                 state: self.state,
                 isRunning: self.isRunning,
@@ -153,11 +165,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 accuracyAuthorization: permission.accuracyAuthorization,
                 locationServicesEnabled: CLLocationManager.locationServicesEnabled(),
                 providerStatus: nil,
-                storedLocationCount: Double(self.storedLocations.count),
-                storedEventCount: Double(self.storedEvents.count),
-                lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
-                lastEventAt: self.storedEvents.map(\.timestamp).max(),
-                geofenceCount: Double(self.geofences.count),
+                storedLocationCount: store.locationCount,
+                storedEventCount: store.eventCount,
+                lastLocationAt: store.lastLocationAt,
+                lastEventAt: store.lastEventAt,
+                geofenceCount: store.geofenceCount,
                 android: nil,
                 ios: IOSBackgroundLocationStatus(
                     allowsBackgroundLocationUpdates: self.manager?.allowsBackgroundLocationUpdates ?? false,
@@ -203,7 +215,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         options: GetStoredBackgroundLocationsOptions?
     ) throws -> Promise<[StoredBackgroundLocation]> {
         return Promise.async {
-            var rows = self.storedLocations
+            var rows = self.withStoreLock { self.storedLocations }
             if options?.includeDelivered != true {
                 rows = rows.filter { !$0.deliveredToJS }
             }
@@ -224,38 +236,42 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func clearStoredBackgroundLocations(ids: [String]?) throws -> Promise<Void> {
         return Promise.async {
-            guard let ids else {
-                self.storedLocations.removeAll()
+            self.withStoreLock {
+                guard let ids else {
+                    self.storedLocations.removeAll()
+                    self.persistStore()
+                    return
+                }
+                self.storedLocations.removeAll { ids.contains($0.id) }
                 self.persistStore()
-                return
             }
-            self.storedLocations.removeAll { ids.contains($0.id) }
-            self.persistStore()
         }
     }
 
     func markStoredBackgroundLocationsDelivered(ids: [String]) throws -> Promise<Void> {
         return Promise.async {
-            self.storedLocations = self.storedLocations.map { location in
-                ids.contains(location.id)
-                    ? StoredBackgroundLocation(
-                        id: location.id,
-                        deliveredToJS: true,
-                        synced: location.synced,
-                        createdAt: location.createdAt,
-                        source: location.source,
-                        isFromBackground: location.isFromBackground,
-                        provider: location.provider,
-                        mocked: location.mocked,
-                        recordedAt: location.recordedAt,
-                        activity: location.activity,
-                        battery: location.battery,
-                        coords: location.coords,
-                        timestamp: location.timestamp
-                    )
-                    : location
+            self.withStoreLock {
+                self.storedLocations = self.storedLocations.map { location in
+                    ids.contains(location.id)
+                        ? StoredBackgroundLocation(
+                            id: location.id,
+                            deliveredToJS: true,
+                            synced: location.synced,
+                            createdAt: location.createdAt,
+                            source: location.source,
+                            isFromBackground: location.isFromBackground,
+                            provider: location.provider,
+                            mocked: location.mocked,
+                            recordedAt: location.recordedAt,
+                            activity: location.activity,
+                            battery: location.battery,
+                            coords: location.coords,
+                            timestamp: location.timestamp
+                        )
+                        : location
+                }
+                self.persistStore()
             }
-            self.persistStore()
         }
     }
 
@@ -263,7 +279,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         options: GetStoredBackgroundEventsOptions?
     ) throws -> Promise<[StoredBackgroundEventEnvelope]> {
         return Promise.async {
-            var rows = self.storedEvents
+            var rows = self.withStoreLock { self.storedEvents }
             if options?.includeDelivered != true {
                 rows = rows.filter { !$0.deliveredToJS }
             }
@@ -284,31 +300,35 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func clearStoredBackgroundEvents(ids: [String]?) throws -> Promise<Void> {
         return Promise.async {
-            guard let ids else {
-                self.storedEvents.removeAll()
+            self.withStoreLock {
+                guard let ids else {
+                    self.storedEvents.removeAll()
+                    self.persistStore()
+                    return
+                }
+                self.storedEvents.removeAll { ids.contains($0.id) }
                 self.persistStore()
-                return
             }
-            self.storedEvents.removeAll { ids.contains($0.id) }
-            self.persistStore()
         }
     }
 
     func markStoredBackgroundEventsDelivered(ids: [String]) throws -> Promise<Void> {
         return Promise.async {
-            self.storedEvents = self.storedEvents.map { event in
-                ids.contains(event.id)
-                    ? StoredBackgroundEventEnvelope(
-                        event: event.event,
-                        createdAt: event.createdAt,
-                        id: event.id,
-                        type: event.type,
-                        timestamp: event.timestamp,
-                        deliveredToJS: true
-                    )
-                    : event
+            self.withStoreLock {
+                self.storedEvents = self.storedEvents.map { event in
+                    ids.contains(event.id)
+                        ? StoredBackgroundEventEnvelope(
+                            event: event.event,
+                            createdAt: event.createdAt,
+                            id: event.id,
+                            type: event.type,
+                            timestamp: event.timestamp,
+                            deliveredToJS: true
+                        )
+                        : event
+                }
+                self.persistStore()
             }
-            self.persistStore()
         }
     }
 
@@ -334,11 +354,13 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     self.manager?.startMonitoring(for: circular)
                 }
             }
-            self.geofences.removeAll { existing in
-                sanitized.contains { $0.identifier == existing.identifier }
+            self.withStoreLock {
+                self.geofences.removeAll { existing in
+                    sanitized.contains { $0.identifier == existing.identifier }
+                }
+                self.geofences.append(contentsOf: sanitized)
+                self.persistStore()
             }
-            self.geofences.append(contentsOf: sanitized)
-            self.persistStore()
         }
     }
 
@@ -348,8 +370,10 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 self.runOnMainSync {
                     self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
                 }
-                self.geofences.removeAll()
-                self.persistStore()
+                self.withStoreLock {
+                    self.geofences.removeAll()
+                    self.persistStore()
+                }
                 return
             }
             self.runOnMainSync {
@@ -357,14 +381,18 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     .filter { identifiers.contains($0.identifier) }
                     .forEach { self.manager?.stopMonitoring(for: $0) }
             }
-            self.geofences.removeAll { identifiers.contains($0.identifier) }
-            self.persistStore()
+            self.withStoreLock {
+                self.geofences.removeAll { identifiers.contains($0.identifier) }
+                self.persistStore()
+            }
         }
     }
 
     func getRegisteredGeofences() throws -> Promise<[GeofenceRegion]> {
         return Promise.async {
-            return self.geofences.map(bridgeSafeGeofence)
+            return self.withStoreLock {
+                self.geofences.map(bridgeSafeGeofence)
+            }
         }
     }
 
@@ -440,18 +468,20 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 timestamp: Date().timeIntervalSince1970 * 1000,
                 deliveredToJS: false
             )
-            appendStoredLocation(stored)
-            appendStoredEvent(
-                StoredBackgroundEventEnvelope(
-                    event: event,
-                    createdAt: Date().timeIntervalSince1970 * 1000,
-                    id: event.id,
-                    type: event.type,
-                    timestamp: event.timestamp,
-                    deliveredToJS: false
+            withStoreLock {
+                appendStoredLocation(stored)
+                appendStoredEvent(
+                    StoredBackgroundEventEnvelope(
+                        event: event,
+                        createdAt: Date().timeIntervalSince1970 * 1000,
+                        id: event.id,
+                        type: event.type,
+                        timestamp: event.timestamp,
+                        deliveredToJS: false
+                    )
                 )
-            )
-            persistStore()
+                persistStore()
+            }
             eventListeners.values.forEach { $0(event) }
             locationListeners.values.forEach { $0(backgroundLocation) }
             scheduleSyncIfNeeded()
@@ -459,7 +489,9 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     }
 
     func handleRegion(_ region: CLRegion, transition: GeofenceTransition) {
-        guard let geofence = geofences.first(where: { $0.identifier == region.identifier }) else {
+        guard let geofence = withStoreLock({
+            geofences.first(where: { $0.identifier == region.identifier })
+        }) else {
             return
         }
         let event = BackgroundEventEnvelope(
@@ -479,17 +511,19 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             timestamp: Date().timeIntervalSince1970 * 1000,
             deliveredToJS: false
         )
-        appendStoredEvent(
-            StoredBackgroundEventEnvelope(
-                event: event,
-                createdAt: Date().timeIntervalSince1970 * 1000,
-                id: event.id,
-                type: event.type,
-                timestamp: event.timestamp,
-                deliveredToJS: false
+        withStoreLock {
+            appendStoredEvent(
+                StoredBackgroundEventEnvelope(
+                    event: event,
+                    createdAt: Date().timeIntervalSince1970 * 1000,
+                    id: event.id,
+                    type: event.type,
+                    timestamp: event.timestamp,
+                    deliveredToJS: false
+                )
             )
-        )
-        persistStore()
+            persistStore()
+        }
         eventListeners.values.forEach { $0(event) }
     }
 
@@ -526,17 +560,19 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             timestamp: Date().timeIntervalSince1970 * 1000,
             deliveredToJS: false
         )
-        appendStoredEvent(
-            StoredBackgroundEventEnvelope(
-                event: event,
-                createdAt: Date().timeIntervalSince1970 * 1000,
-                id: event.id,
-                type: event.type,
-                timestamp: event.timestamp,
-                deliveredToJS: false
+        withStoreLock {
+            appendStoredEvent(
+                StoredBackgroundEventEnvelope(
+                    event: event,
+                    createdAt: Date().timeIntervalSince1970 * 1000,
+                    id: event.id,
+                    type: event.type,
+                    timestamp: event.timestamp,
+                    deliveredToJS: false
+                )
             )
-        )
-        persistStore()
+            persistStore()
+        }
         eventListeners.values.forEach { $0(event) }
         applyActivityAwareTracking(detected)
     }
@@ -556,7 +592,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         errorListeners.values.forEach { $0(locationError) }
     }
 
-    private func ensureManager() {
+    func ensureManager() {
         if manager != nil { return }
         if Thread.isMainThread == false {
             DispatchQueue.main.sync {
@@ -658,20 +694,30 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return modes.contains("location")
     }
 
+    private func withStoreLock<T>(_ work: () throws -> T) rethrows -> T {
+        storeLock.lock()
+        defer { storeLock.unlock() }
+        return try work()
+    }
+
     private func loadPersistedStore() {
-        storedLocations = (defaults.array(forKey: locationsKey) as? [[String: Any]] ?? [])
-            .compactMap(makeStoredLocation)
-        geofences = (defaults.array(forKey: geofencesKey) as? [[String: Any]] ?? [])
-            .compactMap(makeGeofenceRegion)
-        storedEvents = (defaults.array(forKey: eventsKey) as? [[String: Any]] ?? [])
-            .compactMap { makeStoredEvent($0, storedLocations: storedLocations) }
+        withStoreLock {
+            storedLocations = (defaults.array(forKey: locationsKey) as? [[String: Any]] ?? [])
+                .compactMap(makeStoredLocation)
+            geofences = (defaults.array(forKey: geofencesKey) as? [[String: Any]] ?? [])
+                .compactMap(makeGeofenceRegion)
+            storedEvents = (defaults.array(forKey: eventsKey) as? [[String: Any]] ?? [])
+                .compactMap { makeStoredEvent($0, storedLocations: storedLocations) }
+        }
         options = defaults.dictionary(forKey: optionsKey).flatMap(makeBackgroundOptions)
     }
 
     private func persistStore() {
-        defaults.set(storedLocations.map(storedLocationDictionary), forKey: locationsKey)
-        defaults.set(storedEvents.map(storedEventDictionary), forKey: eventsKey)
-        defaults.set(geofences.map(geofenceDictionary), forKey: geofencesKey)
+        withStoreLock {
+            defaults.set(storedLocations.map(storedLocationDictionary), forKey: locationsKey)
+            defaults.set(storedEvents.map(storedEventDictionary), forKey: eventsKey)
+            defaults.set(geofences.map(geofenceDictionary), forKey: geofencesKey)
+        }
     }
 
     private func shouldPersist() -> Bool {
@@ -709,20 +755,24 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     }
 
     private func appendStoredLocation(_ location: StoredBackgroundLocation) {
-        guard shouldPersist() else { return }
-        storedLocations.append(location)
-        if let max = resolveMaxStored(options?.maxStoredLocations, default: Self.defaultMaxStoredRows),
-           storedLocations.count > max {
-            storedLocations = Array(storedLocations.suffix(max))
+        withStoreLock {
+            guard shouldPersist() else { return }
+            storedLocations.append(location)
+            if let max = resolveMaxStored(options?.maxStoredLocations, default: Self.defaultMaxStoredRows),
+               storedLocations.count > max {
+                storedLocations = Array(storedLocations.suffix(max))
+            }
         }
     }
 
     private func appendStoredEvent(_ event: StoredBackgroundEventEnvelope) {
-        guard shouldPersist() else { return }
-        storedEvents.append(event)
-        if let max = resolveMaxStored(options?.maxStoredEvents, default: Self.defaultMaxStoredRows),
-           storedEvents.count > max {
-            storedEvents = Array(storedEvents.suffix(max))
+        withStoreLock {
+            guard shouldPersist() else { return }
+            storedEvents.append(event)
+            if let max = resolveMaxStored(options?.maxStoredEvents, default: Self.defaultMaxStoredRows),
+               storedEvents.count > max {
+                storedEvents = Array(storedEvents.suffix(max))
+            }
         }
     }
 
@@ -733,7 +783,9 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     private func scheduleSyncIfNeeded() {
         guard let sync = options?.sync else { return }
         let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
-        let unsyncedCount = storedLocations.filter { !$0.synced }.count
+        let unsyncedCount = withStoreLock {
+            storedLocations.filter { !$0.synced }.count
+        }
         guard unsyncedCount >= threshold else { return }
 
         let now = Date().timeIntervalSince1970 * 1000
@@ -755,23 +807,27 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 timestamp: Date().timeIntervalSince1970 * 1000,
                 deliveredToJS: false
             )
-            self.appendStoredEvent(
-                StoredBackgroundEventEnvelope(
-                    event: event,
-                    createdAt: Date().timeIntervalSince1970 * 1000,
-                    id: event.id,
-                    type: event.type,
-                    timestamp: event.timestamp,
-                    deliveredToJS: false
+            self.withStoreLock {
+                self.appendStoredEvent(
+                    StoredBackgroundEventEnvelope(
+                        event: event,
+                        createdAt: Date().timeIntervalSince1970 * 1000,
+                        id: event.id,
+                        type: event.type,
+                        timestamp: event.timestamp,
+                        deliveredToJS: false
+                    )
                 )
-            )
-            self.persistStore()
+                self.persistStore()
+            }
             self.eventListeners.values.forEach { $0(event) }
         }
     }
 
     private func performSyncStoredLocations() -> BackgroundHttpSyncResult {
-        let allUnsynced = storedLocations.filter { !$0.synced }
+        let allUnsynced = withStoreLock {
+            storedLocations.filter { !$0.synced }
+        }
         let unsynced = allUnsynced.prefix(safePrefixCount(
             options?.sync?.batchSize,
             defaultValue: 50,
@@ -801,71 +857,32 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             return result
         }
         let syncedIds = result.syncedLocationIds
-        storedLocations = storedLocations.map { location in
-            syncedIds.contains(location.id)
-                ? StoredBackgroundLocation(
-                    id: location.id,
-                    deliveredToJS: location.deliveredToJS,
-                    synced: true,
-                    createdAt: location.createdAt,
-                    source: location.source,
-                    isFromBackground: location.isFromBackground,
-                    provider: location.provider,
-                    mocked: location.mocked,
-                    recordedAt: location.recordedAt,
-                    activity: location.activity,
-                    battery: location.battery,
-                    coords: location.coords,
-                    timestamp: location.timestamp
-                )
-                : location
+        withStoreLock {
+            storedLocations = storedLocations.map { location in
+                syncedIds.contains(location.id)
+                    ? StoredBackgroundLocation(
+                        id: location.id,
+                        deliveredToJS: location.deliveredToJS,
+                        synced: true,
+                        createdAt: location.createdAt,
+                        source: location.source,
+                        isFromBackground: location.isFromBackground,
+                        provider: location.provider,
+                        mocked: location.mocked,
+                        recordedAt: location.recordedAt,
+                        activity: location.activity,
+                        battery: location.battery,
+                        coords: location.coords,
+                        timestamp: location.timestamp
+                    )
+                    : location
+            }
+            if options?.sync?.autoClear == true {
+                storedLocations.removeAll { syncedIds.contains($0.id) }
+            }
+            persistStore()
         }
-        if options?.sync?.autoClear == true {
-            storedLocations.removeAll { syncedIds.contains($0.id) }
-        }
-        persistStore()
         return result
     }
 
-    private func permissionResult() -> BackgroundPermissionResult {
-        ensureManager()
-        let status = CLLocationManager.authorizationStatus()
-        let foreground: PermissionStatus
-        let background: BackgroundPermissionStatus
-        switch status {
-        case .authorizedAlways:
-            foreground = .granted
-            background = .granted
-        case .authorizedWhenInUse:
-            foreground = .granted
-            background = .denied
-        case .denied:
-            foreground = .denied
-            background = .denied
-        case .restricted:
-            foreground = .restricted
-            background = .restricted
-        case .notDetermined:
-            foreground = .undetermined
-            background = .undetermined
-        @unknown default:
-            foreground = .undetermined
-            background = .undetermined
-        }
-
-        let accuracy: AccuracyAuthorization
-        if #available(iOS 14.0, *) {
-            accuracy = manager?.accuracyAuthorization == .fullAccuracy ? .full : .reduced
-        } else {
-            accuracy = .unknown
-        }
-
-        return BackgroundPermissionResult(
-            foreground: foreground,
-            background: background,
-            accuracyAuthorization: accuracy,
-            canRequestBackgroundInline: true,
-            needsSettingsRedirect: background != .granted
-        )
-    }
 }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/c++/JBackgroundLocationStatus.hpp
@@ -68,6 +68,10 @@ namespace margelo::nitro::nitrogeolocation {
       double storedLocationCount = this->getFieldValue(fieldStoredLocationCount);
       static const auto fieldStoredEventCount = clazz->getField<double>("storedEventCount");
       double storedEventCount = this->getFieldValue(fieldStoredEventCount);
+      static const auto fieldLastLocationAt = clazz->getField<jni::JDouble>("lastLocationAt");
+      jni::local_ref<jni::JDouble> lastLocationAt = this->getFieldValue(fieldLastLocationAt);
+      static const auto fieldLastEventAt = clazz->getField<jni::JDouble>("lastEventAt");
+      jni::local_ref<jni::JDouble> lastEventAt = this->getFieldValue(fieldLastEventAt);
       static const auto fieldGeofenceCount = clazz->getField<double>("geofenceCount");
       double geofenceCount = this->getFieldValue(fieldGeofenceCount);
       static const auto fieldAndroid = clazz->getField<JAndroidBackgroundLocationStatus>("android");
@@ -87,6 +91,8 @@ namespace margelo::nitro::nitrogeolocation {
         providerStatus != nullptr ? std::make_optional(providerStatus->toCpp()) : std::nullopt,
         storedLocationCount,
         storedEventCount,
+        lastLocationAt != nullptr ? std::make_optional(lastLocationAt->value()) : std::nullopt,
+        lastEventAt != nullptr ? std::make_optional(lastEventAt->value()) : std::nullopt,
         geofenceCount,
         android != nullptr ? std::make_optional(android->toCpp()) : std::nullopt,
         ios != nullptr ? std::make_optional(ios->toCpp()) : std::nullopt,
@@ -100,7 +106,7 @@ namespace margelo::nitro::nitrogeolocation {
      */
     [[maybe_unused]]
     static jni::local_ref<JBackgroundLocationStatus::javaobject> fromCpp(const BackgroundLocationStatus& value) {
-      using JSignature = JBackgroundLocationStatus(jni::alias_ref<JBackgroundLocationState>, jboolean, jboolean, jni::alias_ref<JPermissionStatus>, jni::alias_ref<JBackgroundPermissionStatus>, jni::alias_ref<JAccuracyAuthorization>, jboolean, jni::alias_ref<JLocationProviderStatus>, double, double, double, jni::alias_ref<JAndroidBackgroundLocationStatus>, jni::alias_ref<JIOSBackgroundLocationStatus>, jni::alias_ref<JLocationError>);
+      using JSignature = JBackgroundLocationStatus(jni::alias_ref<JBackgroundLocationState>, jboolean, jboolean, jni::alias_ref<JPermissionStatus>, jni::alias_ref<JBackgroundPermissionStatus>, jni::alias_ref<JAccuracyAuthorization>, jboolean, jni::alias_ref<JLocationProviderStatus>, double, double, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>, double, jni::alias_ref<JAndroidBackgroundLocationStatus>, jni::alias_ref<JIOSBackgroundLocationStatus>, jni::alias_ref<JLocationError>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
@@ -115,6 +121,8 @@ namespace margelo::nitro::nitrogeolocation {
         value.providerStatus.has_value() ? JLocationProviderStatus::fromCpp(value.providerStatus.value()) : nullptr,
         value.storedLocationCount,
         value.storedEventCount,
+        value.lastLocationAt.has_value() ? jni::JDouble::valueOf(value.lastLocationAt.value()) : nullptr,
+        value.lastEventAt.has_value() ? jni::JDouble::valueOf(value.lastEventAt.value()) : nullptr,
         value.geofenceCount,
         value.android.has_value() ? JAndroidBackgroundLocationStatus::fromCpp(value.android.value()) : nullptr,
         value.ios.has_value() ? JIOSBackgroundLocationStatus::fromCpp(value.ios.value()) : nullptr,

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationStatus.kt
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/android/kotlin/com/margelo/nitro/nitrogeolocation/BackgroundLocationStatus.kt
@@ -50,6 +50,12 @@ data class BackgroundLocationStatus(
   val storedEventCount: Double,
   @DoNotStrip
   @Keep
+  val lastLocationAt: Double?,
+  @DoNotStrip
+  @Keep
+  val lastEventAt: Double?,
+  @DoNotStrip
+  @Keep
   val geofenceCount: Double,
   @DoNotStrip
   @Keep
@@ -76,6 +82,8 @@ data class BackgroundLocationStatus(
       && Objects.deepEquals(this.providerStatus, other.providerStatus)
       && Objects.deepEquals(this.storedLocationCount, other.storedLocationCount)
       && Objects.deepEquals(this.storedEventCount, other.storedEventCount)
+      && Objects.deepEquals(this.lastLocationAt, other.lastLocationAt)
+      && Objects.deepEquals(this.lastEventAt, other.lastEventAt)
       && Objects.deepEquals(this.geofenceCount, other.geofenceCount)
       && Objects.deepEquals(this.android, other.android)
       && Objects.deepEquals(this.ios, other.ios)
@@ -94,6 +102,8 @@ data class BackgroundLocationStatus(
       providerStatus,
       storedLocationCount,
       storedEventCount,
+      lastLocationAt,
+      lastEventAt,
       geofenceCount,
       android,
       ios,
@@ -109,8 +119,8 @@ data class BackgroundLocationStatus(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(state: BackgroundLocationState, isRunning: Boolean, isConfigured: Boolean, foregroundPermission: PermissionStatus, backgroundPermission: BackgroundPermissionStatus, accuracyAuthorization: AccuracyAuthorization?, locationServicesEnabled: Boolean, providerStatus: LocationProviderStatus?, storedLocationCount: Double, storedEventCount: Double, geofenceCount: Double, android: AndroidBackgroundLocationStatus?, ios: IOSBackgroundLocationStatus?, lastError: LocationError?): BackgroundLocationStatus {
-      return BackgroundLocationStatus(state, isRunning, isConfigured, foregroundPermission, backgroundPermission, accuracyAuthorization, locationServicesEnabled, providerStatus, storedLocationCount, storedEventCount, geofenceCount, android, ios, lastError)
+    private fun fromCpp(state: BackgroundLocationState, isRunning: Boolean, isConfigured: Boolean, foregroundPermission: PermissionStatus, backgroundPermission: BackgroundPermissionStatus, accuracyAuthorization: AccuracyAuthorization?, locationServicesEnabled: Boolean, providerStatus: LocationProviderStatus?, storedLocationCount: Double, storedEventCount: Double, lastLocationAt: Double?, lastEventAt: Double?, geofenceCount: Double, android: AndroidBackgroundLocationStatus?, ios: IOSBackgroundLocationStatus?, lastError: LocationError?): BackgroundLocationStatus {
+      return BackgroundLocationStatus(state, isRunning, isConfigured, foregroundPermission, backgroundPermission, accuracyAuthorization, locationServicesEnabled, providerStatus, storedLocationCount, storedEventCount, lastLocationAt, lastEventAt, geofenceCount, android, ios, lastError)
     }
   }
 }

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/BackgroundLocationStatus.swift
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/ios/swift/BackgroundLocationStatus.swift
@@ -18,7 +18,7 @@ public extension BackgroundLocationStatus {
   /**
    * Create a new instance of `BackgroundLocationStatus`.
    */
-  init(state: BackgroundLocationState, isRunning: Bool, isConfigured: Bool, foregroundPermission: PermissionStatus, backgroundPermission: BackgroundPermissionStatus, accuracyAuthorization: AccuracyAuthorization?, locationServicesEnabled: Bool, providerStatus: LocationProviderStatus?, storedLocationCount: Double, storedEventCount: Double, geofenceCount: Double, android: AndroidBackgroundLocationStatus?, ios: IOSBackgroundLocationStatus?, lastError: LocationError?) {
+  init(state: BackgroundLocationState, isRunning: Bool, isConfigured: Bool, foregroundPermission: PermissionStatus, backgroundPermission: BackgroundPermissionStatus, accuracyAuthorization: AccuracyAuthorization?, locationServicesEnabled: Bool, providerStatus: LocationProviderStatus?, storedLocationCount: Double, storedEventCount: Double, lastLocationAt: Double?, lastEventAt: Double?, geofenceCount: Double, android: AndroidBackgroundLocationStatus?, ios: IOSBackgroundLocationStatus?, lastError: LocationError?) {
     self.init(state, isRunning, isConfigured, foregroundPermission, backgroundPermission, { () -> bridge.std__optional_AccuracyAuthorization_ in
       if let __unwrappedValue = accuracyAuthorization {
         return bridge.create_std__optional_AccuracyAuthorization_(__unwrappedValue)
@@ -31,7 +31,19 @@ public extension BackgroundLocationStatus {
       } else {
         return .init()
       }
-    }(), storedLocationCount, storedEventCount, geofenceCount, { () -> bridge.std__optional_AndroidBackgroundLocationStatus_ in
+    }(), storedLocationCount, storedEventCount, { () -> bridge.std__optional_double_ in
+      if let __unwrappedValue = lastLocationAt {
+        return bridge.create_std__optional_double_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_double_ in
+      if let __unwrappedValue = lastEventAt {
+        return bridge.create_std__optional_double_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), geofenceCount, { () -> bridge.std__optional_AndroidBackgroundLocationStatus_ in
       if let __unwrappedValue = android {
         return bridge.create_std__optional_AndroidBackgroundLocationStatus_(__unwrappedValue)
       } else {
@@ -102,6 +114,30 @@ public extension BackgroundLocationStatus {
     return self.__storedEventCount
   }
   
+  @inline(__always)
+  var lastLocationAt: Double? {
+    return { () -> Double? in
+      if bridge.has_value_std__optional_double_(self.__lastLocationAt) {
+        let __unwrapped = bridge.get_std__optional_double_(self.__lastLocationAt)
+        return __unwrapped
+      } else {
+        return nil
+      }
+    }()
+  }
+
+  @inline(__always)
+  var lastEventAt: Double? {
+    return { () -> Double? in
+      if bridge.has_value_std__optional_double_(self.__lastEventAt) {
+        let __unwrapped = bridge.get_std__optional_double_(self.__lastEventAt)
+        return __unwrapped
+      } else {
+        return nil
+      }
+    }()
+  }
+
   @inline(__always)
   var geofenceCount: Double {
     return self.__geofenceCount

--- a/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/BackgroundLocationStatus.hpp
+++ b/packages/react-native-nitro-geolocation/nitrogen/generated/shared/c++/BackgroundLocationStatus.hpp
@@ -72,6 +72,8 @@ namespace margelo::nitro::nitrogeolocation {
     std::optional<LocationProviderStatus> providerStatus     SWIFT_PRIVATE;
     double storedLocationCount     SWIFT_PRIVATE;
     double storedEventCount     SWIFT_PRIVATE;
+    std::optional<double> lastLocationAt     SWIFT_PRIVATE;
+    std::optional<double> lastEventAt     SWIFT_PRIVATE;
     double geofenceCount     SWIFT_PRIVATE;
     std::optional<AndroidBackgroundLocationStatus> android     SWIFT_PRIVATE;
     std::optional<IOSBackgroundLocationStatus> ios     SWIFT_PRIVATE;
@@ -79,7 +81,7 @@ namespace margelo::nitro::nitrogeolocation {
 
   public:
     BackgroundLocationStatus() = default;
-    explicit BackgroundLocationStatus(BackgroundLocationState state, bool isRunning, bool isConfigured, PermissionStatus foregroundPermission, BackgroundPermissionStatus backgroundPermission, std::optional<AccuracyAuthorization> accuracyAuthorization, bool locationServicesEnabled, std::optional<LocationProviderStatus> providerStatus, double storedLocationCount, double storedEventCount, double geofenceCount, std::optional<AndroidBackgroundLocationStatus> android, std::optional<IOSBackgroundLocationStatus> ios, std::optional<LocationError> lastError): state(state), isRunning(isRunning), isConfigured(isConfigured), foregroundPermission(foregroundPermission), backgroundPermission(backgroundPermission), accuracyAuthorization(accuracyAuthorization), locationServicesEnabled(locationServicesEnabled), providerStatus(providerStatus), storedLocationCount(storedLocationCount), storedEventCount(storedEventCount), geofenceCount(geofenceCount), android(android), ios(ios), lastError(lastError) {}
+    explicit BackgroundLocationStatus(BackgroundLocationState state, bool isRunning, bool isConfigured, PermissionStatus foregroundPermission, BackgroundPermissionStatus backgroundPermission, std::optional<AccuracyAuthorization> accuracyAuthorization, bool locationServicesEnabled, std::optional<LocationProviderStatus> providerStatus, double storedLocationCount, double storedEventCount, std::optional<double> lastLocationAt, std::optional<double> lastEventAt, double geofenceCount, std::optional<AndroidBackgroundLocationStatus> android, std::optional<IOSBackgroundLocationStatus> ios, std::optional<LocationError> lastError): state(state), isRunning(isRunning), isConfigured(isConfigured), foregroundPermission(foregroundPermission), backgroundPermission(backgroundPermission), accuracyAuthorization(accuracyAuthorization), locationServicesEnabled(locationServicesEnabled), providerStatus(providerStatus), storedLocationCount(storedLocationCount), storedEventCount(storedEventCount), lastLocationAt(lastLocationAt), lastEventAt(lastEventAt), geofenceCount(geofenceCount), android(android), ios(ios), lastError(lastError) {}
 
   public:
     friend bool operator==(const BackgroundLocationStatus& lhs, const BackgroundLocationStatus& rhs) = default;
@@ -105,6 +107,8 @@ namespace margelo::nitro {
         JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationProviderStatus>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "providerStatus"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "storedLocationCount"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "storedEventCount"))),
+        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lastLocationAt"))),
+        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lastEventAt"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "geofenceCount"))),
         JSIConverter<std::optional<margelo::nitro::nitrogeolocation::AndroidBackgroundLocationStatus>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "android"))),
         JSIConverter<std::optional<margelo::nitro::nitrogeolocation::IOSBackgroundLocationStatus>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ios"))),
@@ -123,6 +127,8 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "providerStatus"), JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationProviderStatus>>::toJSI(runtime, arg.providerStatus));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "storedLocationCount"), JSIConverter<double>::toJSI(runtime, arg.storedLocationCount));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "storedEventCount"), JSIConverter<double>::toJSI(runtime, arg.storedEventCount));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "lastLocationAt"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.lastLocationAt));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "lastEventAt"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.lastEventAt));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "geofenceCount"), JSIConverter<double>::toJSI(runtime, arg.geofenceCount));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "android"), JSIConverter<std::optional<margelo::nitro::nitrogeolocation::AndroidBackgroundLocationStatus>>::toJSI(runtime, arg.android));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "ios"), JSIConverter<std::optional<margelo::nitro::nitrogeolocation::IOSBackgroundLocationStatus>>::toJSI(runtime, arg.ios));
@@ -147,6 +153,8 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<margelo::nitro::nitrogeolocation::LocationProviderStatus>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "providerStatus")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "storedLocationCount")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "storedEventCount")))) return false;
+      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lastLocationAt")))) return false;
+      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "lastEventAt")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "geofenceCount")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitrogeolocation::AndroidBackgroundLocationStatus>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "android")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitrogeolocation::IOSBackgroundLocationStatus>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ios")))) return false;

--- a/packages/react-native-nitro-geolocation/src/background/longRunBackgroundProof.test.ts
+++ b/packages/react-native-nitro-geolocation/src/background/longRunBackgroundProof.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  GEOFENCE_CENTER,
+  GEOFENCE_ID,
+  GEOFENCE_OUTSIDE,
+  hasOrderedBackgroundLocationProof,
+  hasOrderedGeofenceTransitionProof,
+  hasOrderedRebootLocationProof,
+  isLocationEventMeasuredAtOrAfter
+} from "../../../../examples/v0.81.1/src/screens/scenario/native-e2e/longRunBackgroundProof";
+
+const location = (
+  timestamp: number,
+  createdAt: number,
+  coordinate: typeof GEOFENCE_CENTER
+) =>
+  ({
+    timestamp,
+    createdAt,
+    coords: coordinate
+  }) as never;
+
+const locationEvent = (
+  timestamp: number,
+  createdAt: number,
+  coordinate: typeof GEOFENCE_CENTER
+) =>
+  ({
+    createdAt,
+    event: {
+      type: "location",
+      location: location(timestamp, createdAt, coordinate)
+    }
+  }) as never;
+
+const geofenceEvent = (
+  transition: "enter" | "exit",
+  timestamp: number,
+  identifier = GEOFENCE_ID
+) =>
+  ({
+    createdAt: timestamp,
+    event: {
+      type: "geofence",
+      geofence: { transition, timestamp, region: { identifier } }
+    }
+  }) as never;
+
+describe("long-run background proof", () => {
+  it("orders measurements even when receipt timestamps are equal", () => {
+    const locations = [
+      location(1_010, 2_000, GEOFENCE_CENTER),
+      location(1_020, 2_000, GEOFENCE_OUTSIDE)
+    ];
+    const events = [
+      locationEvent(1_010, 2_000, GEOFENCE_CENTER),
+      locationEvent(1_020, 2_000, GEOFENCE_OUTSIDE)
+    ];
+
+    expect(hasOrderedBackgroundLocationProof(locations, events, 1_000)).toBe(
+      true
+    );
+  });
+
+  it("rejects pre-marker measurements received after the marker", () => {
+    const locations = [
+      location(990, 2_000, GEOFENCE_CENTER),
+      location(1_020, 2_010, GEOFENCE_OUTSIDE)
+    ];
+    const events = [
+      locationEvent(990, 2_000, GEOFENCE_CENTER),
+      locationEvent(1_020, 2_010, GEOFENCE_OUTSIDE)
+    ];
+
+    expect(hasOrderedBackgroundLocationProof(locations, events, 1_000)).toBe(
+      false
+    );
+  });
+
+  it("rejects outside-to-inside measurement order", () => {
+    const locations = [
+      location(1_010, 1_010, GEOFENCE_OUTSIDE),
+      location(1_020, 1_020, GEOFENCE_CENTER)
+    ];
+    const events = [
+      locationEvent(1_010, 1_010, GEOFENCE_OUTSIDE),
+      locationEvent(1_020, 1_020, GEOFENCE_CENTER)
+    ];
+
+    expect(hasOrderedBackgroundLocationProof(locations, events, 1_000)).toBe(
+      false
+    );
+  });
+
+  it("requires outside, inside, and outside measurements after reboot", () => {
+    const locations = [
+      location(1_010, 1_010, GEOFENCE_OUTSIDE),
+      location(1_020, 1_020, GEOFENCE_CENTER),
+      location(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+    const events = [
+      locationEvent(1_010, 1_010, GEOFENCE_OUTSIDE),
+      locationEvent(1_020, 1_020, GEOFENCE_CENTER),
+      locationEvent(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+
+    expect(hasOrderedRebootLocationProof(locations, events, 1_000)).toBe(true);
+  });
+
+  it("rejects reboot proof without the first outside measurement", () => {
+    const incompleteLocations = [
+      location(1_020, 1_020, GEOFENCE_CENTER),
+      location(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+    const incompleteEvents = [
+      locationEvent(1_020, 1_020, GEOFENCE_CENTER),
+      locationEvent(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+    const completeLocations = [
+      location(1_010, 1_010, GEOFENCE_OUTSIDE),
+      ...incompleteLocations
+    ];
+    const completeEvents = [
+      locationEvent(1_010, 1_010, GEOFENCE_OUTSIDE),
+      ...incompleteEvents
+    ];
+
+    expect(
+      hasOrderedRebootLocationProof(completeLocations, incompleteEvents, 1_000)
+    ).toBe(false);
+    expect(
+      hasOrderedRebootLocationProof(incompleteLocations, completeEvents, 1_000)
+    ).toBe(false);
+  });
+
+  it("rejects reboot proof when the first outside measurement is late", () => {
+    const locations = [
+      location(1_010, 1_010, GEOFENCE_CENTER),
+      location(1_020, 1_020, GEOFENCE_OUTSIDE),
+      location(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+    const events = [
+      locationEvent(1_010, 1_010, GEOFENCE_CENTER),
+      locationEvent(1_020, 1_020, GEOFENCE_OUTSIDE),
+      locationEvent(1_030, 1_030, GEOFENCE_OUTSIDE)
+    ];
+
+    expect(hasOrderedRebootLocationProof(locations, events, 1_000)).toBe(false);
+  });
+
+  it("rejects a delivered event measured before its proof marker", () => {
+    const event = {
+      ...locationEvent(990, 2_000, GEOFENCE_CENTER),
+      deliveredToJS: true
+    } as never;
+
+    expect(isLocationEventMeasuredAtOrAfter(event, 1_000)).toBe(false);
+    expect(
+      isLocationEventMeasuredAtOrAfter(
+        {
+          ...locationEvent(1_010, 2_000, GEOFENCE_CENTER),
+          deliveredToJS: true
+        } as never,
+        1_000
+      )
+    ).toBe(true);
+  });
+
+  it("requires the target geofence to enter before it exits", () => {
+    expect(
+      hasOrderedGeofenceTransitionProof(
+        [geofenceEvent("exit", 1_010), geofenceEvent("enter", 1_020)],
+        1_000
+      )
+    ).toBe(false);
+    expect(
+      hasOrderedGeofenceTransitionProof(
+        [
+          geofenceEvent("enter", 1_010, "other"),
+          geofenceEvent("enter", 1_020),
+          geofenceEvent("exit", 1_030)
+        ],
+        1_000
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -55,6 +55,10 @@ export interface BackgroundLocationStatus {
   providerStatus?: LocationProviderStatus;
   storedLocationCount: number;
   storedEventCount: number;
+  /** Native recording time of the newest retained background location. */
+  lastLocationAt?: number;
+  /** Native event time of the newest retained background event. */
+  lastEventAt?: number;
   geofenceCount: number;
   android?: AndroidBackgroundLocationStatus;
   ios?: IOSBackgroundLocationStatus;


### PR DESCRIPTION
## What changed

- expose optional retained-native `lastLocationAt` and `lastEventAt` status on Android and iOS
- harden background start/stop, permission, activity, geofence, boot restore, event, and error-state coordination
- serialize manual and automatic HTTP sync behind one bounded scheduler
- fence queued sync work by run, registration/session, service, and config generation
- re-check admission at execution time, use the revision of the batch actually reserved, coalesce automatic bursts, and drain successful backlogs one batch at a time without starving manual sync
- extend the natural long-run page and Maestro flows for empty state, foreground/background, termination, Android reboot restore, real outside → inside → outside geofence transitions, iOS drain, and cleanup
- document the foreground/background/termination/reboot contract, platform limitations, sync ordering, and config-replacement interval behavior
- keep this compatible feature on a `minor` changeset while the repository remains in the `rc` prerelease line

## Why

Roadmap #98 asks for an explicit background reliability contract. A tracker being started is not itself proof that retained native state, JavaScript delivery, geofences, boot restoration, and remote sync remain correct across process and configuration boundaries. This PR makes those guarantees observable, testable, and explicit without changing existing defaults.

Roadmap: #98 — “Background reliability contract” checkbox.

## Red → green evidence

- RED: the example referenced the new status fields before the spec existed and TypeScript failed with `TS2339`.
- GREEN: regenerated bindings and both native Release builds expose the retained timestamps.
- RED: queue/admission regression tests reproduced stale run/config replacement, interval bypass, slow-server burst growth, exception recovery, backlog starvation, and scheduled-key versus actually-reserved-batch revision races.
- GREEN: the bounded schedulers now preserve newer generations, re-key continuations from the actual batch, yield between batches, and stop correctly on empty, partial, or failed sync.
- RED: the original reboot proof could pass without a complete post-boot geofence journey.
- GREEN: the Android flow performs reboot restore followed by outside → inside → outside movement and validates fresh location/geofence evidence.
- Adversarial review rounds found and closed lock inversion, stale-generation overwrite, missing backlog drain, replacement-config interval bypass, and actual-batch re-key races. Final result: P1 0 / P2 0.

## Validation

- Android Release APK build
- iOS Release Simulator app build
- Android unit tests: 65/65
- JavaScript unit tests: 76/76
- Android long-run E2E with emulator reboot
- iOS long-run E2E
- full Android native Maestro suite
- full iOS native Maestro suite
- Android WebView E2E
- iOS WebView E2E
- direct TypeScript checks for package, example, docs, benchmark, and devtools
- Rspress docs build
- lint and format checks
- source-line guard
- dead-code checks
- package dry-run
- actionlint, YAML parsing, `bash -n`, and shellcheck for changed automation

## Release metadata

- this checkbox: `minor` (`.changeset/quiet-lions-report.md`)
- prerelease channel: `rc`
- aggregate Changesets status: `major` only because three separate roadmap changesets remove or split public APIs
