### PR TITLE
feat: add location quality metadata

### DIFF
--- a/.changeset/quiet-geckos-observe.md
+++ b/.changeset/quiet-geckos-observe.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add optional Modern response metadata for delivery source, age, horizontal
+accuracy quality, and stale reasons without changing location acceptance
+policy.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,16 @@ if (status === "granted") {
     accuracy: { android: "high", ios: "best" },
     timeout: 15_000,
   });
+  console.log(position.metadata);
+  // { source, age, quality, staleReason? }
 }
 ```
+
+Modern foreground responses include optional observational metadata for the
+delivery source, age, horizontal-accuracy quality band, and stale reason. This
+metadata never causes the library to reject a stale or low-accuracy position;
+applications can apply their own policy. The `/compat` response shape is
+unchanged.
 
 See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
 for watches, geocoding, heading, cached reads, Android settings, and iOS

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -389,6 +389,24 @@ export type LocationProviderUsed =
   | 'passive'
   | 'unknown';
 
+type LocationResponseSource =
+  | 'currentPosition'
+  | 'watchPosition'
+  | 'platformCache'
+  | 'moduleCache';
+
+type LocationQualityBand = 'high' | 'medium' | 'low' | 'unknown';
+
+interface LocationMetadata {
+  source: LocationResponseSource;
+  age?: number;
+  quality: LocationQualityBand;
+  staleReason?:
+    | 'maximumAgeExceeded'
+    | 'futureTimestamp'
+    | 'invalidTimestamp';
+}
+
 interface GeolocationResponse {
   coords: {
     latitude: number;
@@ -402,10 +420,43 @@ interface GeolocationResponse {
   timestamp: number;
   mocked?: boolean;
   provider?: LocationProviderUsed;
+  metadata?: LocationMetadata;
 }
 ```
 
-`mocked` and `provider` are optional metadata fields added to the Modern API response in v1.2. The `/compat` API keeps the `@react-native-community/geolocation` response shape and does not include these fields.
+`mocked` and `provider` are optional fields added to the Modern API response in
+v1.2. `metadata` adds descriptive location-quality information:
+
+- `source` is the API path that delivered the value. A current request, watch,
+  platform cache query, and synchronous module-cache read report
+  `currentPosition`, `watchPosition`, `platformCache`, and `moduleCache`
+  respectively.
+- `age` is `max(0, delivery time - position.timestamp)` in milliseconds. It is
+  recalculated whenever the synchronous module cache is read and is omitted
+  only when the timestamp is not finite.
+- `quality` is a portable horizontal-accuracy band derived from
+  `coords.accuracy`: `high` is over 0m and at most 10m, `medium` is over 10m and
+  at most 100m, `low` is over 100m, and `unknown` covers zero, negative, or
+  non-finite values. Android may expose zero when a native reading has no
+  accuracy estimate.
+- `staleReason` is present when a provider response was already outside the
+  request's `maximumAge` at request start, has a timestamp more than 1ms in the
+  future at delivery, or has a non-finite timestamp. The 1ms tolerance accounts
+  for native sub-millisecond timestamps compared with JavaScript's integer
+  millisecond clock. `age` continues to describe delivery-time age, so it may be
+  greater than `maximumAge` after a slow but valid request.
+
+These fields are observational. The library does not reject, retry, or replace
+a stale or low-quality response because of this metadata. Apply product-specific
+quality policy explicitly in application code. `source` describes the delivery
+path, while `provider` identifies the native provider such as fused, GPS, or
+network.
+
+The entire `metadata` object is optional for structural backward compatibility.
+Modern foreground API responses produced by this package include it. Native
+background records keep their existing background-specific `source` field. The
+`/compat` API keeps the `@react-native-community/geolocation` response shape and
+does not include Modern metadata.
 
 **Error Handling**:
 

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -60,6 +60,7 @@ appId: nitrogeolocation.example
 - runFlow: location-simulation.yaml
 - runFlow: accuracy-presets.yaml
 - runFlow: last-known-position.yaml
+- runFlow: location-quality-metadata.yaml
 - runFlow: geocoding.yaml
 - runFlow: location-availability.yaml
 - runFlow: heading.yaml

--- a/examples/v0.81.1/.maestro/last-known-position.yaml
+++ b/examples/v0.81.1/.maestro/last-known-position.yaml
@@ -84,6 +84,8 @@ appId: nitrogeolocation.example
 - assertVisible:
     text: ".*37.566500, 126.978000.*"
 - assertVisible:
+    text: ".*source=platformCache.*"
+- assertVisible:
     text: ".*without getCurrentPosition.*"
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/location-quality-metadata.yaml
+++ b/examples/v0.81.1/.maestro/location-quality-metadata.yaml
@@ -1,0 +1,79 @@
+appId: nitrogeolocation.example
+---
+# Natural response-metadata contract: request a real platform position, then
+# observe the same position through the synchronous module cache. No fixture is
+# injected into library code and no accuracy or stale response is rejected.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/location-quality-metadata
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/location-quality-metadata
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Observe delivery source, age, quality, and stale reason without filtering positions"
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- tapOn:
+    id: "e2e-action-location-quality-metadata-run-live-button"
+
+- extendedWaitUntil:
+    visible: "Live metadata: passed"
+    timeout: 20000
+
+- assertVisible:
+    id: "location-quality-metadata-live-result"
+- assertVisible:
+    text: ".*37\\.566500, 126\\.978000.*source=currentPosition.*age=[0-9]+(\\.[0-9]+)?ms.*quality=(high|medium|low|unknown).*stale=none.*"
+
+- tapOn:
+    id: "e2e-action-location-quality-metadata-run-cache-button"
+
+- extendedWaitUntil:
+    visible: "Cache metadata: passed"
+    timeout: 10000
+
+- assertVisible:
+    id: "location-quality-metadata-cache-result"
+- assertVisible:
+    text: ".*Same timestamp.*source=moduleCache.*age advanced from [0-9]+(\\.[0-9]+)?ms to [0-9]+(\\.[0-9]+)?ms.*quality=(high|medium|low|unknown).*"

--- a/examples/v0.81.1/.maestro/watch-position.yaml
+++ b/examples/v0.81.1/.maestro/watch-position.yaml
@@ -80,6 +80,10 @@ appId: nitrogeolocation.example
     id: "longitude-text"
 - assertVisible:
     text: "Longitude: 126\\.978000"
+- assertVisible:
+    id: "metadata-source-text"
+- assertVisible:
+    text: "Metadata source: watchPosition"
 
 # Wait 5 seconds to see if position updates
 - waitForAnimationToEnd

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -30,6 +30,7 @@ import Issue122Screen from "./screens/Issue122Screen";
 import Issue132Screen from "./screens/Issue132Screen";
 import LastKnownPositionScreen from "./screens/LastKnownPositionScreen";
 import LocationAvailabilityScreen from "./screens/LocationAvailabilityScreen";
+import LocationQualityMetadataScreen from "./screens/LocationQualityMetadataScreen";
 import LocationSimulationScreen from "./screens/LocationSimulationScreen";
 import { LongRunBackgroundE2EScreen } from "./screens/LongRunBackgroundE2EScreen";
 import MockedMetadataScreen from "./screens/MockedMetadataScreen";
@@ -54,6 +55,7 @@ const linking = {
       ApiErrors: "api-errors",
       AccuracyPresets: "accuracy-presets",
       LastKnownPosition: "last-known-position",
+      LocationQualityMetadata: "location-quality-metadata",
       Geocoding: "geocoding",
       LocationAvailability: "location-availability",
       Heading: "heading",
@@ -161,6 +163,11 @@ export default function App() {
           <Tab.Screen
             name="LastKnownPosition"
             component={LastKnownPositionScreen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="LocationQualityMetadata"
+            component={LocationQualityMetadataScreen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/DefaultScreen.tsx
+++ b/examples/v0.81.1/src/screens/DefaultScreen.tsx
@@ -179,7 +179,8 @@ export default function DefaultScreen({
         longitude: "longitude-text",
         accuracy: "accuracy-text",
         mocked: "mocked-text",
-        provider: "provider-text"
+        provider: "provider-text",
+        metadataSource: "metadata-source-text"
       }}
     />
   );

--- a/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
@@ -115,10 +115,15 @@ export default function LastKnownPositionScreen() {
 
       const { elapsedMs, position } = await readSystemCacheOnly();
       const coordinates = assertFixtureCoordinates(position);
+      if (position.metadata?.source !== "platformCache") {
+        throw new Error(
+          `Expected platformCache metadata source, received ${position.metadata?.source ?? "none"}.`
+        );
+      }
 
       setResult("system", {
         status: "passed",
-        message: `System cache ${coordinates}; cache-only read ${elapsedMs}ms without getCurrentPosition.`
+        message: `System cache ${coordinates}; source=${position.metadata.source}; cache-only read ${elapsedMs}ms without getCurrentPosition.`
       });
     } catch (error) {
       setResult("system", {

--- a/examples/v0.81.1/src/screens/LocationQualityMetadataScreen.tsx
+++ b/examples/v0.81.1/src/screens/LocationQualityMetadataScreen.tsx
@@ -1,0 +1,187 @@
+import React, { useRef } from "react";
+import {
+  type GeolocationResponse,
+  type LocationResponseSource,
+  getCurrentPosition,
+  getLastKnownPosition
+} from "react-native-nitro-geolocation";
+import {
+  PermissionStatusBlock,
+  ResultBlock,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  assertFixtureCoordinates,
+  createScenarioResults,
+  getDisplayErrorMessage,
+  runWithNativeGeolocation,
+  usePermissionStatus,
+  useScenarioResults
+} from "./scenario";
+
+const PREFIX = "location-quality-metadata";
+const initialResults = createScenarioResults(["live", "cache"] as const);
+
+function readMetadata(
+  position: GeolocationResponse,
+  source: LocationResponseSource
+) {
+  const metadata = position.metadata;
+  if (!metadata) {
+    throw new Error("Location response did not include metadata.");
+  }
+  if (metadata.source !== source) {
+    throw new Error(
+      `Expected ${source} metadata source, received ${metadata.source}.`
+    );
+  }
+  if (
+    metadata.age === undefined ||
+    !Number.isFinite(metadata.age) ||
+    metadata.age < 0
+  ) {
+    throw new Error(`Location age was invalid: ${String(metadata.age)}.`);
+  }
+  if (
+    !(["high", "medium", "low", "unknown"] as const).includes(metadata.quality)
+  ) {
+    throw new Error(`Location quality was invalid: ${metadata.quality}.`);
+  }
+  return metadata;
+}
+
+export default function LocationQualityMetadataScreen() {
+  const { permissionStatus, refreshPermission, requestLocationPermission } =
+    usePermissionStatus();
+  const { results, setResult } = useScenarioResults(initialResults);
+  const latestLivePosition = useRef<GeolocationResponse | undefined>(undefined);
+
+  const runLiveScenario = async () => {
+    setResult("live", {
+      status: "running",
+      message: "Requesting a normal native position with descriptive metadata"
+    });
+
+    try {
+      const status = await requestLocationPermission();
+      if (status !== "granted") {
+        throw new Error(`Permission was not granted: ${status}`);
+      }
+
+      const position = await runWithNativeGeolocation(() =>
+        getCurrentPosition({
+          accuracy: { android: "high", ios: "best" },
+          maximumAge: 30_000,
+          timeout: 15_000
+        })
+      );
+      const coordinates = assertFixtureCoordinates(position);
+      const metadata = readMetadata(position, "currentPosition");
+      if (metadata.staleReason !== undefined) {
+        throw new Error(
+          `Fresh current position was unexpectedly stale: ${metadata.staleReason}.`
+        );
+      }
+      latestLivePosition.current = position;
+
+      setResult("live", {
+        status: "passed",
+        message: `${coordinates}; source=${metadata.source}; age=${metadata.age}ms; quality=${metadata.quality}; stale=${metadata.staleReason ?? "none"}.`
+      });
+    } catch (error) {
+      setResult("live", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      await refreshPermission();
+    }
+  };
+
+  const runCacheScenario = async () => {
+    setResult("cache", {
+      status: "running",
+      message: "Reading the same observed position from the synchronous cache"
+    });
+
+    try {
+      const live = latestLivePosition.current;
+      if (!live) {
+        throw new Error(
+          "Request a live position before reading its module cache."
+        );
+      }
+
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 250);
+      });
+      const cached = getLastKnownPosition();
+      if (!cached) {
+        throw new Error(
+          "Observed module cache unexpectedly returned undefined."
+        );
+      }
+      const metadata = readMetadata(cached, "moduleCache");
+      const liveAge = live.metadata?.age ?? 0;
+      if (cached.timestamp !== live.timestamp) {
+        throw new Error(
+          "Module cache did not return the observed live position."
+        );
+      }
+      if ((metadata.age ?? 0) < liveAge) {
+        throw new Error("Module cache age moved backwards.");
+      }
+
+      setResult("cache", {
+        status: "passed",
+        message: `Same timestamp; source=${metadata.source}; age advanced from ${liveAge}ms to ${metadata.age}ms; quality=${metadata.quality}.`
+      });
+    } catch (error) {
+      setResult("cache", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    }
+  };
+
+  return (
+    <ScenarioScreen
+      prefix={PREFIX}
+      title="Location Quality Metadata"
+      subtitle="Observe delivery source, age, quality, and stale reason without filtering positions"
+    >
+      <ScenarioSection index={1} title="Permission">
+        <PermissionStatusBlock prefix={PREFIX} status={permissionStatus} />
+      </ScenarioSection>
+
+      <ScenarioSection index={2} title="Live Position" divided>
+        <ScenarioButton
+          title="Request Live Position"
+          onPress={runLiveScenario}
+          testID={`${PREFIX}-run-live-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="live"
+          label="Live metadata"
+          result={results.live}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={3} title="Observed Cache" divided>
+        <ScenarioButton
+          title="Read Observed Cache"
+          onPress={runCacheScenario}
+          color="#00897B"
+          testID={`${PREFIX}-run-cache-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="cache"
+          label="Cache metadata"
+          result={results.cache}
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}

--- a/examples/v0.81.1/src/screens/scenario/components/PositionInfo.tsx
+++ b/examples/v0.81.1/src/screens/scenario/components/PositionInfo.tsx
@@ -30,6 +30,8 @@ export type PositionInfoTestIDs = {
   mocked?: string;
   /** Optional Maestro testID attached to the provider metadata row. */
   provider?: string;
+  /** Optional Maestro testID attached to the response metadata source row. */
+  metadataSource?: string;
   /** Optional Maestro testID attached to the altitude row. */
   altitude?: string;
   /** Optional Maestro testID attached to the speed row. */
@@ -164,6 +166,9 @@ function PositionInfoContent({
     position.provider === undefined
       ? undefined
       : `Provider: ${position.provider}`;
+  const metadataSourceText = position.metadata
+    ? `Metadata source: ${position.metadata.source}`
+    : undefined;
   const altitudeText =
     position.coords.altitude === null
       ? undefined
@@ -185,7 +190,8 @@ function PositionInfoContent({
       longitudeText,
       accuracyText,
       includeOptionalFields ? mockedText : undefined,
-      includeOptionalFields ? providerText : undefined
+      includeOptionalFields ? providerText : undefined,
+      includeOptionalFields ? metadataSourceText : undefined
     ]
       .filter(Boolean)
       .join(" "),
@@ -202,6 +208,10 @@ function PositionInfoContent({
   useE2EDumpNode(
     includeOptionalFields ? providerText : undefined,
     testIDs.provider
+  );
+  useE2EDumpNode(
+    includeOptionalFields ? metadataSourceText : undefined,
+    testIDs.metadataSource
   );
   useE2EDumpNode(
     includeOptionalFields ? altitudeText : undefined,
@@ -236,6 +246,11 @@ function PositionInfoContent({
       {includeOptionalFields && position.provider !== undefined && (
         <Text style={sharedStyles.positionText} testID={testIDs.provider}>
           {providerText}
+        </Text>
+      )}
+      {includeOptionalFields && position.metadata !== undefined && (
+        <Text style={sharedStyles.positionText} testID={testIDs.metadataSource}>
+          {metadataSourceText}
         </Text>
       )}
       {includeOptionalFields && position.coords.altitude !== null && (

--- a/examples/web-e2e/src/locationAssertions.ts
+++ b/examples/web-e2e/src/locationAssertions.ts
@@ -35,6 +35,47 @@ export function assertPosition(position: GeolocationResponse) {
   }
 }
 
+export function assertLocationMetadata(
+  position: GeolocationResponse,
+  expectedSource:
+    | "currentPosition"
+    | "watchPosition"
+    | "platformCache"
+    | "moduleCache"
+) {
+  const metadata = position.metadata;
+  if (!metadata) {
+    throw new Error("Modern position missing location metadata.");
+  }
+  if (metadata.source !== expectedSource) {
+    throw new Error(
+      `Expected metadata source ${expectedSource}, got ${metadata.source}.`
+    );
+  }
+  if (
+    metadata.age === undefined ||
+    !Number.isFinite(metadata.age) ||
+    metadata.age < 0
+  ) {
+    throw new Error(`Modern position has invalid age: ${metadata.age}.`);
+  }
+  if (
+    !(["high", "medium", "low", "unknown"] as const).includes(metadata.quality)
+  ) {
+    throw new Error(
+      `Modern position has invalid quality: ${metadata.quality}.`
+    );
+  }
+}
+
+export function assertModernPosition(
+  position: GeolocationResponse,
+  source: NonNullable<GeolocationResponse["metadata"]>["source"]
+) {
+  assertPosition(position);
+  assertLocationMetadata(position, source);
+}
+
 export function getErrorCode(error: unknown): number | undefined {
   return (error as Partial<LocationError>).code;
 }

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -22,7 +22,7 @@ import {
 } from "./lastKnownAssertions";
 import {
   type ExpectedLocation,
-  assertPosition,
+  assertModernPosition,
   expectedLocations,
   getErrorCode,
   isNearExpected
@@ -282,7 +282,7 @@ export async function runSuccessSuite() {
         timeoutMs: 30000
       });
     },
-    (result) => assertPosition(result.position)
+    (result) => assertModernPosition(result.position, "currentPosition")
   );
 
   await runStep(
@@ -292,7 +292,7 @@ export async function runSuccessSuite() {
       expectLatestCachedPosition(
         cached,
         position.position.timestamp,
-        assertPosition
+        (cached) => assertModernPosition(cached, "moduleCache")
       )
   );
 
@@ -303,7 +303,7 @@ export async function runSuccessSuite() {
       expectValidCachedPosition(
         cached,
         "Async browser module cache did not return a position.",
-        assertPosition
+        (cached) => assertModernPosition(cached, "moduleCache")
       )
   );
 
@@ -336,7 +336,7 @@ export async function runSuccessSuite() {
         }
       });
     },
-    (result) => assertPosition(result.position)
+    (result) => assertModernPosition(result.position, "watchPosition")
   );
 
   await runStep(

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -77,8 +77,16 @@ if (status === "granted") {
     accuracy: { android: "high", ios: "best" },
     timeout: 15_000,
   });
+  console.log(position.metadata);
+  // { source, age, quality, staleReason? }
 }
 ```
+
+Modern foreground responses include optional observational metadata for the
+delivery source, age, horizontal-accuracy quality band, and stale reason. This
+metadata never causes the library to reject a stale or low-accuracy position;
+applications can apply their own policy. The `/compat` response shape is
+unchanged.
 
 See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
 for watches, geocoding, heading, cached reads, Android settings, and iOS

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -3,6 +3,7 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsCurrentPosition } from "../devtools/getCurrentPosition";
 import type { GeolocationResponse } from "../publicTypes";
+import { decoratePositionWithMetadata } from "./locationMetadata";
 import { rememberPosition } from "./positionCache";
 
 /**
@@ -34,15 +35,25 @@ import { rememberPosition } from "./positionCache";
 export function getCurrentPosition(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse> {
+  const requestedAt = Date.now();
+  const rememberCurrentPosition = (position: GeolocationResponse) =>
+    rememberPosition(
+      decoratePositionWithMetadata(position, {
+        source: "currentPosition",
+        maximumAge: options?.maximumAge ?? 0,
+        requestedAt
+      })
+    );
+
   if (isDevtoolsEnabled()) {
     const devtoolsResult = getDevtoolsCurrentPosition();
     if (devtoolsResult) {
-      return devtoolsResult.then(rememberPosition);
+      return devtoolsResult.then(rememberCurrentPosition);
     }
   }
   return new Promise((resolve, reject) => {
     NitroGeolocationHybridObject.getCurrentPosition(
-      (position) => resolve(rememberPosition(position)),
+      (position) => resolve(rememberCurrentPosition(position)),
       options ?? {},
       reject
     );

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -4,6 +4,7 @@ import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsLastKnownPosition } from "../devtools/getLastKnownPosition";
 import type { GeolocationResponse } from "../publicTypes";
 import { LocationErrorCode } from "../utils/errors";
+import { decoratePositionWithMetadata } from "./locationMetadata";
 import { readLastKnownPosition, rememberPosition } from "./positionCache";
 
 /**
@@ -33,14 +34,24 @@ export function getLastKnownPosition(): GeolocationResponse | undefined {
 export function getLastKnownPositionAsync(
   options?: LocationRequestOptions
 ): Promise<GeolocationResponse | undefined> {
+  const requestedAt = Date.now();
+  const rememberPlatformCache = (position: GeolocationResponse) =>
+    rememberPosition(
+      decoratePositionWithMetadata(position, {
+        source: "platformCache",
+        maximumAge: options?.maximumAge ?? Number.POSITIVE_INFINITY,
+        requestedAt
+      })
+    );
+
   if (isDevtoolsEnabled()) {
     const cached = getDevtoolsLastKnownPosition(options);
-    return Promise.resolve(cached ? rememberPosition(cached) : undefined);
+    return Promise.resolve(cached ? rememberPlatformCache(cached) : undefined);
   }
 
   return new Promise<GeolocationResponse>((resolve, reject) => {
     NitroGeolocationHybridObject.getLastKnownPosition(
-      (position) => resolve(rememberPosition(position)),
+      (position) => resolve(rememberPlatformCache(position)),
       options ?? {},
       reject
     );

--- a/packages/react-native-nitro-geolocation/src/api/locationMetadata.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/locationMetadata.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { GeolocationResponse } from "../publicTypes";
+import { decoratePositionWithMetadata } from "./locationMetadata";
+
+const createPosition = (
+  accuracy: number,
+  timestamp: number
+): GeolocationResponse => ({
+  coords: {
+    latitude: 37.5665,
+    longitude: 126.978,
+    altitude: null,
+    accuracy,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null
+  },
+  timestamp
+});
+
+describe("location response metadata", () => {
+  it("describes a current-position result without mutating the native response", () => {
+    const position = createPosition(5, 9_500);
+
+    const result = decoratePositionWithMetadata(position, {
+      source: "currentPosition",
+      maximumAge: 1_000,
+      requestedAt: 9_000,
+      observedAt: 10_000
+    });
+
+    expect(result).not.toBe(position);
+    expect(position).not.toHaveProperty("metadata");
+    expect(result).toMatchObject({
+      metadata: {
+        source: "currentPosition",
+        age: 500,
+        quality: "high"
+      }
+    });
+    expect(result.metadata).not.toHaveProperty("staleReason");
+  });
+
+  it.each([
+    [0, "unknown"],
+    [10, "high"],
+    [10.01, "medium"],
+    [100, "medium"],
+    [100.01, "low"],
+    [-1, "unknown"],
+    [Number.POSITIVE_INFINITY, "unknown"]
+  ] as const)("classifies %s metre accuracy as %s", (accuracy, quality) => {
+    expect(
+      decoratePositionWithMetadata(createPosition(accuracy, 10_000), {
+        source: "watchPosition",
+        observedAt: 10_000
+      }).metadata?.quality
+    ).toBe(quality);
+  });
+
+  it("reports a provider result that violates maximumAge without rejecting it", () => {
+    const result = decoratePositionWithMetadata(createPosition(25, 5_000), {
+      source: "currentPosition",
+      maximumAge: 2_000,
+      requestedAt: 8_000,
+      observedAt: 9_000
+    });
+
+    expect(result.coords.latitude).toBe(37.5665);
+    expect(result.metadata?.age).toBe(4_000);
+    expect(result.metadata?.staleReason).toBe("maximumAgeExceeded");
+  });
+
+  it("does not label a fresh maximumAge zero result as stale", () => {
+    const result = decoratePositionWithMetadata(createPosition(25, 8_000), {
+      source: "currentPosition",
+      maximumAge: 0,
+      requestedAt: 8_000,
+      observedAt: 8_100
+    });
+
+    expect(result.metadata?.age).toBe(100);
+    expect(result.metadata).not.toHaveProperty("staleReason");
+  });
+
+  it("recomputes delivery metadata instead of carrying an earlier stale reason", () => {
+    const stale = decoratePositionWithMetadata(createPosition(25, 5_000), {
+      source: "currentPosition",
+      maximumAge: 2_000,
+      requestedAt: 8_000,
+      observedAt: 9_000
+    });
+    const cached = decoratePositionWithMetadata(stale, {
+      source: "moduleCache",
+      observedAt: 10_000
+    });
+
+    expect(stale.metadata?.staleReason).toBe("maximumAgeExceeded");
+    expect(cached.metadata).not.toHaveProperty("staleReason");
+  });
+
+  it("tolerates sub-millisecond clock precision without hiding future timestamps", () => {
+    const withinClockResolution = decoratePositionWithMetadata(
+      createPosition(25, 10_000.5),
+      {
+        source: "platformCache",
+        observedAt: 10_000
+      }
+    );
+    const future = decoratePositionWithMetadata(createPosition(25, 10_002), {
+      source: "platformCache",
+      observedAt: 10_000
+    });
+    const invalid = decoratePositionWithMetadata(
+      createPosition(25, Number.NaN),
+      {
+        source: "platformCache",
+        observedAt: 10_000
+      }
+    );
+
+    expect(withinClockResolution.metadata?.age).toBe(0);
+    expect(withinClockResolution.metadata).not.toHaveProperty("staleReason");
+    expect(future.metadata?.age).toBe(0);
+    expect(future.metadata?.staleReason).toBe("futureTimestamp");
+    expect(invalid.metadata).not.toHaveProperty("age");
+    expect(invalid.metadata?.staleReason).toBe("invalidTimestamp");
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/api/locationMetadata.ts
+++ b/packages/react-native-nitro-geolocation/src/api/locationMetadata.ts
@@ -1,0 +1,89 @@
+import type {
+  GeolocationResponse,
+  LocationMetadata,
+  LocationQualityBand,
+  LocationResponseSource,
+  LocationStaleReason
+} from "../publicTypes";
+
+export interface LocationMetadataContext {
+  source: LocationResponseSource;
+  maximumAge?: number;
+  requestedAt?: number;
+  observedAt?: number;
+}
+
+const TIMESTAMP_CLOCK_TOLERANCE_MS = 1;
+
+function classifyAccuracy(accuracy: number): LocationQualityBand {
+  if (!Number.isFinite(accuracy) || accuracy <= 0) {
+    return "unknown";
+  }
+  if (accuracy <= 10) {
+    return "high";
+  }
+  if (accuracy <= 100) {
+    return "medium";
+  }
+  return "low";
+}
+
+function getStaleReason(
+  timestamp: number,
+  maximumAge: number | undefined,
+  requestedAt: number,
+  observedAt: number
+): LocationStaleReason | undefined {
+  if (!Number.isFinite(timestamp)) {
+    return "invalidTimestamp";
+  }
+  if (timestamp - observedAt > TIMESTAMP_CLOCK_TOLERANCE_MS) {
+    return "futureTimestamp";
+  }
+  if (
+    maximumAge === undefined ||
+    maximumAge === Number.POSITIVE_INFINITY ||
+    !Number.isFinite(maximumAge) ||
+    maximumAge < 0
+  ) {
+    return undefined;
+  }
+
+  if (maximumAge === 0) {
+    return timestamp < requestedAt ? "maximumAgeExceeded" : undefined;
+  }
+
+  return Math.max(0, requestedAt - timestamp) >= maximumAge
+    ? "maximumAgeExceeded"
+    : undefined;
+}
+
+/** Add descriptive metadata without changing whether a position is accepted. */
+export function decoratePositionWithMetadata(
+  position: GeolocationResponse,
+  context: LocationMetadataContext
+): GeolocationResponse {
+  const observedAt = context.observedAt ?? Date.now();
+  const requestedAt = context.requestedAt ?? observedAt;
+  const basePosition = { ...position };
+  basePosition.metadata = undefined;
+  const staleReason = getStaleReason(
+    position.timestamp,
+    context.maximumAge,
+    requestedAt,
+    observedAt
+  );
+  const metadata: LocationMetadata = {
+    quality: classifyAccuracy(position.coords.accuracy),
+    source: context.source
+  };
+
+  if (Number.isFinite(position.timestamp)) {
+    metadata.age = Math.max(0, observedAt - position.timestamp);
+  }
+  if (staleReason) {
+    metadata.staleReason = staleReason;
+  }
+
+  return { ...basePosition, metadata };
+}

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.test.ts
@@ -29,7 +29,25 @@ describe("positionCache", () => {
 
   it("returns the latest observed position synchronously", () => {
     expect(rememberPosition(position)).toBe(position);
-    expect(readLastKnownPosition()).toBe(position);
+    expect(readLastKnownPosition(position.timestamp + 2_000)).toMatchObject({
+      ...position,
+      metadata: {
+        source: "moduleCache",
+        age: 2_000,
+        quality: "high"
+      }
+    });
+  });
+
+  it("recomputes cache age for every synchronous read", () => {
+    rememberPosition(position);
+
+    expect(
+      readLastKnownPosition(position.timestamp + 2_000)?.metadata?.age
+    ).toBe(2_000);
+    expect(
+      readLastKnownPosition(position.timestamp + 8_000)?.metadata?.age
+    ).toBe(8_000);
   });
 
   it("selects only positions within maximumAge", () => {

--- a/packages/react-native-nitro-geolocation/src/api/positionCache.ts
+++ b/packages/react-native-nitro-geolocation/src/api/positionCache.ts
@@ -1,4 +1,5 @@
 import type { GeolocationResponse } from "../publicTypes";
+import { decoratePositionWithMetadata } from "./locationMetadata";
 
 let lastKnownPosition: GeolocationResponse | undefined;
 
@@ -9,8 +10,15 @@ export function rememberPosition(
   return position;
 }
 
-export function readLastKnownPosition(): GeolocationResponse | undefined {
-  return lastKnownPosition;
+export function readLastKnownPosition(
+  currentTime = Date.now()
+): GeolocationResponse | undefined {
+  return lastKnownPosition
+    ? decoratePositionWithMetadata(lastKnownPosition, {
+        source: "moduleCache",
+        observedAt: currentTime
+      })
+    : undefined;
 }
 
 export function selectCachedPosition(

--- a/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
@@ -6,6 +6,7 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { devtoolsWatchPosition } from "../devtools/watchPosition";
 import type { GeolocationResponse } from "../publicTypes";
+import { decoratePositionWithMetadata } from "./locationMetadata";
 import { rememberPosition } from "./positionCache";
 
 /**
@@ -37,8 +38,17 @@ export function watchPosition(
   error?: (error: LocationError) => void,
   options?: LocationRequestOptions
 ): string {
+  const requestedAt = Date.now();
   const rememberAndNotify = (position: GeolocationResponse) => {
-    success(rememberPosition(position));
+    success(
+      rememberPosition(
+        decoratePositionWithMetadata(position, {
+          source: "watchPosition",
+          maximumAge: options?.maximumAge ?? 0,
+          requestedAt
+        })
+      )
+    );
   };
 
   if (isDevtoolsEnabled()) {

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -5,11 +5,11 @@ import type {
 import type {
   AccuracyAuthorization,
   AndroidGranularity,
-  GeolocationResponse,
   LocationAccuracyOptions,
   LocationProviderStatus,
   LocationProviderUsed
 } from "../publicTypes";
+import type { GeolocationResponse as SchemaGeolocationResponse } from "../types";
 
 export type BackgroundPermissionStatus =
   | "granted"
@@ -149,7 +149,7 @@ export interface BatterySnapshot {
   isCharging?: boolean;
 }
 
-export interface BackgroundLocation extends GeolocationResponse {
+export interface BackgroundLocation extends SchemaGeolocationResponse {
   id?: string;
   source: BackgroundLocationSource;
   isFromBackground: boolean;

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -104,6 +104,10 @@ export type {
   AuthorizationLevel,
   LocationProvider,
   LocationProviderUsed,
+  LocationMetadata,
+  LocationQualityBand,
+  LocationResponseSource,
+  LocationStaleReason,
   GeolocationConfiguration
 } from "./publicTypes";
 

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -34,6 +34,10 @@ export type {
   AuthorizationLevel,
   LocationProvider,
   LocationProviderUsed,
+  LocationMetadata,
+  LocationQualityBand,
+  LocationResponseSource,
+  LocationStaleReason,
   GeolocationConfiguration
 } from "./publicTypes";
 

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -28,7 +28,37 @@ type NativeLocationProvider = NonNullable<
   NativeGeolocationConfiguration["locationProvider"]
 >;
 
-export type GeolocationResponse = SchemaGeolocationResponse;
+/** API path that delivered a Modern location response. */
+export type LocationResponseSource =
+  | "currentPosition"
+  | "watchPosition"
+  | "platformCache"
+  | "moduleCache";
+
+/** Descriptive horizontal-accuracy band. It is not an acceptance policy. */
+export type LocationQualityBand = "high" | "medium" | "low" | "unknown";
+
+/** Why a delivered response cannot satisfy its timestamp freshness contract. */
+export type LocationStaleReason =
+  | "maximumAgeExceeded"
+  | "futureTimestamp"
+  | "invalidTimestamp";
+
+export interface LocationMetadata {
+  /** API path that delivered this response. */
+  source: LocationResponseSource;
+  /** Milliseconds elapsed between the location timestamp and this delivery. */
+  age?: number;
+  /** `high` is >0m and <=10m, `medium` is <=100m, and `low` is >100m. */
+  quality: LocationQualityBand;
+  /** Present when timestamp freshness is invalid or violates `maximumAge`. */
+  staleReason?: LocationStaleReason;
+}
+
+export type GeolocationResponse = SchemaGeolocationResponse & {
+  /** Descriptive delivery, age, accuracy, and freshness metadata. */
+  metadata?: LocationMetadata;
+};
 export type LocationProviderStatus = SchemaLocationProviderStatus;
 export type LocationAvailability = SchemaLocationAvailability;
 export type GeocodingCoordinates = SchemaGeocodingCoordinates;

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -68,8 +68,9 @@ describe("web Modern API", () => {
   });
 
   it("wraps navigator.geolocation.getCurrentPosition and normalizes nullable coords", async () => {
+    const timestamp = Date.now();
     const getCurrentPositionMock = vi.fn((success) => {
-      success(createPosition());
+      success({ ...createPosition(), timestamp });
     });
     setNavigator({
       geolocation: {
@@ -79,12 +80,11 @@ describe("web Modern API", () => {
       }
     });
 
-    await expect(
-      getCurrentPosition({
-        accuracy: { android: "high" },
-        timeout: 1234
-      })
-    ).resolves.toEqual({
+    const position = await getCurrentPosition({
+      accuracy: { android: "high" },
+      timeout: 1234
+    });
+    expect(position).toEqual({
       coords: {
         latitude: 37.5665,
         longitude: 126.978,
@@ -94,7 +94,12 @@ describe("web Modern API", () => {
         heading: null,
         speed: null
       },
-      timestamp: 1779015190000,
+      timestamp,
+      metadata: {
+        age: expect.any(Number),
+        quality: "medium",
+        source: "currentPosition"
+      },
       provider: "unknown"
     });
     expect(getCurrentPositionMock.mock.calls[0][2]).toEqual({
@@ -104,7 +109,8 @@ describe("web Modern API", () => {
     });
     expect(getLastKnownPosition()).toMatchObject({
       coords: { latitude: 37.5665, longitude: 126.978 },
-      timestamp: 1779015190000
+      metadata: { source: "moduleCache" },
+      timestamp
     });
   });
 
@@ -283,6 +289,7 @@ describe("web Modern API", () => {
 
   it("tracks web watch tokens and clears individual/all watchers", () => {
     const clearWatch = vi.fn();
+    const firstSuccess = vi.fn();
     const watchPositionMock = vi
       .fn()
       .mockReturnValueOnce(10)
@@ -295,8 +302,21 @@ describe("web Modern API", () => {
       }
     });
 
-    const firstToken = watchPosition(vi.fn());
+    const firstToken = watchPosition(firstSuccess);
     const secondToken = watchPosition(vi.fn());
+
+    watchPositionMock.mock.calls[0][0]({
+      ...createPosition(),
+      timestamp: Date.now()
+    });
+    expect(firstSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          source: "watchPosition",
+          quality: "medium"
+        })
+      })
+    );
 
     expect(firstToken).toMatch(/^web-/);
     expect(secondToken).toMatch(/^web-/);

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -4,6 +4,7 @@ import type {
   LocationSettingsOptions,
   PermissionStatus
 } from "../NitroGeolocation.nitro";
+import { decoratePositionWithMetadata } from "../api/locationMetadata";
 import {
   readLastKnownPosition,
   rememberPosition,
@@ -131,9 +132,19 @@ export function getCurrentPosition(
     return rejectUnsupported();
   }
 
+  const requestedAt = Date.now();
   return new Promise((resolve, reject) => {
     geolocation.getCurrentPosition(
-      (position) => resolve(rememberPosition(normalizePosition(position))),
+      (position) =>
+        resolve(
+          rememberPosition(
+            decoratePositionWithMetadata(normalizePosition(position), {
+              source: "currentPosition",
+              maximumAge: options?.maximumAge ?? 0,
+              requestedAt
+            })
+          )
+        ),
       (error) => reject(mapBrowserError(error)),
       toPositionOptions(options)
     );

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -2,6 +2,7 @@ import type {
   LocationError,
   LocationRequestOptions
 } from "../NitroGeolocation.nitro";
+import { decoratePositionWithMetadata } from "../api/locationMetadata";
 import { rememberPosition } from "../api/positionCache";
 import type {
   GeolocationResponse,
@@ -44,9 +45,17 @@ export function watchPosition(
   }
 
   let lastEmitted: GeolocationResponse | null = null;
+  const requestedAt = Date.now();
   const watchId = geolocation.watchPosition(
     (position) => {
-      const normalizedPosition = normalizePosition(position);
+      const normalizedPosition = decoratePositionWithMetadata(
+        normalizePosition(position),
+        {
+          source: "watchPosition",
+          maximumAge: options?.maximumAge ?? 0,
+          requestedAt
+        }
+      );
       const filter = options?.distanceFilter ?? 0;
       if (
         filter <= 0 ||


### PR DESCRIPTION
## Summary
- add optional Modern response metadata for delivery source, age, accuracy band, and stale reason
- preserve location acceptance behavior, `/compat`, background native schemas, and the existing `LocationQuality` API
- add natural native happy/cache-edge pages plus Android, iOS, and Web coverage

Roadmap checkbox: #98 — Location quality metadata

## Release
- changeset: `minor`
- prerelease mode: `rc` (`2.0.0-rc.0` with the current v2 changesets)

## Validation
- unit: 81/81
- package, example, and docs typechecks
- Android Release: metadata, watch, last-known Maestro flows
- iOS Release: metadata, watch, last-known Maestro flows
- Android/iOS Web E2E
- docs build and Web E2E build
- lint, format, deadcode, pack, source-lines, diff check
- three adversarial reviews: no P0/P1/P2 findings