### PR TITLE
test: cover modern integrity metadata

### DIFF
--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -424,39 +424,57 @@ interface GeolocationResponse {
 }
 ```
 
-`mocked` and `provider` are optional fields added to the Modern API response in
-v1.2. `metadata` adds descriptive location-quality information:
+### Mock and provider metadata
 
-- `source` is the API path that delivered the value. A current request, watch,
-  platform cache query, and synchronous module-cache read report
-  `currentPosition`, `watchPosition`, `platformCache`, and `moduleCache`
-  respectively.
-- `age` is `max(0, delivery time - position.timestamp)` in milliseconds. It is
-  recalculated whenever the synchronous module cache is read and is omitted
-  only when the timestamp is not finite.
-- `quality` is a portable horizontal-accuracy band derived from
-  `coords.accuracy`: `high` is over 0m and at most 10m, `medium` is over 10m and
-  at most 100m, `low` is over 100m, and `unknown` covers zero, negative, or
-  non-finite values. Android may expose zero when a native reading has no
-  accuracy estimate.
-- `staleReason` is present when a provider response was already outside the
-  request's `maximumAge` at request start, has a timestamp more than 1ms in the
-  future at delivery, or has a non-finite timestamp. The 1ms tolerance accounts
-  for native sub-millisecond timestamps compared with JavaScript's integer
-  millisecond clock. `age` continues to describe delivery-time age, so it may be
-  greater than `maximumAge` after a slow but valid request.
+`mocked` and `provider` are optional Modern API metadata fields added in v1.2.
+They describe the source of that particular position sample:
 
-These fields are observational. The library does not reject, retry, or replace
-a stale or low-quality response because of this metadata. Apply product-specific
-quality policy explicitly in application code. `source` describes the delivery
-path, while `provider` identifies the native provider such as fused, GPS, or
-network.
+- `mocked` reports whether the sample source identified it as simulated or
+  supplied by a test provider. Native Android responses use `Location.isMock`
+  (or `isFromMockProvider` on older Android versions). Native iOS responses use
+  `CLLocation.sourceInformation` when it is available on iOS 15 and later;
+  otherwise the field can be absent.
+- `provider` identifies the Android provider route as `fused`, `gps`,
+  `network`, or `passive`. iOS and web return `unknown` because those platforms
+  do not expose an equivalent provider name through this API.
+- Web positions omit `mocked` because the browser Geolocation API does not
+  expose trustworthy simulation metadata.
+- The optional development-tools integration returns `mocked: true` for its
+  injected JavaScript samples. That value identifies the tooling source; it is
+  not native platform attestation.
 
-The entire `metadata` object is optional for structural backward compatibility.
-Modern foreground API responses produced by this package include it. Native
-background records keep their existing background-specific `source` field. The
-`/compat` API keeps the `@react-native-community/geolocation` response shape and
-does not include Modern metadata.
+Treat `mocked` as per-sample diagnostic evidence, not as an anti-fraud or
+device-integrity guarantee. A missing value means the platform did not expose
+the signal; it does not mean `false`. Likewise, `provider` describes the route
+used for the sample and does not establish whether the coordinates should be
+trusted.
+
+The synchronous module cache returned by `getLastKnownPosition()` preserves
+the metadata attached to the last position observed by this JavaScript module.
+Disabling a mock-location app or simulator fixture cannot rewrite that cached
+response, so it may still contain `mocked: true`. By contrast,
+`getLastKnownPositionAsync()` converts a native cached sample when it is read
+on Android or iOS; platform metadata is derived again and Android `provider`
+can reflect the current query route. On web it filters the JavaScript module
+cache, while the optional development-tools integration filters its configured
+mock cache. Do not require an asynchronous native-cache response to be
+identical to an earlier JavaScript response. Request or observe a newer sample
+when application policy requires fresher evidence, and apply `maximumAge` when
+reading the platform cache.
+
+The `/compat` entry point keeps the
+`@react-native-community/geolocation` response shape and does not include these
+fields.
+
+#### Testing the signal naturally
+
+- Test `mocked: true` with an emulator or simulator location fixture such as
+  Maestro `setLocation`.
+- Test `mocked: false` only on a physical device receiving a real provider
+  location, without coordinate injection. Do not manufacture the false branch
+  by changing or hiding returned metadata.
+- Assert absence separately on platforms that cannot provide the signal; do
+  not convert an unavailable value to `false`.
 
 **Error Handling**:
 

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -211,7 +211,8 @@ yarn test:e2e:background-long-run:ios
 ### `mocked-metadata-android-true.yaml`
 - Android-only contract for `mocked=true` and `provider` response metadata
 - Opens the dedicated mocked metadata page
-- Uses Maestro `setLocation`, then verifies the public result surfaces `Mocked: true` and `Provider: gps`
+- Uses Maestro `setLocation`, then verifies the public result surfaces `Mocked: true` and a native Android provider
+- Verifies the empty-cache edge case before requesting a position, then proves the current sample's timestamp, `mocked`, and `provider` values survive the synchronous module-cache read
 - Included in `all-tests.yaml` because Maestro controls the location fixture deterministically
 - Uses a cold deep-link open after `stopApp` so the hidden metadata route is the screen under test
 
@@ -220,6 +221,7 @@ yarn test:e2e:background-long-run:ios
 - Opens the same mocked metadata page, but does not call Maestro `setLocation`
 - Run this separately on a physical Android device, or on an emulator whose location is not currently backed by a test provider
 - Not included in `all-tests.yaml` because emulator mock state can persist across flows and would make `Mocked: false` environment-dependent
+- Verifies the same empty-cache and cached-sample preservation contracts without injecting coordinates
 - Uses a cold deep-link open after `stopApp` so the hidden metadata route is the screen under test
 
 Run both metadata cases when you need to compare the visible contract:
@@ -233,21 +235,29 @@ The two Android cases intentionally differ like this:
 
 | Case | Uses `setLocation` | Expected metadata | Coordinate assertions |
 | --- | --- | --- | --- |
-| `mocked-metadata-android-true.yaml` | Yes | `Mocked: true`, `Provider: gps` | Presence only |
+| `mocked-metadata-android-true.yaml` | Yes | `Mocked: true`, native provider | Presence only |
 | `mocked-metadata-android-false.yaml` | No | `Mocked: false` | None |
+
+`mocked` belongs to the returned sample, not to a live global trust state. A
+cached sample remains mocked after the test provider is disabled. Acquire a new
+sample when testing a state transition instead of expecting old cache metadata
+to change.
 
 ### `mocked-metadata-ios-true.yaml`
 - iOS-only contract for `mocked=true` and `provider` response metadata
 - Opens the dedicated mocked metadata page
 - Uses Maestro `setLocation`, then verifies the public result surfaces `Mocked: true` and `Provider: unknown`
+- Verifies the empty-cache edge case before requesting a position, then proves the current sample's timestamp, `mocked`, and `provider` values survive the synchronous module-cache read
 - Included in `all-tests.yaml` because Maestro controls the simulator location fixture deterministically
 - Uses a cold deep-link open after `stopApp` so the hidden metadata route is the screen under test
 
 ### `mocked-metadata-ios-false.yaml`
 - iOS-only contract for the non-simulated provider branch, `mocked=false`
 - Opens the same mocked metadata page, but does not call Maestro `setLocation`
-- Run this separately on a physical iOS device using a real location provider
+- Run this separately on an iOS 15+ physical device using a real location provider, and only when the returned `CLLocation` includes `sourceInformation`
+- Skip this false-specific proof when `sourceInformation` is absent; `mocked` is then correctly omitted instead of set to `false`
 - Not included in `all-tests.yaml` because simulator location state can persist across flows and would make `Mocked: false` environment-dependent
+- Verifies the same empty-cache and cached-sample preservation contracts without injecting coordinates
 - Uses a cold deep-link open after `stopApp` so the hidden metadata route is the screen under test
 
 Run both metadata cases when you need to compare the visible iOS contract:
@@ -263,6 +273,11 @@ The two iOS cases intentionally differ like this:
 | --- | --- | --- | --- |
 | `mocked-metadata-ios-true.yaml` | Yes | `Mocked: true`, `Provider: unknown` | Presence only |
 | `mocked-metadata-ios-false.yaml` | No | `Mocked: false`, `Provider: unknown` | None |
+
+On iOS versions where `CLLocation.sourceInformation` is unavailable, `mocked`
+can be absent instead of `false`. The automated true flow therefore targets a
+current simulator runtime; the physical-device false flow must be interpreted
+against the device OS and the returned sample.
 
 ### `api-errors.yaml`
 - Opens the API Errors screen and triggers real native Modern API errors.

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-false.yaml
@@ -54,6 +54,17 @@ appId: nitrogeolocation.example
     timeout: 10000
 
 - tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cold module cache returned undefined before any position request."
+
+- tapOn:
     id: "e2e-action-permission-request-button"
 - extendedWaitUntil:
     visible: "granted ✅"
@@ -75,3 +86,14 @@ appId: nitrogeolocation.example
 - assertNotVisible: "Mocked: true"
 - assertVisible:
     id: "provider-text"
+
+- tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cached sample preserved timestamp, mocked, and provider metadata."

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -51,6 +51,17 @@ appId: nitrogeolocation.example
     timeout: 10000
 
 - tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cold module cache returned undefined before any position request."
+
+- tapOn:
     id: "e2e-action-permission-request-button"
 - extendedWaitUntil:
     visible: "granted ✅"
@@ -81,3 +92,14 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "provider-text"
 - assertVisible: "Provider: (fused|gps|network|passive)"
+
+- tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cached sample preserved timestamp, mocked, and provider metadata."

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-false.yaml
@@ -2,9 +2,11 @@ appId: nitrogeolocation.example
 ---
 # iOS contract: mocked=false
 #
-# Run this on a physical iOS device/provider that is not using simulated
-# location. It is intentionally not included in all-tests.yaml because
-# simulator setLocation() state can persist outside app state.
+# Run this on an iOS 15+ physical device/provider that is not using simulated
+# location and whose CLLocation sample includes sourceInformation. It is
+# intentionally not included in all-tests.yaml because simulator setLocation()
+# state can persist outside app state. If sourceInformation is absent, mocked
+# is correctly omitted and this false-specific proof must be skipped.
 #
 # Do not add setLocation() to this flow. For mocked=false, the contract is about
 # source metadata from a real/non-simulated provider; injected coordinates must
@@ -51,6 +53,17 @@ appId: nitrogeolocation.example
     timeout: 10000
 
 - tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cold module cache returned undefined before any position request."
+
+- tapOn:
     id: "e2e-action-permission-request-button"
 - tapOn:
     text: "Allow While Using App|앱을 사용하는 동안 허용"
@@ -76,3 +89,14 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "provider-text"
 - assertVisible: "Provider: unknown"
+
+- tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cached sample preserved timestamp, mocked, and provider metadata."

--- a/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-ios-true.yaml
@@ -52,6 +52,17 @@ appId: nitrogeolocation.example
     timeout: 10000
 
 - tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cold module cache returned undefined before any position request."
+
+- tapOn:
     id: "e2e-action-permission-request-button"
 - tapOn:
     text: "Allow While Using App|앱을 사용하는 동안 허용"
@@ -85,3 +96,14 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "provider-text"
 - assertVisible: "Provider: unknown"
+
+- tapOn:
+    id: "e2e-action-metadata-cache-verify-button"
+- extendedWaitUntil:
+    visible:
+      id: "metadata-cache-preservation-status"
+      text: "Cached metadata: passed"
+    timeout: 10000
+- assertVisible:
+    id: "metadata-cache-preservation-message"
+    text: "Cached sample preserved timestamp, mocked, and provider metadata."

--- a/examples/v0.81.1/src/screens/DefaultScreen.tsx
+++ b/examples/v0.81.1/src/screens/DefaultScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Switch, Text, View } from "react-native";
 import {
   getCurrentPosition,
+  getLastKnownPosition,
   useWatchPosition
 } from "react-native-nitro-geolocation";
 import type { GeolocationResponse } from "react-native-nitro-geolocation";
@@ -9,16 +10,23 @@ import {
   ButtonRow,
   ErrorBlock,
   PositionInfo,
+  ResultBlock,
   ScenarioButton,
   ScenarioScreen,
   ScenarioSection,
   StatusBlock,
+  createIdleResult,
   runWithNativeGeolocation,
   sharedStyles,
   usePermissionStatus
 } from "./scenario";
+import type { ScenarioResult } from "./scenario";
 
-type DefaultScreenSection = "permission" | "currentPosition" | "watchPosition";
+type DefaultScreenSection =
+  | "permission"
+  | "currentPosition"
+  | "metadataCache"
+  | "watchPosition";
 
 interface DefaultScreenProps {
   nativeGeolocation?: boolean;
@@ -56,6 +64,8 @@ export default function DefaultScreen({
   const [currentPositionError, setCurrentPositionError] = useState<
     string | null
   >(null);
+  const [metadataCacheResult, setMetadataCacheResult] =
+    useState<ScenarioResult>(createIdleResult);
 
   // Watch position hook (continuous)
   const [watchEnabled, setWatchEnabled] = useState(false);
@@ -105,6 +115,7 @@ export default function DefaultScreen({
     setIsCurrentPositionLoading(true);
     setCurrentPosition(null);
     setCurrentPositionError(null);
+    setMetadataCacheResult(createIdleResult());
     try {
       const position = await (nativeGeolocation
         ? runWithNativeGeolocation(() =>
@@ -123,6 +134,40 @@ export default function DefaultScreen({
     } finally {
       setIsCurrentPositionLoading(false);
     }
+  };
+
+  const handleVerifyMetadataCache = () => {
+    const cached = getLastKnownPosition();
+
+    if (!currentPosition) {
+      setMetadataCacheResult({
+        status: cached ? "failed" : "passed",
+        message: cached
+          ? "Cold module cache unexpectedly contained a position."
+          : "Cold module cache returned undefined before any position request."
+      });
+      return;
+    }
+
+    if (!cached) {
+      setMetadataCacheResult({
+        status: "failed",
+        message: "The current position was not present in the module cache."
+      });
+      return;
+    }
+
+    const metadataMatches =
+      cached.timestamp === currentPosition.timestamp &&
+      cached.mocked === currentPosition.mocked &&
+      cached.provider === currentPosition.provider;
+
+    setMetadataCacheResult({
+      status: metadataMatches ? "passed" : "failed",
+      message: metadataMatches
+        ? "Cached sample preserved timestamp, mocked, and provider metadata."
+        : "Cached sample metadata did not match the current position."
+    });
   };
 
   const renderPermissionSection = (divided: boolean) => (
@@ -251,12 +296,36 @@ export default function DefaultScreen({
     </ScenarioSection>
   );
 
+  const renderMetadataCacheSection = (divided: boolean) => (
+    <ScenarioSection
+      index={3}
+      title="Cached Sample Metadata"
+      description="Verify the module cache preserves metadata from the position sample"
+      divided={divided}
+    >
+      <ScenarioButton
+        title="Verify Cached Metadata"
+        onPress={handleVerifyMetadataCache}
+        color="#5E35B1"
+        testID="metadata-cache-verify-button"
+      />
+      <ResultBlock
+        prefix="metadata-cache"
+        id="preservation"
+        label="Cached metadata"
+        result={metadataCacheResult}
+      />
+    </ScenarioSection>
+  );
+
   const renderSection = (section: DefaultScreenSection, divided: boolean) => {
     switch (section) {
       case "permission":
         return renderPermissionSection(divided);
       case "currentPosition":
         return renderCurrentPositionSection(divided);
+      case "metadataCache":
+        return renderMetadataCacheSection(divided);
       case "watchPosition":
         return renderWatchPositionSection(divided);
     }

--- a/examples/v0.81.1/src/screens/MockedMetadataScreen.tsx
+++ b/examples/v0.81.1/src/screens/MockedMetadataScreen.tsx
@@ -5,7 +5,7 @@ export default function MockedMetadataScreen() {
   return (
     <DefaultScreen
       nativeGeolocation
-      sections={["permission", "currentPosition"]}
+      sections={["permission", "currentPosition", "metadataCache"]}
       subtitle="Mocked location metadata contract"
       title="Mocked Location Metadata"
     />

--- a/examples/v0.81.1/src/type-contracts/modern-integrity-metadata.ts
+++ b/examples/v0.81.1/src/type-contracts/modern-integrity-metadata.ts
@@ -1,0 +1,45 @@
+import type {
+  GeolocationResponse,
+  LocationProviderUsed
+} from "react-native-nitro-geolocation";
+import type { GeolocationResponse as CompatGeolocationResponse } from "react-native-nitro-geolocation/compat";
+
+const coords = {
+  latitude: 37.5665,
+  longitude: 126.978,
+  altitude: null,
+  accuracy: 5,
+  altitudeAccuracy: null,
+  heading: null,
+  speed: null
+};
+
+const modernPosition: GeolocationResponse = {
+  coords,
+  timestamp: 1779015190000,
+  mocked: true,
+  provider: "gps"
+};
+
+const providers: LocationProviderUsed[] = [
+  "fused",
+  "gps",
+  "network",
+  "passive",
+  "unknown"
+];
+
+const compatPosition: CompatGeolocationResponse = {
+  coords,
+  timestamp: modernPosition.timestamp
+};
+
+// @ts-expect-error Compat keeps the community response shape.
+void compatPosition.mocked;
+// @ts-expect-error Compat keeps the community response shape.
+void compatPosition.provider;
+
+// @ts-expect-error Modern providers are a closed native-provider union.
+providers.push("bluetooth");
+
+void [modernPosition, providers, compatPosition];


### PR DESCRIPTION
## Summary

- document Modern `mocked` / `provider` provenance, platform availability, cache semantics, and compat boundaries
- extend the natural native test page with a real cold module-cache check and cached metadata preservation check
- cover Modern/compat metadata boundaries with an example TypeScript contract
- keep injected `mocked=true` automation separate from physical-device-only `mocked=false` proof flows

Part of #98: **Improve Modern API metadata docs/tests**.

## Behavior and scope

This PR does not change the published package runtime or response shape. It documents and tests the existing Modern API metadata contract. The compat opt-in decision remains a separate roadmap checkbox and will be handled in a separate PR.

The `mocked=false` flows remain manual because adding `setLocation` would invalidate the non-mocked proof. The iOS flow now states its iOS 15+ `sourceInformation` prerequisite explicitly.

## RED → GREEN

- RED: the Android Release flow failed on the newly declared cache-verification action before the test page implemented it.
- GREEN: Android and iOS Release flows now prove a real cold `getLastKnownPosition()` miss, then prove timestamp / `mocked` / `provider` preservation after a real Modern current-position request.

## Validation

- `mocked-metadata-android-true.yaml` on Android Release: pass
- `mocked-metadata-ios-true.yaml` on iOS Release: pass
- TypeScript checks: pass
- unit tests: 68/68 pass
- docs build and all workspace builds: pass
- format, lint, dead-code, package dry-run, source-line guard: pass
- `yarn changeset status --since=origin/main`: pass with no package bump (docs/example-only change)
- adversarial pre-commit review: no P0/P1/P2 findings after fixes
