### PR TITLE
test: add GPS-only offline verification recipe

### DIFF
--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -4,6 +4,7 @@
   "migration-assistance",
   "community-migration",
   "service-migration",
+  "gps-offline-recipe",
   "expo-development-build",
   "react-native-directory",
   "modern-api",

--- a/docs/docs/guide/agent-context-map.md
+++ b/docs/docs/guide/agent-context-map.md
@@ -114,6 +114,7 @@ permission helpers, and location assertions live in
 | Android request options | `android-request-options.yaml` | `AndroidRequestOptionsScreen.tsx` |
 | Android provider selection | `android-provider-selection.yaml` | `AndroidRequestOptionsScreen.tsx` |
 | Android provider settings | `provider-settings.yaml`, `provider-settings-not-ready.yaml` | `ProviderSettingsScreen.tsx` |
+| GPS-only / offline recipe | `gps-only-recipe.yaml`, `gps-only-recipe-coarse.yaml`, runner-orchestrated `gps-only-recipe-stale-readiness-prepare.yaml` + `gps-only-recipe-stale-readiness-verify.yaml`, `gps-only-recipe-not-ready.yaml`, `gps-offline-emulator.yaml`, `gps-offline-physical.yaml` | `GpsOfflineRecipeScreen.tsx` |
 | iOS location tuning | `ios-location-tuning.yaml` | `IOSLocationTuningScreen.tsx` |
 | iOS accuracy authorization | `ios-accuracy-authorization.yaml` | `IOSAccuracyAuthorizationScreen.tsx` |
 | iOS release bridge options | `ios-release-options-bridge.yaml` | `IOSReleaseOptionsBridgeScreen.tsx` |
@@ -139,6 +140,7 @@ Run from repo root with the matching workspace script:
 | Target | Command |
 | --- | --- |
 | Android native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:android` |
+| Android GPS/offline verification | `yarn workspace react-native-nitro-geolocation-example test:e2e:gps-offline:android` |
 | iOS native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:ios` |
 | Android long-run background | `yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |
 | Android long-run background with reboot | `RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |

--- a/docs/docs/guide/gps-offline-recipe.md
+++ b/docs/docs/guide/gps-offline-recipe.md
@@ -1,0 +1,149 @@
+# GPS-only and offline verification
+
+GPS-only routing and offline operation are related but different contracts:
+
+- **GPS-only result acceptance** means Android's platform location manager is
+  selected and the app accepts only a result whose provider is `gps`. The
+  native high-accuracy route prefers GPS but may try the network provider when
+  GPS cannot serve the request; the recipe detects and rejects that fallback.
+- **Offline** describes the device environment. The app cannot infer that
+  Wi-Fi and mobile data are truly unavailable from geolocation provider status,
+  so verify it outside the app.
+
+This recipe is intentionally explicit. It does not install a hidden provider
+policy or retry after a timeout. It makes any native fallback visible instead
+of accepting it as a GPS result.
+
+## Android recipe
+
+Request `ACCESS_FINE_LOCATION`, keep Android location services enabled, and
+configure the Android platform provider once during app startup:
+
+```ts
+import {
+  getCurrentPosition,
+  getAccuracyAuthorization,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  locationProvider: 'android'
+});
+
+export async function getFreshGpsPosition() {
+  const permission = await requestPermission();
+  const accuracyAuthorization = await getAccuracyAuthorization();
+  if (permission !== 'granted' || accuracyAuthorization !== 'full') {
+    throw new Error('Precise location permission is required');
+  }
+
+  const position = await getCurrentPosition({
+    accuracy: { android: 'high' },
+    granularity: 'fine',
+    maximumAge: 0,
+    maxUpdateAge: 0,
+    maxUpdateDelay: 0,
+    timeout: 45_000
+  });
+
+  if (position.provider !== 'gps') {
+    throw new Error(
+      `Expected the GPS provider, received ${position.provider ?? 'unknown'}`
+    );
+  }
+
+  return position;
+}
+```
+
+`maximumAge: 0` and `maxUpdateAge: 0` prevent an accepted cached fix. A long
+timeout is still normal for the first satellite fix, especially after reboot,
+travel, or a long period indoors. The Android platform route can try a network
+provider if GPS fails; the response assertion turns that into an explicit
+application error. Decide whether to show a retry action in your product, but
+do not silently accept or retry another provider when the feature requires a
+GPS result.
+
+Before calling the recipe, `getProviderStatus()` can report whether Android
+location services and the GPS provider are available. `networkAvailable` is the
+Android network *location provider*, not proof that the device has internet
+connectivity.
+
+Android reports coarse-only access as granted, so also require
+`getAccuracyAuthorization() === 'full'`. If it returns `reduced`, send the user
+to the app's system settings with React Native's `Linking.openSettings()` and
+let them opt into precise location; calling `requestPermission()` again is not
+an upgrade path after coarse access is already granted.
+
+## iOS boundary
+
+iOS Core Location does not expose a public sensor-selection API. You can test
+that an iOS feature works without connectivity, but you cannot truthfully label
+the request GPS-only or assert an iOS `provider` value of `gps`. Keep the normal
+`locationProvider: 'auto'` configuration on iOS.
+
+## Verification matrix
+
+Run the same product action in every required environment. Record the device,
+OS, permission scope, sky conditions, elapsed time, returned provider, mock
+flag, and outcome.
+
+| Case | Environment | Expected result | Automation role |
+| --- | --- | --- | --- |
+| Android route | Emulator, location services on, injected fix | Fresh accepted result with `provider=gps` and `mocked=true` | Required E2E; proves routing and response checks, not satellites |
+| Android no services | Emulator, master location switch off | Readiness reports services/GPS unavailable and request stays blocked | Required edge-case E2E |
+| Android online | Physical device outdoors, precise permission, network on | Fresh non-mocked `gps` result | Manual baseline |
+| Android offline | Same physical device, Wi-Fi and mobile data off, location services on | Fresh non-mocked `gps` result or an explicit timeout | Required manual offline proof |
+| Android approximate only | Emulator or physical device, precise permission denied | Readiness reports `accuracy=reduced`, blocks the request, and opens app settings for remediation | Required E2E and manual permission edge case |
+| Android GPS unavailable | Physical device, GPS/location services off | Readiness blocks the request | Manual provider edge case |
+| Android cold start | Physical device offline after reboot or long idle, clear sky | `gps` result within the product timeout or an explicit timeout | Manual latency boundary |
+| iOS offline | Physical iPhone, connectivity off | Core Location result or explicit error/timeout; no source assertion | Manual platform boundary |
+
+An emulator result cannot replace the physical offline row: Maestro location
+injection is mocked. A physical result is valid only when `mocked=false` and the
+device network state was checked independently.
+
+## Repository verification kit
+
+Build and install the Release example before running these commands from the
+repository root.
+
+The normal Android suite includes the injected GPS route and the
+location-services-disabled edge case:
+
+```bash
+yarn workspace react-native-nitro-geolocation-example test:e2e:android
+```
+
+Start the emulator with validated internet access. The dedicated command first
+verifies that online baseline, temporarily disables Wi-Fi and mobile data, runs
+the injected provider-routing flow, and restores both on exit. It intentionally
+rejects an emulator that starts offline or behind an unvalidated/captive route
+because it could not prove the disconnect-and-restore transition:
+
+```bash
+yarn workspace react-native-nitro-geolocation-example \
+  test:e2e:gps-offline:android
+```
+
+For a physical satellite proof, disable Wi-Fi and mobile data yourself, keep
+location services enabled, move outdoors, then acknowledge the prepared state:
+
+```bash
+GPS_OFFLINE_NETWORK_PREPARED=1 \
+ANDROID_SERIAL=<device-serial> \
+yarn workspace react-native-nitro-geolocation-example \
+  test:e2e:gps-offline:android
+```
+
+The physical flow does not mutate connectivity. It rejects a result unless the
+provider is `gps` and `mocked` is `false`.
+
+The example page is available at
+`nitrogeolocation://app/gps-offline-recipe`. Use it for Android manual matrix
+runs and capture its readiness and result cards with the environment notes
+above. The page intentionally reports iOS as unsupported because Core Location
+does not expose sensor routing; exercise the iOS offline row through the normal
+current-position screen or your product flow and record the result without a
+source assertion.

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -74,7 +74,8 @@ yarn test:e2e:android
 `test:e2e:ios` runs `.maestro/all-tests.yaml` with the iOS platform flag.
 `test:e2e:android` runs the same master flow with the Android platform flag,
 then runs `provider-settings-not-ready.yaml` after disabling Android location
-services and restores the device state afterward. Set
+services, verifies the GPS recipe's not-ready edge case, and restores the
+device state afterward. Set
 `RUN_ANDROID_PROVIDER_SELECTION=1` on a physical Android device to include the
 live provider-selection proof. The wrapper rejects emulators for this proof and
 requires `ANDROID_SERIAL` when multiple Android devices are connected.
@@ -160,6 +161,15 @@ When adding a flow:
 - Verifies `auto` and `playServices` return a live non-mocked fix through the fused API route
 - Verifies explicit `android` and native `android_platform` stay on the platform provider path
 - Included from `all-tests.yaml` when `RUN_ANDROID_PROVIDER_SELECTION=1`
+
+### GPS-only / offline recipe flows
+- `gps-only-recipe.yaml` injects a deterministic GPS fix and proves the Android platform route accepts `provider=gps` with `mocked=true`; it is included in `all-tests.yaml`
+- `gps-only-recipe-coarse.yaml` grants only coarse permission and proves `accuracy=reduced` keeps the GPS result contract blocked
+- `gps-only-recipe-stale-readiness-prepare.yaml` and `gps-only-recipe-stale-readiness-verify.yaml` are a runner-orchestrated pair: the Android wrapper confirms readiness, disables location services between the flows, then proves runtime revalidation disables the request again
+- `gps-only-recipe-not-ready.yaml` runs with Android location services disabled and proves readiness blocks the request
+- `gps-offline-emulator.yaml` is selected by `yarn test:e2e:gps-offline:android` on an emulator after its wrapper verifies validated internet, then disables Wi-Fi and mobile data; start online so the wrapper can prove both disconnection and restoration
+- `gps-offline-physical.yaml` is selected on a physical device only when `GPS_OFFLINE_NETWORK_PREPARED=1`; it requires `provider=gps` and `mocked=false`
+- Injected emulator locations prove provider routing, not real satellite acquisition; use the physical flow for the offline field matrix
 
 ### `issue-67-android-coarse-location.yaml`
 - Android-only contract for approximate/coarse permission handling
@@ -312,6 +322,8 @@ London: 51.5074, -0.1278
    yarn ios:release  # or yarn android:release
    yarn test:e2e:ios  # or yarn test:e2e:android
    RUN_ANDROID_PROVIDER_SELECTION=1 yarn test:e2e:android  # physical Android live provider proof
+   yarn test:e2e:gps-offline:android  # emulator network-off provider-routing proof
+   GPS_OFFLINE_NETWORK_PREPARED=1 ANDROID_SERIAL=<serial> yarn test:e2e:gps-offline:android  # physical offline GPS proof
    ```
 
 2. Copy the terminal output
@@ -326,6 +338,10 @@ London: 51.5074, -0.1278
 
 ✅ Run permission-check.yaml
 ✅ Run android-provider-selection.yaml (physical Android with RUN_ANDROID_PROVIDER_SELECTION=1)
+✅ Run gps-only-recipe.yaml
+✅ Run gps-only-recipe-coarse.yaml
+✅ Run gps-only-recipe-stale-readiness-prepare.yaml + gps-only-recipe-stale-readiness-verify.yaml
+✅ Run gps-only-recipe-not-ready.yaml
 ✅ Run current-position.yaml
 ✅ Run watch-position.yaml
 ✅ Run location-simulation.yaml

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -55,6 +55,14 @@ appId: nitrogeolocation.example
     when:
       platform: Android
     file: android-request-options-errors.yaml
+- runFlow:
+    when:
+      platform: Android
+    file: gps-only-recipe.yaml
+- runFlow:
+    when:
+      platform: Android
+    file: gps-only-recipe-coarse.yaml
 - runFlow: current-position.yaml
 - runFlow: watch-position.yaml
 - runFlow: location-simulation.yaml

--- a/examples/v0.81.1/.maestro/gps-offline-emulator.yaml
+++ b/examples/v0.81.1/.maestro/gps-offline-emulator.yaml
@@ -1,0 +1,7 @@
+appId: nitrogeolocation.example
+---
+# The wrapper script disables emulator Wi-Fi and mobile data before this flow.
+# setLocation still makes this a provider-routing proof, not satellite proof.
+
+- assertTrue: ${GPS_OFFLINE_NETWORK_DISABLED == '1'}
+- runFlow: gps-only-recipe.yaml

--- a/examples/v0.81.1/.maestro/gps-offline-physical.yaml
+++ b/examples/v0.81.1/.maestro/gps-offline-physical.yaml
@@ -1,0 +1,47 @@
+appId: nitrogeolocation.example
+---
+# Manual physical-device proof. Before running, disable Wi-Fi and mobile data,
+# keep system location/GPS enabled, and move outdoors with a clear sky view.
+
+- assertTrue: ${GPS_OFFLINE_PHYSICAL_DEVICE == '1'}
+- assertTrue: ${GPS_OFFLINE_NETWORK_PREPARED == '1'}
+
+- launchApp:
+    clearState: true
+    permissions:
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- openLink:
+    link: nitrogeolocation://app/gps-offline-recipe
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-check-readiness-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-readiness-message"
+      text: ".*GPS recipe: ready.*"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-run-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-request-status"
+      text: "GPS-only request: passed"
+    timeout: 60000
+
+- assertVisible:
+    id: "gps-offline-request-message"
+    text: ".*provider=gps; mocked=false; maximumAge=0.*"

--- a/examples/v0.81.1/.maestro/gps-only-recipe-coarse.yaml
+++ b/examples/v0.81.1/.maestro/gps-only-recipe-coarse.yaml
@@ -1,0 +1,54 @@
+appId: nitrogeolocation.example
+---
+# Edge case: coarse permission is granted, but GPS-result-only acceptance needs
+# Android precise/fine authorization and must remain blocked.
+
+- launchApp:
+    clearState: true
+    permissions:
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: deny
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/gps-offline-recipe
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-check-readiness-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-readiness-message"
+      text: ".*GPS recipe: unavailable.*permission=granted; accuracy=reduced.*"
+    timeout: 10000
+
+- assertVisible:
+    id: "gps-offline-accuracy-authorization"
+    text: "reduced"
+- assertVisible:
+    id: "gps-offline-request-blocked"
+    text: "GPS-only request is blocked until GPS readiness is ready."
+- assertVisible:
+    id: "e2e-action-gps-offline-run-button"
+    enabled: false
+- assertVisible:
+    id: "e2e-action-gps-offline-request-permission-button"
+
+- tapOn:
+    id: "e2e-action-gps-offline-request-permission-button"
+
+- extendedWaitUntil:
+    visible: "Permissions|권한"
+    timeout: 10000
+
+- pressKey: BACK
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000

--- a/examples/v0.81.1/.maestro/gps-only-recipe-not-ready.yaml
+++ b/examples/v0.81.1/.maestro/gps-only-recipe-not-ready.yaml
@@ -1,0 +1,39 @@
+appId: nitrogeolocation.example
+---
+# Edge case: Android's master location switch is disabled by the E2E runner.
+# The recipe must report that GPS is unavailable and keep the request disabled.
+
+- launchApp:
+    clearState: true
+    permissions:
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: allow
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/gps-offline-recipe
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-check-readiness-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-readiness-message"
+      text: ".*GPS recipe: unavailable.*"
+    timeout: 10000
+
+- assertVisible:
+    id: "gps-offline-readiness-message"
+    text: ".*locationServices=false; gps=false; permission=granted; accuracy=full.*"
+- assertVisible:
+    id: "gps-offline-request-blocked"
+    text: "GPS-only request is blocked until GPS readiness is ready."
+- assertVisible:
+    id: "e2e-action-gps-offline-run-button"
+    enabled: false

--- a/examples/v0.81.1/.maestro/gps-only-recipe-stale-readiness-prepare.yaml
+++ b/examples/v0.81.1/.maestro/gps-only-recipe-stale-readiness-prepare.yaml
@@ -1,0 +1,33 @@
+appId: nitrogeolocation.example
+---
+# First half of the stale-readiness edge. The Android runner disables location
+# services after this flow while leaving the prepared screen in place.
+
+- launchApp:
+    clearState: true
+    permissions:
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: allow
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/gps-offline-recipe
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-check-readiness-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-readiness-message"
+      text: ".*GPS recipe: ready.*"
+    timeout: 10000
+
+- assertVisible:
+    id: "e2e-action-gps-offline-run-button"
+    enabled: true

--- a/examples/v0.81.1/.maestro/gps-only-recipe-stale-readiness-verify.yaml
+++ b/examples/v0.81.1/.maestro/gps-only-recipe-stale-readiness-verify.yaml
@@ -1,0 +1,22 @@
+appId: nitrogeolocation.example
+---
+# Second half of the stale-readiness edge. The Android runner has disabled
+# location services since the prepare flow completed.
+
+- assertVisible: "Android GPS-preferred routing with GPS-only result acceptance"
+
+- tapOn:
+    id: "e2e-action-gps-offline-run-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-request-status"
+      text: "GPS-only request: failed"
+    timeout: 10000
+
+- assertVisible:
+    id: "gps-offline-request-blocked"
+    text: "GPS-only request is blocked until GPS readiness is ready."
+- assertVisible:
+    id: "e2e-action-gps-offline-run-button"
+    enabled: false

--- a/examples/v0.81.1/.maestro/gps-only-recipe.yaml
+++ b/examples/v0.81.1/.maestro/gps-only-recipe.yaml
@@ -1,0 +1,58 @@
+appId: nitrogeolocation.example
+---
+# Automated provider-routing proof for the GPS-only recipe. Maestro injects a
+# location, so this proves the Android platform GPS route but is not evidence
+# that a physical device can obtain a satellite fix while offline.
+
+- launchApp:
+    clearState: true
+    permissions:
+      android.permission.ACCESS_COARSE_LOCATION: allow
+      android.permission.ACCESS_FINE_LOCATION: allow
+
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- openLink:
+    link: nitrogeolocation://app/gps-offline-recipe
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Android GPS-preferred routing with GPS-only result acceptance"
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- tapOn:
+    id: "e2e-action-gps-offline-check-readiness-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-readiness-message"
+      text: ".*GPS recipe: ready.*"
+    timeout: 10000
+
+- tapOn:
+    id: "e2e-action-gps-offline-run-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "gps-offline-request-status"
+      text: "GPS-only request: passed"
+    timeout: 60000
+
+- assertVisible:
+    id: "gps-offline-request-result"
+- assertVisible:
+    id: "gps-offline-request-message"
+    text: ".*provider=gps; mocked=true; maximumAge=0.*"

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
     "test:e2e:android": "bash ./scripts/test-maestro-retry-flows.sh && bash ./scripts/test-e2e-android.sh",
+    "test:e2e:gps-offline:android": "bash ./scripts/test-gps-offline-android.sh",
     "test:e2e:ios": "bash ./scripts/test-e2e-ios.sh",
     "test:e2e:background-long-run:android": "bash ./scripts/test-background-long-run-android.sh",
     "test:e2e:background-long-run:ios": "bash ./scripts/test-background-long-run-ios.sh",

--- a/examples/v0.81.1/scripts/test-e2e-android.sh
+++ b/examples/v0.81.1/scripts/test-e2e-android.sh
@@ -9,6 +9,7 @@ ADB_BIN="${ADB:-adb}"
 MAESTRO_BIN="${MAESTRO:-maestro}"
 NODE_BIN="${NODE:-node}"
 DISABLED_LAUNCHER_PACKAGE=""
+LOCATION_WAS_ENABLED=""
 
 adb_cmd() {
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
@@ -36,7 +37,9 @@ disable_emulator_launcher() {
       awk -F/ 'NF > 1 { package = $1 } END { print package }'
   )"
 
-  if [[ -z "$launcher_package" || "$launcher_package" == "android" ]]; then
+  if [[ -z "$launcher_package" ||
+    "$launcher_package" == "android" ||
+    "$launcher_package" == "com.android.settings" ]]; then
     return
   fi
 
@@ -55,7 +58,9 @@ restore_emulator_launcher() {
 
 restore_location() {
   restore_emulator_launcher
-  set_location_enabled true || true
+  if [[ -n "$LOCATION_WAS_ENABLED" ]]; then
+    set_location_enabled "$LOCATION_WAS_ENABLED"
+  fi
   adb_cmd reverse --remove tcp:8081 >/dev/null 2>&1 || true
 }
 
@@ -74,8 +79,6 @@ connected_device_count() {
   "$ADB_BIN" devices | awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }'
 }
 
-trap restore_location_on_exit EXIT
-
 RUN_ANDROID_PROVIDER_SELECTION_VALUE="${RUN_ANDROID_PROVIDER_SELECTION:-0}"
 PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="0"
 
@@ -90,6 +93,16 @@ fi
 if [[ "$RUN_ANDROID_PROVIDER_SELECTION_VALUE" == "1" ]]; then
   PROVIDER_SELECTION_PHYSICAL_DEVICE_VALUE="1"
 fi
+
+LOCATION_WAS_ENABLED="$(
+  adb_cmd shell cmd location is-location-enabled | tr -d '\r'
+)"
+if [[ "$LOCATION_WAS_ENABLED" != "true" && "$LOCATION_WAS_ENABLED" != "false" ]]; then
+  echo "Unable to capture the initial Android location-services state." >&2
+  exit 1
+fi
+
+trap restore_location_on_exit EXIT
 
 if ! android_flow_output="$(
   "$NODE_BIN" "$SCRIPT_DIR/maestro-suite-flows.mjs" "$FLOW_DIR/all-tests.yaml" android
@@ -137,8 +150,15 @@ status=0
 
 set_location_enabled true
 run_maestro_flows "android location-enabled" "${ANDROID_FLOWS[@]}" || status=1
+run_maestro_flows \
+  "android GPS stale-readiness setup" \
+  gps-only-recipe-stale-readiness-prepare.yaml || status=1
 
 set_location_enabled false
+run_maestro_flows \
+  "android GPS stale-readiness verification" \
+  gps-only-recipe-stale-readiness-verify.yaml || status=1
 run_maestro_flows "android location-disabled" provider-settings-not-ready.yaml || status=1
+run_maestro_flows "android GPS not-ready" gps-only-recipe-not-ready.yaml || status=1
 
 exit "$status"

--- a/examples/v0.81.1/scripts/test-gps-offline-android.sh
+++ b/examples/v0.81.1/scripts/test-gps-offline-android.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLOW_DIR="$EXAMPLE_DIR/.maestro"
+
+ADB_BIN="${ADB:-adb}"
+MAESTRO_BIN="${MAESTRO:-maestro}"
+
+adb_cmd() {
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    "$ADB_BIN" -s "$ANDROID_SERIAL" "$@"
+  else
+    "$ADB_BIN" "$@"
+  fi
+}
+
+is_emulator() {
+  [[ "$(adb_cmd shell getprop ro.kernel.qemu | tr -d '\r')" == "1" ]]
+}
+
+connected_device_count() {
+  "$ADB_BIN" devices | awk 'NR > 1 && $2 == "device" { count++ } END { print count + 0 }'
+}
+
+read_binary_setting() {
+  local setting_name="$1"
+  local value
+  value="$(adb_cmd shell settings get global "$setting_name" | tr -d '\r')"
+
+  if [[ "$value" != "0" && "$value" != "1" ]]; then
+    echo "Expected Android global setting $setting_name to be 0 or 1, received '$value'." >&2
+    return 1
+  fi
+
+  printf '%s' "$value"
+}
+
+wait_for_binary_setting() {
+  local setting_name="$1"
+  local expected="$2"
+  local attempt value
+
+  for attempt in {1..15}; do
+    value="$(adb_cmd shell settings get global "$setting_name" | tr -d '\r')"
+    if [[ "$value" == "$expected" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Android global setting $setting_name did not reach $expected." >&2
+  return 1
+}
+
+has_validated_internet() {
+  adb_cmd shell dumpsys connectivity |
+    grep -Eq 'NetworkAgentInfo.*CONNECTED.*Capabilities:.*INTERNET.*VALIDATED'
+}
+
+wait_for_validated_internet_state() {
+  local expected="$1"
+  local _attempt
+  local actual
+
+  for _attempt in {1..15}; do
+    if has_validated_internet; then
+      actual="1"
+    else
+      actual="0"
+    fi
+
+    if [[ "$actual" == "$expected" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Android validated internet state did not reach $expected." >&2
+  return 1
+}
+
+run_flow() {
+  local flow="$1"
+  shift
+
+  local args=(
+    --platform android
+    --flow-dir "$FLOW_DIR"
+    --maestro "$MAESTRO_BIN"
+    --suite-name "android GPS offline recipe"
+  )
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    args+=(--maestro-arg --udid --maestro-arg "$ANDROID_SERIAL")
+  fi
+
+  "$SCRIPT_DIR/maestro-retry-flows.sh" "${args[@]}" "$@" -- "$flow"
+}
+
+if [[ -z "${ANDROID_SERIAL:-}" && "$(connected_device_count)" != "1" ]]; then
+  echo "GPS offline verification requires ANDROID_SERIAL when zero or multiple Android devices are connected." >&2
+  exit 1
+fi
+
+if ! is_emulator; then
+  if [[ "${GPS_OFFLINE_NETWORK_PREPARED:-0}" != "1" ]]; then
+    echo "Physical-device proof requires GPS_OFFLINE_NETWORK_PREPARED=1 after Wi-Fi and mobile data are disabled." >&2
+    exit 1
+  fi
+
+  run_flow \
+    gps-offline-physical.yaml \
+    --env GPS_OFFLINE_PHYSICAL_DEVICE=1 \
+    --env GPS_OFFLINE_NETWORK_PREPARED=1
+  exit 0
+fi
+
+WIFI_WAS_ENABLED="$(read_binary_setting wifi_on)"
+DATA_WAS_ENABLED="$(read_binary_setting mobile_data)"
+wait_for_validated_internet_state 1
+
+restore_network() {
+  local restore_failed=0
+
+  if [[ "$WIFI_WAS_ENABLED" == "0" ]]; then
+    if ! adb_cmd shell svc wifi disable >/dev/null; then
+      restore_failed=1
+    fi
+  else
+    if ! adb_cmd shell svc wifi enable >/dev/null; then
+      restore_failed=1
+    fi
+  fi
+
+  if [[ "$DATA_WAS_ENABLED" == "0" ]]; then
+    if ! adb_cmd shell svc data disable >/dev/null; then
+      restore_failed=1
+    fi
+  else
+    if ! adb_cmd shell svc data enable >/dev/null; then
+      restore_failed=1
+    fi
+  fi
+
+  if ! wait_for_binary_setting wifi_on "$WIFI_WAS_ENABLED"; then
+    restore_failed=1
+  fi
+  if ! wait_for_binary_setting mobile_data "$DATA_WAS_ENABLED"; then
+    restore_failed=1
+  fi
+  if ! wait_for_validated_internet_state 1; then
+    restore_failed=1
+  fi
+
+  return "$restore_failed"
+}
+
+restore_network_on_exit() {
+  local exit_code=$?
+  trap - EXIT
+
+  if ! restore_network; then
+    echo "Failed to restore the Android emulator network state." >&2
+    exit 1
+  fi
+
+  exit "$exit_code"
+}
+
+trap restore_network_on_exit EXIT
+
+adb_cmd shell svc wifi disable >/dev/null
+adb_cmd shell svc data disable >/dev/null
+wait_for_binary_setting wifi_on 0
+wait_for_binary_setting mobile_data 0
+wait_for_validated_internet_state 0
+
+run_flow \
+  gps-offline-emulator.yaml \
+  --env GPS_OFFLINE_NETWORK_DISABLED=1

--- a/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
+++ b/examples/v0.81.1/scripts/test-maestro-retry-flows.sh
@@ -27,6 +27,10 @@ cat >"$TEST_ROOT/bin/adb" <<'ADB'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"$FAKE_ADB_LOG"
+
+if [[ "$*" == "shell cmd location is-location-enabled" ]]; then
+  printf 'true\n'
+fi
 ADB
 
 cat >"$TEST_ROOT/bin/sleep" <<'SLEEP'

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -18,6 +18,7 @@ import CompatScreen from "./screens/CompatScreen";
 import CurrentPositionScreen from "./screens/CurrentPositionScreen";
 import DefaultScreen from "./screens/DefaultScreen";
 import GeocodingScreen from "./screens/GeocodingScreen";
+import GpsOfflineRecipeScreen from "./screens/GpsOfflineRecipeScreen";
 import HeadingScreen from "./screens/HeadingScreen";
 import IOSAccuracyAuthorizationScreen from "./screens/IOSAccuracyAuthorizationScreen";
 import IOSLocationTuningScreen from "./screens/IOSLocationTuningScreen";
@@ -55,6 +56,7 @@ const linking = {
       AccuracyPresets: "accuracy-presets",
       LastKnownPosition: "last-known-position",
       Geocoding: "geocoding",
+      GpsOfflineRecipe: "gps-offline-recipe",
       LocationAvailability: "location-availability",
       Heading: "heading",
       AndroidRequestOptions: "android-request-options",
@@ -166,6 +168,11 @@ export default function App() {
           <Tab.Screen
             name="Geocoding"
             component={GeocodingScreen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="GpsOfflineRecipe"
+            component={GpsOfflineRecipeScreen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/GpsOfflineRecipeScreen.tsx
+++ b/examples/v0.81.1/src/screens/GpsOfflineRecipeScreen.tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useState } from "react";
+import { Linking, Platform } from "react-native";
+import {
+  getAccuracyAuthorization,
+  getCurrentPosition,
+  getProviderStatus,
+  setConfiguration
+} from "react-native-nitro-geolocation";
+import type {
+  AccuracyAuthorization,
+  LocationProviderStatus
+} from "react-native-nitro-geolocation";
+import {
+  DumpedText,
+  PermissionStatusBlock,
+  ResultList,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  StatusBlock,
+  createScenarioResults,
+  getDisplayErrorMessage,
+  runWithNativeGeolocation,
+  sharedStyles,
+  usePermissionStatus,
+  useScenarioResults
+} from "./scenario";
+
+const PREFIX = "gps-offline";
+const GPS_REQUEST_TIMEOUT_MS = 45_000;
+const resultsInitialState = createScenarioResults([
+  "readiness",
+  "request"
+] as const);
+
+type GpsReadiness = "checking" | "ready" | "unavailable";
+
+const formatAvailability = (value: boolean | undefined) => {
+  if (value === undefined) return "unknown";
+  return value ? "available" : "unavailable";
+};
+
+export default function GpsOfflineRecipeScreen() {
+  const { permissionStatus, refreshPermission, requestLocationPermission } =
+    usePermissionStatus({ autoRefresh: false });
+  const { results, setResult } = useScenarioResults(resultsInitialState);
+  const [providerStatus, setProviderStatus] =
+    useState<LocationProviderStatus | null>(null);
+  const [accuracyAuthorization, setAccuracyAuthorization] =
+    useState<AccuracyAuthorization>("unknown");
+  const [readiness, setReadiness] = useState<GpsReadiness>("checking");
+  const [isBusy, setIsBusy] = useState(false);
+
+  const checkReadiness = async () => {
+    setIsBusy(true);
+    setReadiness("checking");
+    setResult("readiness", {
+      status: "running",
+      message: "Checking permission, location services, and GPS availability"
+    });
+
+    try {
+      if (Platform.OS !== "android") {
+        setReadiness("unavailable");
+        setResult("readiness", {
+          status: "passed",
+          message:
+            "GPS recipe: unsupported; iOS Core Location does not expose sensor routing."
+        });
+        return;
+      }
+
+      const [permission, accuracy, status] = await Promise.all([
+        refreshPermission(),
+        getAccuracyAuthorization(),
+        getProviderStatus()
+      ]);
+      setAccuracyAuthorization(accuracy);
+      setProviderStatus(status);
+
+      const isReady =
+        permission === "granted" &&
+        accuracy === "full" &&
+        status.locationServicesEnabled &&
+        status.gpsAvailable === true;
+      setReadiness(isReady ? "ready" : "unavailable");
+      setResult("readiness", {
+        status: "passed",
+        message: `GPS recipe: ${isReady ? "ready" : "unavailable"}; locationServices=${status.locationServicesEnabled}; gps=${status.gpsAvailable ?? "unknown"}; permission=${permission}; accuracy=${accuracy}.`
+      });
+    } catch (error) {
+      setReadiness("unavailable");
+      setResult("readiness", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const resolvePrecisePermission = async () => {
+    setIsBusy(true);
+    try {
+      if (
+        Platform.OS === "android" &&
+        permissionStatus === "granted" &&
+        accuracyAuthorization === "reduced"
+      ) {
+        await Linking.openSettings();
+        return;
+      }
+
+      await requestLocationPermission();
+      await checkReadiness();
+    } catch (error) {
+      setReadiness("unavailable");
+      setResult("readiness", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const runGpsOnlyRequest = async () => {
+    setIsBusy(true);
+    setResult("request", {
+      status: "running",
+      message: "Requesting one fresh Android platform GPS fix"
+    });
+
+    try {
+      if (Platform.OS !== "android") {
+        throw new Error(
+          "GPS-only sensor routing is Android-only; iOS Core Location chooses the source."
+        );
+      }
+
+      const [permission, accuracy, status] = await Promise.all([
+        refreshPermission(),
+        getAccuracyAuthorization(),
+        getProviderStatus()
+      ]);
+      setAccuracyAuthorization(accuracy);
+      setProviderStatus(status);
+      const isReady =
+        permission === "granted" &&
+        accuracy === "full" &&
+        status.locationServicesEnabled &&
+        status.gpsAvailable === true;
+      setReadiness(isReady ? "ready" : "unavailable");
+      setResult("readiness", {
+        status: "passed",
+        message: `GPS recipe: ${isReady ? "ready" : "unavailable"}; locationServices=${status.locationServicesEnabled}; gps=${status.gpsAvailable ?? "unknown"}; permission=${permission}; accuracy=${accuracy}.`
+      });
+      if (permission !== "granted") {
+        throw new Error(
+          `GPS-only result acceptance requires location permission; permission=${permission}.`
+        );
+      }
+      if (accuracy !== "full") {
+        throw new Error(
+          `GPS-only result acceptance requires precise location permission; accuracy=${accuracy}.`
+        );
+      }
+      if (!status.locationServicesEnabled || status.gpsAvailable !== true) {
+        throw new Error(
+          "GPS-only recipe requires Android location services and the GPS provider to be available."
+        );
+      }
+
+      setConfiguration({ locationProvider: "android" });
+      const startedAt = Date.now();
+      const position = await runWithNativeGeolocation(() =>
+        getCurrentPosition({
+          accuracy: { android: "high" },
+          granularity: "fine",
+          maximumAge: 0,
+          maxUpdateAge: 0,
+          maxUpdateDelay: 0,
+          timeout: GPS_REQUEST_TIMEOUT_MS
+        })
+      );
+
+      if (position.provider !== "gps") {
+        throw new Error(
+          `GPS-only result contract rejected ${position.provider ?? "an unknown provider"}; the Android platform route may fall back, but this recipe never accepts that result.`
+        );
+      }
+      if (position.timestamp < startedAt - 30_000) {
+        throw new Error(
+          `GPS-only request returned a stale fix from ${position.timestamp}.`
+        );
+      }
+      if (typeof position.mocked !== "boolean") {
+        throw new Error("Android GPS-only request did not report mock status.");
+      }
+
+      setResult("request", {
+        status: "passed",
+        message: `Fresh fix ${position.coords.latitude.toFixed(6)}, ${position.coords.longitude.toFixed(6)}; provider=${position.provider}; mocked=${position.mocked}; maximumAge=0.`
+      });
+    } catch (error) {
+      setResult("request", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    } finally {
+      setConfiguration({ locationProvider: "auto" });
+      await refreshPermission();
+      setIsBusy(false);
+    }
+  };
+
+  useEffect(() => {
+    void checkReadiness();
+  }, []);
+
+  return (
+    <ScenarioScreen
+      prefix={PREFIX}
+      title="GPS-only / Offline Recipe"
+      subtitle="Android GPS-preferred routing with GPS-only result acceptance"
+    >
+      <ScenarioSection
+        index={1}
+        title="Readiness"
+        description="Network availability is informational. This recipe requires precise permission, location services, and the Android GPS provider."
+      >
+        <PermissionStatusBlock prefix={PREFIX} status={permissionStatus} />
+        <StatusBlock
+          testID="gps-offline-provider-status"
+          rows={[
+            {
+              label: "Accuracy authorization:",
+              value: accuracyAuthorization,
+              testID: "gps-offline-accuracy-authorization"
+            },
+            {
+              label: "Location services:",
+              value: formatAvailability(
+                providerStatus?.locationServicesEnabled
+              ),
+              testID: "gps-offline-location-services"
+            },
+            {
+              label: "GPS:",
+              value: formatAvailability(providerStatus?.gpsAvailable),
+              testID: "gps-offline-gps"
+            },
+            {
+              label: "Network provider:",
+              value: formatAvailability(providerStatus?.networkAvailable),
+              testID: "gps-offline-network"
+            }
+          ]}
+        />
+        <ResultList
+          prefix={PREFIX}
+          results={results}
+          items={[
+            {
+              id: "readiness",
+              label: "GPS readiness"
+            }
+          ]}
+        />
+        <ScenarioButton
+          title={isBusy ? "Checking..." : "Check GPS Readiness"}
+          onPress={checkReadiness}
+          disabled={isBusy}
+          color="#1565C0"
+          testID="gps-offline-check-readiness-button"
+        />
+        {permissionStatus !== "granted" || accuracyAuthorization !== "full" ? (
+          <ScenarioButton
+            title={
+              Platform.OS === "android" && permissionStatus === "granted"
+                ? "Open App Settings for Precise Location"
+                : "Request Location Permission"
+            }
+            onPress={resolvePrecisePermission}
+            disabled={isBusy}
+            color="#6A1B9A"
+            testID="gps-offline-request-permission-button"
+          />
+        ) : null}
+      </ScenarioSection>
+
+      <ScenarioSection
+        index={2}
+        title="Fresh GPS Fix"
+        description="Run the same explicit request online and offline. Android may try a fallback provider, but this recipe rejects every non-GPS result and never retries in secret."
+        divided
+      >
+        {readiness !== "ready" ? (
+          <DumpedText
+            dumpText="GPS-only request is blocked until GPS readiness is ready."
+            style={sharedStyles.resultMessage}
+            testID="gps-offline-request-blocked"
+          >
+            GPS-only request is blocked until GPS readiness is ready.
+          </DumpedText>
+        ) : null}
+        <ScenarioButton
+          title={isBusy ? "Locating..." : "Run GPS-only Request"}
+          onPress={runGpsOnlyRequest}
+          disabled={isBusy || readiness !== "ready"}
+          color="#2E7D32"
+          testID="gps-offline-run-button"
+        />
+        <ResultList
+          prefix={PREFIX}
+          results={results}
+          items={[
+            {
+              id: "request",
+              label: "GPS-only request"
+            }
+          ]}
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}


### PR DESCRIPTION
## Roadmap checkbox

Closes the issue #98 checkbox: **11.1 Add GPS-only / offline recipe and E2E/manual matrix.**

This PR is independent and targets `main`.

## What changed

- adds a natural GPS-only/offline example page with explicit Android readiness checks
- treats Android platform high-accuracy routing as GPS-preferred and rejects every returned non-`gps` result
- blocks coarse-only, location-disabled, GPS-unavailable, and stale-readiness states
- sends coarse-only users to Android App Settings for precise-location remediation
- adds deterministic mocked emulator happy/coarse/not-ready/stale-readiness E2E coverage
- adds a guarded offline emulator runner that proves network disconnect and exact restoration
- adds a separately gated physical-device flow requiring `provider=gps` and `mocked=false`
- documents the manual Android/iOS, emulator/physical, online/offline, and cold-start matrix

## RED → GREEN evidence

- happy flow first failed because the route/page did not exist
- coarse-only flow first failed because precise authorization was not modeled
- coarse remediation first failed because the action did not open Android settings
- stale-readiness verification first failed because the UI remained ready after location services changed
- each contract was implemented only after its RED failure and then rerun on the Release example

## Verification

- Android Release build: passed
- full Android Maestro suite: 24 location-enabled flows passed on attempt 1/3
- runner-managed stale-readiness setup + verification: passed on attempt 1/3
- location-disabled provider settings + GPS not-ready flows: passed on attempt 1/3
- dedicated emulator offline flow: passed on attempt 1/3
- Wi-Fi, mobile-data, validated-internet, location-service, and launcher restoration: verified
- format, lint, package/example/docs TypeScript, shell syntax, YAML parse, Maestro retry self-test: passed
- docs build: passed
- adversarial reviews: no P1/P2 findings

The physical satellite row is intentionally a manual proof and is not claimed as executed by the mocked emulator run.

## Release note

No changeset: this PR changes only the example, E2E harness, and docs; it does not change a published package. The repository remains in Changesets prerelease mode with tag `rc`.