### PR TITLE
refactor: remove source line limit exceptions

### DIFF
--- a/.changeset/steady-lines-share.md
+++ b/.changeset/steady-lines-share.md
@@ -1,0 +1,5 @@
+---
+---
+
+Remove file-specific source-line guard exceptions and split native adapters
+without changing published package behavior.

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidCurrentPositionManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidCurrentPositionManager.kt
@@ -1,0 +1,279 @@
+package com.margelo.nitro.nitrogeolocation
+
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Build
+import android.os.CancellationSignal
+import android.os.Handler
+import android.os.Looper
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+internal class AndroidCurrentPositionManager(
+    private val locationManager: LocationManager,
+    private val isCachedLocationValid: (Location, ParsedOptions) -> Boolean,
+    private val effectiveMaximumAge: (ParsedOptions) -> Double,
+    private val createNoProviderError: (ParsedOptions) -> LocationError,
+    private val createTimeoutError: (ParsedOptions) -> LocationError,
+    private val locationToPosition: (Location) -> GeolocationResponse
+) {
+    private val pendingRequests = ConcurrentHashMap<String, PositionRequest>()
+
+    fun requestFreshLocation(
+        providers: List<String>,
+        options: ParsedOptions,
+        deadlineElapsedRealtime: Long,
+        resolver: (PositionResult) -> Unit,
+        requestId: String? = null,
+        onCancellationReady: ((() -> Unit) -> Unit)? = null
+    ) {
+        val id = requestId ?: UUID.randomUUID().toString()
+        val handler = Handler(Looper.getMainLooper())
+        pendingRequests[id] = PositionRequest(
+            id = id,
+            resolver = resolver,
+            options = options,
+            handler = handler,
+            providers = providers,
+            deadlineElapsedRealtime = deadlineElapsedRealtime
+        )
+        onCancellationReady?.invoke { cancel(requestId = id) }
+        requestFreshLocationForCurrentProvider(id)
+    }
+
+    private fun cancel(requestId: String) {
+        val request = pendingRequests.remove(requestId) ?: return
+        request.handler.removeCallbacksAndMessages(null)
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+    }
+
+    private fun requestFreshLocationForCurrentProvider(requestId: String) {
+        val request = pendingRequests[requestId] ?: return
+        val provider = request.providers.getOrNull(request.providerIndex)
+        val remainingTimeoutMillis = request.remainingTimeoutMillis()
+
+        if (provider == null) {
+            pendingRequests.remove(requestId)?.resolver(
+                PositionResult.Failure(createNoProviderError(request.options))
+            )
+            return
+        }
+
+        if (remainingTimeoutMillis <= 0L) {
+            pendingRequests.remove(requestId)?.resolver(
+                PositionResult.Failure(createTimeoutError(request.options))
+            )
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            effectiveMaximumAge(request.options) > 0.0
+        ) {
+            requestCurrentLocationModern(
+                provider,
+                requestId,
+                request.handler,
+                remainingTimeoutMillis
+            )
+        } else {
+            requestCurrentLocationLegacy(
+                provider,
+                requestId,
+                request.handler,
+                remainingTimeoutMillis
+            )
+        }
+    }
+
+    @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
+    private fun requestCurrentLocationModern(
+        provider: String,
+        requestId: String,
+        handler: Handler,
+        timeoutMillis: Long
+    ) {
+        val cancellationSignal = CancellationSignal()
+        val timeoutRunnable = Runnable { handlePositionTimeout(requestId) }
+
+        try {
+            locationManager.getCurrentLocation(
+                provider,
+                cancellationSignal,
+                { runnable -> handler.post(runnable) }
+            ) { location ->
+                handler.removeCallbacks(timeoutRunnable)
+                val request = pendingRequests[requestId]
+                if (request != null) {
+                    when {
+                        location != null && isCachedLocationValid(location, request.options) -> {
+                            pendingRequests.remove(requestId)
+                            request.resolver(PositionResult.Success(locationToPosition(location)))
+                        }
+                        location != null -> retryCurrentLocationLegacyAfterStaleModern(
+                            provider,
+                            requestId,
+                            handler,
+                            request
+                        )
+                        else -> handleProviderFailure(
+                            requestId,
+                            createLocationError(
+                                POSITION_UNAVAILABLE,
+                                "Unable to get fresh location"
+                            )
+                        )
+                    }
+                }
+            }
+
+            handler.postDelayed(timeoutRunnable, timeoutMillis)
+            val cleanup = {
+                handler.removeCallbacksAndMessages(null)
+                cancellationSignal.cancel()
+            }
+            installCancellationAction(requestId, cleanup)
+        } catch (error: SecurityException) {
+            handler.removeCallbacks(timeoutRunnable)
+            handleProviderFailure(
+                requestId,
+                createLocationError(
+                    PERMISSION_DENIED,
+                    "Security exception: ${error.message}"
+                )
+            )
+        }
+    }
+
+    private fun retryCurrentLocationLegacyAfterStaleModern(
+        provider: String,
+        requestId: String,
+        handler: Handler,
+        request: PositionRequest
+    ) {
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+        val remainingTimeoutMillis = request.remainingTimeoutMillis()
+        if (remainingTimeoutMillis <= 0L) {
+            handlePositionTimeout(requestId)
+            return
+        }
+        requestCurrentLocationLegacy(provider, requestId, handler, remainingTimeoutMillis)
+    }
+
+    private fun requestCurrentLocationLegacy(
+        provider: String,
+        requestId: String,
+        handler: Handler,
+        timeoutMillis: Long
+    ) {
+        var isResolved = false
+        var oldLocation: Location? = null
+        val listener = object : LocationListener {
+            override fun onLocationChanged(location: Location) {
+                synchronized(this) {
+                    if (isResolved) return
+                    val bestLocation = selectBestLocation(location, oldLocation)
+                    if (bestLocation == location) {
+                        isResolved = true
+                        handler.removeCallbacksAndMessages(null)
+                        runCatching { locationManager.removeUpdates(this) }
+                        pendingRequests.remove(requestId)?.let { request ->
+                            request.resolver(
+                                PositionResult.Success(locationToPosition(location))
+                            )
+                        }
+                    }
+                    oldLocation = location
+                }
+            }
+
+            override fun onProviderDisabled(provider: String) = Unit
+            override fun onProviderEnabled(provider: String) = Unit
+
+            @Deprecated("Deprecated in Java")
+            override fun onStatusChanged(
+                provider: String?,
+                status: Int,
+                extras: android.os.Bundle?
+            ) = Unit
+        }
+
+        val timeoutRunnable = Runnable {
+            synchronized(listener) {
+                if (!isResolved) {
+                    isResolved = true
+                    runCatching { locationManager.removeUpdates(listener) }
+                    handlePositionTimeout(requestId)
+                }
+            }
+        }
+
+        try {
+            locationManager.requestLocationUpdates(
+                provider,
+                100,
+                1f,
+                listener,
+                Looper.getMainLooper()
+            )
+            handler.postDelayed(timeoutRunnable, timeoutMillis)
+            val cleanup = {
+                synchronized(listener) {
+                    isResolved = true
+                    handler.removeCallbacksAndMessages(null)
+                    runCatching { locationManager.removeUpdates(listener) }
+                    Unit
+                }
+            }
+            installCancellationAction(requestId, cleanup)
+        } catch (error: SecurityException) {
+            handleProviderFailure(
+                requestId,
+                createLocationError(
+                    PERMISSION_DENIED,
+                    "Security exception: ${error.message}"
+                )
+            )
+        }
+    }
+
+    private fun installCancellationAction(requestId: String, cleanup: () -> Unit) {
+        val request = pendingRequests[requestId]
+        if (request != null) {
+            request.cancellationAction = cleanup
+            if (pendingRequests[requestId] !== request) cleanup()
+        } else {
+            cleanup()
+        }
+    }
+
+    private fun handleProviderFailure(requestId: String, error: LocationError) {
+        val request = pendingRequests[requestId] ?: return
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+        request.providerIndex += 1
+
+        if (request.providerIndex < request.providers.size) {
+            if (request.remainingTimeoutMillis() <= 0L) {
+                pendingRequests.remove(requestId)?.resolver(
+                    PositionResult.Failure(createTimeoutError(request.options))
+                )
+                return
+            }
+            requestFreshLocationForCurrentProvider(requestId)
+            return
+        }
+
+        pendingRequests.remove(requestId)?.resolver(PositionResult.Failure(error))
+    }
+
+    private fun handlePositionTimeout(requestId: String) {
+        val request = pendingRequests.remove(requestId) ?: return
+        request.handler.removeCallbacksAndMessages(null)
+        request.cancellationAction?.invoke()
+        request.cancellationAction = null
+        request.resolver(PositionResult.Failure(createTimeoutError(request.options)))
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
@@ -1,0 +1,264 @@
+package com.margelo.nitro.nitrogeolocation
+
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Looper
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationResult
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+internal class AndroidPositionWatchManager(
+    private val locationManager: LocationManager,
+    private val fusedLocationClient: FusedLocationProviderClient,
+    private val fusedLocationProvider: AndroidFusedLocationProvider,
+    private val providerRoute: () -> AndroidProviderRoute,
+    private val configuredProvider: () -> LocationProvider?,
+    private val getValidProvider: (ParsedOptions) -> String?,
+    private val getNoProviderMessage: (ParsedOptions) -> String,
+    private val locationToPosition: (Location, LocationProviderUsed?) -> GeolocationResponse
+) {
+    private val subscriptions = ConcurrentHashMap<String, WatchSubscription>()
+    private var platformListener: LocationListener? = null
+    private var fusedCallback: LocationCallback? = null
+    private val generation = AtomicLong(0L)
+
+    fun watch(
+        success: (GeolocationResponse) -> Unit,
+        error: ((LocationError) -> Unit)?,
+        options: ParsedOptions
+    ): String {
+        val token = UUID.randomUUID().toString()
+        subscriptions[token] = WatchSubscription(token, success, error, options)
+        if (subscriptions.size == 1) start() else restart()
+        return token
+    }
+
+    fun unwatch(token: String): Boolean {
+        if (subscriptions.remove(token) == null) return false
+        if (subscriptions.isEmpty()) stop() else restart()
+        return true
+    }
+
+    fun activeWatches(): Array<ActiveWatch> = subscriptions.keys
+        .map { ActiveWatch(token = it, kind = ActiveWatchKind.POSITION) }
+        .sortedBy { it.token }
+        .toTypedArray()
+
+    fun stopObserving() {
+        subscriptions.clear()
+        stop()
+    }
+
+    private fun start() {
+        val activeGeneration = generation.get()
+        if (providerRoute() == AndroidProviderRoute.FUSED) {
+            startFused(activeGeneration)
+        } else {
+            startPlatform(activeGeneration)
+        }
+    }
+
+    private fun isActive(activeGeneration: Long): Boolean =
+        subscriptions.isNotEmpty() && generation.get() == activeGeneration
+
+    private fun startPlatform(activeGeneration: Long) {
+        if (!isActive(activeGeneration)) return
+        val options = mergeOptions()
+        val provider = getValidProvider(options)
+        if (provider == null) {
+            notifyProviderUnavailable()
+            return
+        }
+
+        val listener = object : LocationListener {
+            override fun onLocationChanged(location: Location) {
+                if (!isActive(activeGeneration)) return
+                deliver(locationToPosition(location, null))
+            }
+
+            override fun onProviderDisabled(provider: String) {
+                if (!isActive(activeGeneration)) return
+                notifyError(LocationError(
+                    code = SETTINGS_NOT_SATISFIED,
+                    message = "Provider disabled: $provider"
+                ))
+            }
+
+            override fun onProviderEnabled(provider: String) = Unit
+
+            @Deprecated("Deprecated in Java")
+            override fun onStatusChanged(
+                provider: String?,
+                status: Int,
+                extras: android.os.Bundle?
+            ) = Unit
+        }
+
+        removePlatformListener()
+        platformListener = listener
+        try {
+            locationManager.requestLocationUpdates(
+                provider,
+                options.interval.toLong(),
+                options.distanceFilter.toFloat(),
+                listener,
+                Looper.getMainLooper()
+            )
+        } catch (error: SecurityException) {
+            notifyError(LocationError(
+                code = PERMISSION_DENIED,
+                message = "Permission denied: ${error.message}"
+            ))
+        }
+    }
+
+    private fun startFused(activeGeneration: Long) {
+        if (!isActive(activeGeneration)) return
+        val options = mergeOptions()
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                if (!isActive(activeGeneration)) return
+                val location = result.lastLocation ?: return
+                deliver(locationToPosition(location, LocationProviderUsed.FUSED))
+            }
+        }
+
+        removeFusedCallback()
+        fusedCallback = callback
+
+        fun handleFailure(error: LocationError? = null) {
+            if (!isActive(activeGeneration)) return
+            removeFusedCallback()
+            runAndroidWatchPositionFallbackAfterFusedFailure(
+                locationProvider = configuredProvider(),
+                runPlatformFallback = { startPlatform(activeGeneration) },
+                failWithoutFallback = {
+                    if (error != null) notifyError(error) else notifyProviderUnavailable()
+                }
+            )
+        }
+
+        fusedLocationProvider.requestWatchUpdates(
+            options = options,
+            callback = callback,
+            onInactiveStart = {
+                if (!isActive(activeGeneration)) {
+                    runCatching { fusedLocationClient.removeLocationUpdates(callback) }
+                }
+            },
+            onFailure = { error -> handleFailure(error) }
+        )
+    }
+
+    private fun mergeOptions(): ParsedOptions {
+        var androidAccuracy: AndroidAccuracyResolution? = null
+        var interval = Double.MAX_VALUE
+        var fastestInterval = Double.MAX_VALUE
+        var distanceFilter = Double.MAX_VALUE
+        var granularity = AndroidGranularity.PERMISSION
+        var waitForAccurateLocation = false
+        var maxUpdateAge: Double? = null
+        var maxUpdateDelay = Double.MAX_VALUE
+
+        for (subscription in subscriptions.values) {
+            androidAccuracy = mostDemandingAndroidAccuracy(
+                androidAccuracy,
+                subscription.options.androidAccuracy
+            )
+            interval = minOf(interval, subscription.options.interval)
+            fastestInterval = minOf(fastestInterval, subscription.options.fastestInterval)
+            distanceFilter = minOf(distanceFilter, subscription.options.distanceFilter)
+            granularity = mergeGranularity(granularity, subscription.options.granularity)
+            waitForAccurateLocation = waitForAccurateLocation ||
+                subscription.options.waitForAccurateLocation
+            maxUpdateAge = mergeNullableMinimum(maxUpdateAge, subscription.options.maxUpdateAge)
+            maxUpdateDelay = minOf(maxUpdateDelay, subscription.options.maxUpdateDelay)
+        }
+
+        return ParsedOptions(
+            timeout = Double.POSITIVE_INFINITY,
+            maximumAge = 0.0,
+            androidAccuracy = androidAccuracy ?:
+                resolveAndroidAccuracy(null, enableHighAccuracy = false),
+            interval = interval,
+            fastestInterval = fastestInterval,
+            distanceFilter = distanceFilter,
+            granularity = granularity,
+            waitForAccurateLocation = waitForAccurateLocation,
+            maxUpdateAge = maxUpdateAge,
+            maxUpdateDelay = if (maxUpdateDelay == Double.MAX_VALUE) 0.0 else maxUpdateDelay,
+            maxUpdates = null
+        )
+    }
+
+    private fun deliver(position: GeolocationResponse) {
+        val finishedTokens = mutableListOf<String>()
+        for ((token, subscription) in subscriptions) {
+            subscription.success(position)
+            subscription.deliveredUpdates += 1
+            val maxUpdates = subscription.options.maxUpdates
+            if (maxUpdates != null && subscription.deliveredUpdates >= maxUpdates) {
+                finishedTokens.add(token)
+            }
+        }
+        finishedTokens.forEach(subscriptions::remove)
+        if (finishedTokens.isNotEmpty()) {
+            if (subscriptions.isEmpty()) stop() else restart()
+        }
+    }
+
+    private fun notifyProviderUnavailable() {
+        for (subscription in subscriptions.values) {
+            subscription.error?.invoke(LocationError(
+                code = SETTINGS_NOT_SATISFIED,
+                message = getNoProviderMessage(subscription.options)
+            ))
+        }
+    }
+
+    private fun notifyError(error: LocationError) {
+        subscriptions.values.forEach { it.error?.invoke(error) }
+    }
+
+    private fun mergeGranularity(
+        current: AndroidGranularity,
+        next: AndroidGranularity
+    ): AndroidGranularity = when {
+        current == AndroidGranularity.COARSE || next == AndroidGranularity.COARSE -> {
+            AndroidGranularity.COARSE
+        }
+        current == AndroidGranularity.FINE || next == AndroidGranularity.FINE -> {
+            AndroidGranularity.FINE
+        }
+        else -> AndroidGranularity.PERMISSION
+    }
+
+    private fun stop() {
+        generation.incrementAndGet()
+        removePlatformListener()
+        removeFusedCallback()
+    }
+
+    private fun removePlatformListener() {
+        platformListener?.let { listener ->
+            runCatching { locationManager.removeUpdates(listener) }
+        }
+        platformListener = null
+    }
+
+    private fun removeFusedCallback() {
+        fusedCallback?.let { callback ->
+            runCatching { fusedLocationClient.removeLocationUpdates(callback) }
+        }
+        fusedCallback = null
+    }
+
+    private fun restart() {
+        stop()
+        start()
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -4,12 +4,8 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
-import android.location.LocationListener
 import android.location.LocationManager as AndroidLocationManager
 import android.os.Build
-import android.os.CancellationSignal
-import android.os.Handler
-import android.os.Looper
 import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import com.facebook.proguard.annotations.DoNotStrip
@@ -18,14 +14,11 @@ import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.location.LocationCallback
-import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.margelo.nitro.NitroModules
 import com.margelo.nitro.core.Promise
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Geolocation implementation for Android.
@@ -67,6 +60,30 @@ class NitroGeolocation(
             locationToPosition = ::locationToPosition
         )
     }
+    private val currentPositionManager by lazy {
+        AndroidCurrentPositionManager(
+            locationManager = locationManager,
+            isCachedLocationValid = ::isCachedLocationValid,
+            effectiveMaximumAge = ::effectiveMaximumAge,
+            createNoProviderError = ::createNoLocationProviderError,
+            createTimeoutError = ::createPositionTimeoutError,
+            locationToPosition = { location -> locationToPosition(location) }
+        )
+    }
+    private val positionWatchManager by lazy {
+        AndroidPositionWatchManager(
+            locationManager = locationManager,
+            fusedLocationClient = fusedLocationClient,
+            fusedLocationProvider = fusedLocationProvider,
+            providerRoute = {
+                currentProviderRoute(isGooglePlayServicesAvailable())
+            },
+            configuredProvider = { configuration?.locationProvider },
+            getValidProvider = ::getValidProvider,
+            getNoProviderMessage = ::getNoLocationProviderMessage,
+            locationToPosition = ::locationToPosition
+        )
+    }
     private val headingManager: AndroidHeadingManager by lazy {
         AndroidHeadingManager(
             context = reactContext,
@@ -86,17 +103,8 @@ class NitroGeolocation(
     private val pendingPermissionResolvers = mutableListOf<(PermissionStatus) -> Unit>()
 
     // getCurrentPosition requests
-    private val pendingPositionRequests = ConcurrentHashMap<String, PositionRequest>()
     private val cancellablePositionRequests =
         ConcurrentHashMap<String, CurrentPositionCancellationState>()
-
-    // Watch subscriptions (token -> callback)
-    private val watchSubscriptions = ConcurrentHashMap<String, WatchSubscription>()
-
-    // Location listener for watch subscriptions
-    private var watchLocationListener: LocationListener? = null
-    private var fusedWatchLocationCallback: LocationCallback? = null
-    private val watchLocationGeneration = AtomicLong(0L)
 
     // MARK: - Configuration
 
@@ -388,7 +396,7 @@ class NitroGeolocation(
         }
 
         // Request fresh location
-        requestFreshLocation(
+        currentPositionManager.requestFreshLocation(
             providers,
             parsedOptions,
             deadlineElapsedRealtime,
@@ -519,23 +527,7 @@ class NitroGeolocation(
             return token
         }
 
-        val subscription = WatchSubscription(
-            token = token,
-            success = success,
-            error = error,
-            options = parsedOptions
-        )
-
-        watchSubscriptions[token] = subscription
-
-        // Start watching if first subscriber
-        if (watchSubscriptions.size == 1) {
-            startWatchingLocation()
-        } else {
-            restartWatchingLocation()
-        }
-
-        return token
+        return positionWatchManager.watch(success, error, parsedOptions)
     }
 
     override fun getHeading(
@@ -571,26 +563,13 @@ class NitroGeolocation(
     }
 
     override fun unwatch(token: String) {
-        val didRemoveLocationSubscription = watchSubscriptions.remove(token) != null
+        positionWatchManager.unwatch(token)
         headingManager.unwatch(token)
         providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.unwatch(token)
-
-        if (!didRemoveLocationSubscription) {
-            return
-        }
-
-        // Stop watching if no more subscribers
-        if (watchSubscriptions.isEmpty()) {
-            stopWatchingLocation()
-        } else {
-            restartWatchingLocation()
-        }
     }
 
     override fun getActiveWatches(): Array<ActiveWatch> {
-        val watches = watchSubscriptions.keys.map {
-            ActiveWatch(token = it, kind = ActiveWatchKind.POSITION)
-        }
+        val watches = positionWatchManager.activeWatches()
         val headings = headingManager.getActiveWatchTokens().map {
             ActiveWatch(token = it, kind = ActiveWatchKind.HEADING)
         }
@@ -598,10 +577,9 @@ class NitroGeolocation(
     }
 
     override fun stopObserving() {
-        watchSubscriptions.clear()
+        positionWatchManager.stopObserving()
         headingManager.stopObserving()
         providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.stopObserving()
-        stopWatchingLocation()
     }
     override fun dispose() {
         runCatching { providerStatusWatcherDelegate.takeIf { it.isInitialized() }?.value?.dispose() }
@@ -823,540 +801,6 @@ class NitroGeolocation(
         }
 
         return bestLocation
-    }
-
-    // MARK: - Helper Functions - Request Fresh Location
-
-    private fun requestFreshLocation(
-        providers: List<String>,
-        options: ParsedOptions,
-        deadlineElapsedRealtime: Long = createRequestDeadlineElapsedRealtime(options.timeout),
-        resolver: (PositionResult) -> Unit,
-        requestId: String? = null,
-        onCancellationReady: ((() -> Unit) -> Unit)? = null
-    ) {
-        val id = requestId ?: UUID.randomUUID().toString()
-        val handler = Handler(Looper.getMainLooper())
-
-        val request = PositionRequest(
-            id = id,
-            resolver = resolver,
-            options = options,
-            handler = handler,
-            providers = providers,
-            deadlineElapsedRealtime = deadlineElapsedRealtime
-        )
-
-        pendingPositionRequests[id] = request
-        onCancellationReady?.invoke { cancelPlatformCurrentPositionRequest(id) }
-        requestFreshLocationForCurrentProvider(id)
-    }
-
-    private fun cancelPlatformCurrentPositionRequest(requestId: String) {
-        val request = pendingPositionRequests.remove(requestId) ?: return
-        request.handler.removeCallbacksAndMessages(null)
-        request.cancellationAction?.invoke()
-        request.cancellationAction = null
-    }
-
-    private fun requestFreshLocationForCurrentProvider(requestId: String) {
-        val request = pendingPositionRequests[requestId] ?: return
-        val provider = request.providers.getOrNull(request.providerIndex)
-        val remainingTimeoutMillis = request.remainingTimeoutMillis()
-
-        if (provider == null) {
-            pendingPositionRequests.remove(requestId)?.resolver(
-                PositionResult.Failure(createNoLocationProviderError(request.options))
-            )
-            return
-        }
-
-        if (remainingTimeoutMillis <= 0L) {
-            pendingPositionRequests.remove(requestId)?.resolver(
-                PositionResult.Failure(createPositionTimeoutError(request.options))
-            )
-            return
-        }
-
-        // Android's getCurrentLocation may resolve a recent historical fix. An effective
-        // maximum age of 0 means callers explicitly asked us to wait for a fresh update.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && effectiveMaximumAge(request.options) > 0.0) {
-            requestCurrentLocationModern(provider, requestId, request.handler, remainingTimeoutMillis)
-        } else {
-            requestCurrentLocationLegacy(provider, requestId, request.handler, remainingTimeoutMillis)
-        }
-    }
-
-    @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
-    private fun requestCurrentLocationModern(
-        provider: String,
-        requestId: String,
-        handler: Handler,
-        timeoutMillis: Long
-    ) {
-        val cancellationSignal = CancellationSignal()
-
-        // Timeout handler
-        val timeoutRunnable = Runnable {
-            handlePositionTimeout(requestId)
-        }
-
-        try {
-            locationManager.getCurrentLocation(
-                provider,
-                cancellationSignal,
-                { runnable -> handler.post(runnable) }
-            ) { location ->
-                handler.removeCallbacks(timeoutRunnable)
-
-                val request = pendingPositionRequests[requestId]
-                if (request != null) {
-                    if (location != null && isCachedLocationValid(location, request.options)) {
-                        pendingPositionRequests.remove(requestId)
-                        val position = locationToPosition(location)
-                        request.resolver(PositionResult.Success(position))
-                    } else if (location != null) {
-                        retryCurrentLocationLegacyAfterStaleModern(
-                            provider,
-                            requestId,
-                            handler,
-                            request
-                        )
-                    } else {
-                        handleProviderFailure(requestId, createLocationError(
-                            POSITION_UNAVAILABLE,
-                            "Unable to get fresh location"
-                        ))
-                    }
-                }
-            }
-
-            handler.postDelayed(timeoutRunnable, timeoutMillis)
-
-            val cleanup = {
-                handler.removeCallbacksAndMessages(null)
-                cancellationSignal.cancel()
-            }
-            val request = pendingPositionRequests[requestId]
-            if (request != null) {
-                request.cancellationAction = cleanup
-                if (pendingPositionRequests[requestId] !== request) cleanup()
-            } else {
-                cleanup()
-            }
-
-        } catch (e: SecurityException) {
-            handler.removeCallbacks(timeoutRunnable)
-            handleProviderFailure(requestId, createLocationError(
-                PERMISSION_DENIED,
-                "Security exception: ${e.message}"
-            ))
-        }
-    }
-
-    private fun retryCurrentLocationLegacyAfterStaleModern(
-        provider: String,
-        requestId: String,
-        handler: Handler,
-        request: PositionRequest
-    ) {
-        request.cancellationAction?.invoke()
-        request.cancellationAction = null
-
-        val remainingTimeoutMillis = request.remainingTimeoutMillis()
-        if (remainingTimeoutMillis <= 0L) {
-            handlePositionTimeout(requestId)
-            return
-        }
-
-        requestCurrentLocationLegacy(provider, requestId, handler, remainingTimeoutMillis)
-    }
-
-    private fun requestCurrentLocationLegacy(
-        provider: String,
-        requestId: String,
-        handler: Handler,
-        timeoutMillis: Long
-    ) {
-        var isResolved = false
-        var oldLocation: Location? = null
-
-        val listener = object : LocationListener {
-            override fun onLocationChanged(location: Location) {
-                synchronized(this) {
-                    if (!isResolved) {
-                        val bestLocation = selectBestLocation(location, oldLocation)
-                        if (bestLocation == location) {
-                            isResolved = true
-                            handler.removeCallbacksAndMessages(null)
-
-                            try {
-                                locationManager.removeUpdates(this)
-                            } catch (e: Exception) {
-                                // Ignore
-                            }
-
-                            val request = pendingPositionRequests.remove(requestId)
-                            if (request != null) {
-                                val position = locationToPosition(location)
-                                request.resolver(PositionResult.Success(position))
-                            }
-                        }
-                        oldLocation = location
-                    }
-                }
-            }
-
-            override fun onProviderDisabled(provider: String) {}
-            override fun onProviderEnabled(provider: String) {}
-            @Deprecated("Deprecated in Java")
-            override fun onStatusChanged(provider: String?, status: Int, extras: android.os.Bundle?) {}
-        }
-
-        // Timeout handler
-        val timeoutRunnable = Runnable {
-            synchronized(listener) {
-                if (!isResolved) {
-                    isResolved = true
-                    try {
-                        locationManager.removeUpdates(listener)
-                    } catch (e: Exception) {
-                        // Ignore
-                    }
-                    handlePositionTimeout(requestId)
-                }
-            }
-        }
-
-        try {
-            locationManager.requestLocationUpdates(
-                provider,
-                100, // min time (ms)
-                1f,  // min distance (m)
-                listener,
-                Looper.getMainLooper()
-            )
-
-            handler.postDelayed(timeoutRunnable, timeoutMillis)
-
-            val cleanup = {
-                synchronized(listener) {
-                    isResolved = true
-                    handler.removeCallbacksAndMessages(null)
-                    try {
-                        locationManager.removeUpdates(listener)
-                    } catch (_: Exception) {
-                        // Ignore cleanup races.
-                    }
-                }
-            }
-            val request = pendingPositionRequests[requestId]
-            if (request != null) {
-                request.cancellationAction = cleanup
-                if (pendingPositionRequests[requestId] !== request) cleanup()
-            } else {
-                cleanup()
-            }
-
-        } catch (e: SecurityException) {
-            handleProviderFailure(requestId, createLocationError(
-                PERMISSION_DENIED,
-                "Security exception: ${e.message}"
-            ))
-        }
-    }
-
-    private fun handleProviderFailure(requestId: String, error: LocationError) {
-        val request = pendingPositionRequests[requestId] ?: return
-
-        request.cancellationAction?.invoke()
-        request.cancellationAction = null
-        request.providerIndex += 1
-
-        if (request.providerIndex < request.providers.size) {
-            if (request.remainingTimeoutMillis() <= 0L) {
-                pendingPositionRequests.remove(requestId)?.resolver(
-                    PositionResult.Failure(createPositionTimeoutError(request.options))
-                )
-                return
-            }
-
-            requestFreshLocationForCurrentProvider(requestId)
-            return
-        }
-
-        pendingPositionRequests.remove(requestId)?.resolver(PositionResult.Failure(error))
-    }
-
-    private fun handlePositionTimeout(requestId: String) {
-        val request = pendingPositionRequests.remove(requestId) ?: return
-        request.handler.removeCallbacksAndMessages(null)
-        request.cancellationAction?.invoke()
-        request.cancellationAction = null
-        request.resolver(PositionResult.Failure(createPositionTimeoutError(request.options)))
-    }
-
-    // MARK: - Helper Functions - Watch Position
-
-    private fun startWatchingLocation() {
-        val generation = watchLocationGeneration.get()
-
-        if (currentProviderRoute(isGooglePlayServicesAvailable()) == AndroidProviderRoute.FUSED) {
-            startWatchingFusedLocation(generation)
-            return
-        }
-
-        startWatchingPlatformLocation(generation)
-    }
-
-    private fun isActiveWatchGeneration(generation: Long): Boolean {
-        return watchSubscriptions.isNotEmpty() && watchLocationGeneration.get() == generation
-    }
-
-    private fun startWatchingPlatformLocation(generation: Long) {
-        if (!isActiveWatchGeneration(generation)) return
-
-        val mergedOptions = mergeWatchOptions()
-        val provider = getValidProvider(mergedOptions)
-        if (provider == null) {
-            notifyWatchProviderUnavailable()
-            return
-        }
-
-        val listener = object : LocationListener {
-            override fun onLocationChanged(location: Location) {
-                if (!isActiveWatchGeneration(generation)) return
-
-                val position = locationToPosition(location)
-                deliverWatchPosition(position)
-            }
-
-            override fun onProviderDisabled(provider: String) {
-                if (!isActiveWatchGeneration(generation)) return
-
-                val error = LocationError(
-                    code = SETTINGS_NOT_SATISFIED,
-                    message = "Provider disabled: $provider"
-                )
-
-                for ((_, subscription) in watchSubscriptions) {
-                    subscription.error?.invoke(error)
-                }
-            }
-
-            override fun onProviderEnabled(provider: String) {}
-            @Deprecated("Deprecated in Java")
-            override fun onStatusChanged(provider: String?, status: Int, extras: android.os.Bundle?) {}
-        }
-
-        removePlatformWatchLocationListener()
-        watchLocationListener = listener
-
-        try {
-            locationManager.requestLocationUpdates(
-                provider,
-                mergedOptions.interval.toLong(),
-                mergedOptions.distanceFilter.toFloat(),
-                listener,
-                Looper.getMainLooper()
-            )
-        } catch (e: SecurityException) {
-            val error = LocationError(
-                code = PERMISSION_DENIED,
-                message = "Permission denied: ${e.message}"
-            )
-
-            for ((_, subscription) in watchSubscriptions) {
-                subscription.error?.invoke(error)
-            }
-        }
-    }
-
-    private fun startWatchingFusedLocation(generation: Long) {
-        if (!isActiveWatchGeneration(generation)) return
-
-        val mergedOptions = mergeWatchOptions()
-        val callback = object : LocationCallback() {
-            override fun onLocationResult(result: LocationResult) {
-                if (!isActiveWatchGeneration(generation)) return
-
-                val location = result.lastLocation ?: return
-                deliverWatchPosition(locationToPosition(location, LocationProviderUsed.FUSED))
-            }
-        }
-
-        removeFusedWatchLocationCallback()
-        fusedWatchLocationCallback = callback
-
-        fun handleFusedRequestFailure(fusedError: LocationError? = null) {
-            if (!isActiveWatchGeneration(generation)) return
-
-            removeFusedWatchLocationCallback()
-            runAndroidWatchPositionFallbackAfterFusedFailure(
-                locationProvider = configuration?.locationProvider,
-                runPlatformFallback = { startWatchingPlatformLocation(generation) },
-                failWithoutFallback = {
-                    if (fusedError != null) {
-                        notifyWatchError(fusedError)
-                    } else {
-                        notifyWatchProviderUnavailable()
-                    }
-                }
-            )
-        }
-
-        fusedLocationProvider.requestWatchUpdates(
-            options = mergedOptions,
-            callback = callback,
-            onInactiveStart = {
-                if (!isActiveWatchGeneration(generation)) {
-                    try {
-                        fusedLocationClient.removeLocationUpdates(callback)
-                    } catch (e: Exception) {
-                        // Ignore
-                    }
-                }
-            },
-            onFailure = { fusedError -> handleFusedRequestFailure(fusedError) }
-        )
-    }
-
-    private fun mergeWatchOptions(): ParsedOptions {
-        var androidAccuracy: AndroidAccuracyResolution? = null
-        var smallestInterval = Double.MAX_VALUE
-        var smallestFastestInterval = Double.MAX_VALUE
-        var smallestDistanceFilter = Double.MAX_VALUE
-        var granularity = AndroidGranularity.PERMISSION
-        var waitForAccurateLocation = false
-        var maxUpdateAge: Double? = null
-        var smallestMaxUpdateDelay = Double.MAX_VALUE
-
-        for ((_, subscription) in watchSubscriptions) {
-            androidAccuracy = mostDemandingAndroidAccuracy(
-                androidAccuracy,
-                subscription.options.androidAccuracy
-            )
-            smallestInterval = minOf(smallestInterval, subscription.options.interval)
-            smallestFastestInterval = minOf(
-                smallestFastestInterval,
-                subscription.options.fastestInterval
-            )
-            smallestDistanceFilter = minOf(
-                smallestDistanceFilter,
-                subscription.options.distanceFilter
-            )
-            granularity = mergeWatchGranularity(granularity, subscription.options.granularity)
-            waitForAccurateLocation = waitForAccurateLocation ||
-                subscription.options.waitForAccurateLocation
-            maxUpdateAge = mergeNullableMinimum(maxUpdateAge, subscription.options.maxUpdateAge)
-            smallestMaxUpdateDelay = minOf(
-                smallestMaxUpdateDelay,
-                subscription.options.maxUpdateDelay
-            )
-        }
-
-        return ParsedOptions(
-            timeout = Double.POSITIVE_INFINITY,
-            maximumAge = 0.0,
-            androidAccuracy = androidAccuracy ?: resolveAndroidAccuracy(null, enableHighAccuracy = false),
-            interval = smallestInterval,
-            fastestInterval = smallestFastestInterval,
-            distanceFilter = smallestDistanceFilter,
-            granularity = granularity,
-            waitForAccurateLocation = waitForAccurateLocation,
-            maxUpdateAge = maxUpdateAge,
-            maxUpdateDelay = if (smallestMaxUpdateDelay == Double.MAX_VALUE) 0.0 else smallestMaxUpdateDelay,
-            maxUpdates = null
-        )
-    }
-
-    private fun deliverWatchPosition(position: GeolocationResponse) {
-        val tokensToRemove = mutableListOf<String>()
-
-        for ((token, subscription) in watchSubscriptions) {
-            subscription.success(position)
-            subscription.deliveredUpdates += 1
-
-            val maxUpdates = subscription.options.maxUpdates
-            if (maxUpdates != null && subscription.deliveredUpdates >= maxUpdates) {
-                tokensToRemove.add(token)
-            }
-        }
-
-        for (token in tokensToRemove) {
-            watchSubscriptions.remove(token)
-        }
-
-        if (tokensToRemove.isNotEmpty()) {
-            if (watchSubscriptions.isEmpty()) {
-                stopWatchingLocation()
-            } else {
-                restartWatchingLocation()
-            }
-        }
-    }
-
-    private fun notifyWatchProviderUnavailable() {
-        for ((_, subscription) in watchSubscriptions) {
-            subscription.error?.invoke(LocationError(
-                code = SETTINGS_NOT_SATISFIED,
-                message = getNoLocationProviderMessage(subscription.options)
-            ))
-        }
-    }
-
-    private fun notifyWatchError(error: LocationError) {
-        for ((_, subscription) in watchSubscriptions) {
-            subscription.error?.invoke(error)
-        }
-    }
-
-    private fun mergeWatchGranularity(
-        current: AndroidGranularity,
-        next: AndroidGranularity
-    ): AndroidGranularity {
-        return when {
-            current == AndroidGranularity.COARSE || next == AndroidGranularity.COARSE -> {
-                AndroidGranularity.COARSE
-            }
-            current == AndroidGranularity.FINE || next == AndroidGranularity.FINE -> {
-                AndroidGranularity.FINE
-            }
-            else -> AndroidGranularity.PERMISSION
-        }
-    }
-
-    private fun stopWatchingLocation() {
-        watchLocationGeneration.incrementAndGet()
-        removePlatformWatchLocationListener()
-        removeFusedWatchLocationCallback()
-    }
-
-    private fun removePlatformWatchLocationListener() {
-        watchLocationListener?.let { listener ->
-            try {
-                locationManager.removeUpdates(listener)
-            } catch (e: Exception) {
-                // Ignore
-            }
-        }
-        watchLocationListener = null
-    }
-
-    private fun removeFusedWatchLocationCallback() {
-        fusedWatchLocationCallback?.let { callback ->
-            try {
-                fusedLocationClient.removeLocationUpdates(callback)
-            } catch (e: Exception) {
-                // Ignore
-            }
-        }
-        fusedWatchLocationCallback = null
-    }
-
-    private fun restartWatchingLocation() {
-        stopWatchingLocation()
-        startWatchingLocation()
     }
 
     // MARK: - Helper Functions - Conversion

--- a/packages/react-native-nitro-geolocation/ios/IOSGeocoder.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeocoder.swift
@@ -1,0 +1,131 @@
+import CoreLocation
+import Foundation
+
+final class IOSGeocoder {
+    private var activeGeocoders: [UUID: CLGeocoder] = [:]
+
+    func geocode(
+        address: String,
+        success: @escaping ([GeocodedLocation]) -> Void,
+        error: ((LocationError) -> Void)?
+    ) {
+        let query = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            error?(createLocationError(
+                code: INTERNAL_ERROR,
+                message: "address must not be empty."
+            ))
+            return
+        }
+
+        DispatchQueue.main.async {
+            let id = UUID()
+            let geocoder = CLGeocoder()
+            self.activeGeocoders[id] = geocoder
+            geocoder.geocodeAddressString(query) { [weak self] placemarks, geocodeError in
+                guard let self else { return }
+                DispatchQueue.main.async {
+                    self.activeGeocoders.removeValue(forKey: id)
+                    if let geocodeError {
+                        if self.isNoResult(geocodeError) {
+                            success([])
+                        } else {
+                            error?(self.createError(
+                                geocodeError,
+                                messagePrefix: "Unable to geocode address"
+                            ))
+                        }
+                        return
+                    }
+                    success((placemarks ?? []).compactMap { $0.toGeocodedLocation() })
+                }
+            }
+        }
+    }
+
+    func reverseGeocode(
+        coords: GeocodingCoordinates,
+        success: @escaping ([ReverseGeocodedAddress]) -> Void,
+        error: ((LocationError) -> Void)?
+    ) {
+        if let validationError = validate(coords) {
+            error?(validationError)
+            return
+        }
+
+        DispatchQueue.main.async {
+            let id = UUID()
+            let geocoder = CLGeocoder()
+            self.activeGeocoders[id] = geocoder
+            let location = CLLocation(
+                latitude: coords.latitude,
+                longitude: coords.longitude
+            )
+            geocoder.reverseGeocodeLocation(location) { [weak self] placemarks, geocodeError in
+                guard let self else { return }
+                DispatchQueue.main.async {
+                    self.activeGeocoders.removeValue(forKey: id)
+                    if let geocodeError {
+                        if self.isNoResult(geocodeError) {
+                            success([])
+                        } else {
+                            error?(self.createError(
+                                geocodeError,
+                                messagePrefix: "Unable to reverse geocode coordinates"
+                            ))
+                        }
+                        return
+                    }
+                    success((placemarks ?? []).map { $0.toReverseGeocodedAddress() })
+                }
+            }
+        }
+    }
+
+    private func validate(_ coords: GeocodingCoordinates) -> LocationError? {
+        if !coords.latitude.isFinite || coords.latitude < -90 || coords.latitude > 90 {
+            return createLocationError(
+                code: INTERNAL_ERROR,
+                message: "latitude must be a finite number between -90 and 90."
+            )
+        }
+        if !coords.longitude.isFinite || coords.longitude < -180 || coords.longitude > 180 {
+            return createLocationError(
+                code: INTERNAL_ERROR,
+                message: "longitude must be a finite number between -180 and 180."
+            )
+        }
+        return nil
+    }
+
+    private func isNoResult(_ error: Error) -> Bool {
+        guard let clError = error as? CLError else { return false }
+        return clError.code == .geocodeFoundNoResult
+    }
+
+    private func createError(_ error: Error, messagePrefix: String) -> LocationError {
+        guard let clError = error as? CLError else {
+            return createLocationError(
+                code: POSITION_UNAVAILABLE,
+                message: "\(messagePrefix): \(error.localizedDescription)"
+            )
+        }
+        switch clError.code {
+        case .denied:
+            return createLocationError(
+                code: PERMISSION_DENIED,
+                message: "\(messagePrefix): geocoder access denied."
+            )
+        case .network:
+            return createLocationError(
+                code: POSITION_UNAVAILABLE,
+                message: "\(messagePrefix): network unavailable."
+            )
+        default:
+            return createLocationError(
+                code: POSITION_UNAVAILABLE,
+                message: "\(messagePrefix): \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationConversions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationConversions.swift
@@ -1,6 +1,62 @@
 import CoreLocation
 import Foundation
 
+func getCurrentAuthorizationStatus(from manager: CLLocationManager) -> CLAuthorizationStatus {
+    if #available(iOS 14.0, *) {
+        return manager.authorizationStatus
+    }
+    return CLLocationManager.authorizationStatus()
+}
+
+func mapCLAuthorizationStatus(_ status: CLAuthorizationStatus) -> PermissionStatus {
+    switch status {
+    case .authorizedAlways, .authorizedWhenInUse:
+        return .granted
+    case .denied:
+        return .denied
+    case .restricted:
+        return .restricted
+    case .notDetermined:
+        return .undetermined
+    @unknown default:
+        return .undetermined
+    }
+}
+
+func currentAccuracyAuthorization(from locationManager: CLLocationManager?) -> AccuracyAuthorization {
+    guard #available(iOS 14.0, *) else { return .unknown }
+    let manager = locationManager ?? CLLocationManager()
+    switch manager.accuracyAuthorization {
+    case .fullAccuracy:
+        return .full
+    case .reducedAccuracy:
+        return .reduced
+    @unknown default:
+        return .unknown
+    }
+}
+
+func currentAccuracyAuthorizationOnMain(
+    from locationManager: CLLocationManager?
+) -> AccuracyAuthorization {
+    if Thread.isMainThread {
+        return currentAccuracyAuthorization(from: locationManager)
+    }
+    return DispatchQueue.main.sync {
+        currentAccuracyAuthorization(from: locationManager)
+    }
+}
+
+func determineAuthorizationLevelFromInfoPlist() -> AuthorizationLevel {
+    let hasAlwaysKey = Bundle.main.object(
+        forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription"
+    ) != nil
+    let hasWhenInUseKey = Bundle.main.object(
+        forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription"
+    ) != nil
+    return hasAlwaysKey && hasWhenInUseKey ? .always : .wheninuse
+}
+
 func headingToResponse(_ clHeading: CLHeading) -> Heading {
     let trueHeading = clHeading.trueHeading >= 0
         ? clHeading.trueHeading

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -33,7 +33,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     private var pendingHeadingRequests: [UUID: HeadingRequest] = [:]
     @ActiveWatchRegistry(kind: .heading)
     private var headingSubscriptions: [String: HeadingSubscription] = [:]
-    private var activeGeocoders: [UUID: CLGeocoder] = [:]
+    private let geocoder = IOSGeocoder()
 
     // MARK: - Configuration
 
@@ -48,7 +48,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     func checkPermission() throws -> Promise<PermissionStatus> {
         return Promise.async {
             let status = CLLocationManager.authorizationStatus()
-            return self.mapCLAuthorizationStatus(status)
+            return mapCLAuthorizationStatus(status)
         }
     }
 
@@ -61,7 +61,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
             let currentStatus = CLLocationManager.authorizationStatus()
             if currentStatus != .notDetermined {
-                success(self.mapCLAuthorizationStatus(currentStatus))
+                success(mapCLAuthorizationStatus(currentStatus))
                 return
             }
 
@@ -131,7 +131,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     func getAccuracyAuthorization() throws -> Promise<AccuracyAuthorization> {
         return Promise.async {
-            return self.getCurrentAccuracyAuthorizationOnMain()
+            return currentAccuracyAuthorizationOnMain(from: self.locationManager)
         }
     }
 
@@ -173,7 +173,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
                         return
                     }
 
-                    success(self.getCurrentAccuracyAuthorization())
+                    success(currentAccuracyAuthorization(from: self.locationManager))
                 }
             }
         }
@@ -285,46 +285,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         success: @escaping ([GeocodedLocation]) -> Void,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        let query = address.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else {
-            error?(createLocationError(
-                code: INTERNAL_ERROR,
-                message: "address must not be empty."
-            ))
-            return
-        }
-
-        DispatchQueue.main.async {
-            let id = UUID()
-            let geocoder = CLGeocoder()
-            self.activeGeocoders[id] = geocoder
-
-            geocoder.geocodeAddressString(query) { [weak self] placemarks, geocodeError in
-                guard let self else { return }
-
-                DispatchQueue.main.async {
-                    self.activeGeocoders.removeValue(forKey: id)
-
-                    if let geocodeError {
-                        if self.isNoGeocoderResult(geocodeError) {
-                            success([])
-                            return
-                        }
-
-                        error?(self.createGeocoderError(
-                            geocodeError,
-                            messagePrefix: "Unable to geocode address"
-                        ))
-                        return
-                    }
-
-                    let locations = (placemarks ?? []).compactMap {
-                        $0.toGeocodedLocation()
-                    }
-                    success(locations)
-                }
-            }
-        }
+        geocoder.geocode(address: address, success: success, error: error)
     }
 
     func reverseGeocode(
@@ -332,47 +293,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         success: @escaping ([ReverseGeocodedAddress]) -> Void,
         error: ((LocationError) -> Void)?
     ) throws -> Void {
-        if let validationError = validateGeocodingCoordinates(coords) {
-            error?(validationError)
-            return
-        }
-
-        DispatchQueue.main.async {
-            let id = UUID()
-            let geocoder = CLGeocoder()
-            self.activeGeocoders[id] = geocoder
-
-            let location = CLLocation(
-                latitude: coords.latitude,
-                longitude: coords.longitude
-            )
-
-            geocoder.reverseGeocodeLocation(location) { [weak self] placemarks, geocodeError in
-                guard let self else { return }
-
-                DispatchQueue.main.async {
-                    self.activeGeocoders.removeValue(forKey: id)
-
-                    if let geocodeError {
-                        if self.isNoGeocoderResult(geocodeError) {
-                            success([])
-                            return
-                        }
-
-                        error?(self.createGeocoderError(
-                            geocodeError,
-                            messagePrefix: "Unable to reverse geocode coordinates"
-                        ))
-                        return
-                    }
-
-                    let addresses = (placemarks ?? []).map {
-                        $0.toReverseGeocodedAddress()
-                    }
-                    success(addresses)
-                }
-            }
-        }
+        geocoder.reverseGeocode(coords: coords, success: success, error: error)
     }
 
     // MARK: - Heading
@@ -943,19 +864,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         return determineAuthorizationLevelFromInfoPlist()
     }
 
-    private func determineAuthorizationLevelFromInfoPlist() -> AuthorizationLevel {
-        let hasAlwaysKey = Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription") != nil
-        let hasWhenInUseKey = Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil
-
-        if hasAlwaysKey && hasWhenInUseKey {
-            return .always
-        } else if hasWhenInUseKey {
-            return .wheninuse
-        }
-
-        return .wheninuse  // Default
-    }
-
     private func requestSystemPermission(for type: AuthorizationLevel) {
         switch type {
         case .always:
@@ -979,110 +887,9 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         locationManager?.allowsBackgroundLocationUpdates = true
     }
 
-    private func getCurrentAuthorizationStatus(from manager: CLLocationManager) -> CLAuthorizationStatus {
-        if #available(iOS 14.0, *) {
-            return manager.authorizationStatus
-        } else {
-            return CLLocationManager.authorizationStatus()
-        }
-    }
-
-    private func mapCLAuthorizationStatus(_ status: CLAuthorizationStatus) -> PermissionStatus {
-        switch status {
-        case .authorizedAlways, .authorizedWhenInUse:
-            return .granted
-        case .denied:
-            return .denied
-        case .restricted:
-            return .restricted
-        case .notDetermined:
-            return .undetermined
-        @unknown default:
-            return .undetermined
-        }
-    }
-
-    private func getCurrentAccuracyAuthorization() -> AccuracyAuthorization {
-        guard #available(iOS 14.0, *) else {
-            return .unknown
-        }
-
-        let manager = locationManager ?? CLLocationManager()
-        switch manager.accuracyAuthorization {
-        case .fullAccuracy:
-            return .full
-        case .reducedAccuracy:
-            return .reduced
-        @unknown default:
-            return .unknown
-        }
-    }
-
-    private func getCurrentAccuracyAuthorizationOnMain() -> AccuracyAuthorization {
-        if Thread.isMainThread {
-            return getCurrentAccuracyAuthorization()
-        }
-
-        return DispatchQueue.main.sync {
-            getCurrentAccuracyAuthorization()
-        }
-    }
-
     private func locationToPosition(_ location: CLLocation) -> GeolocationResponse {
         return location.toGeolocationResponse()
     }
 
-    private func validateGeocodingCoordinates(_ coords: GeocodingCoordinates) -> LocationError? {
-        if !coords.latitude.isFinite || coords.latitude < -90 || coords.latitude > 90 {
-            return createLocationError(
-                code: INTERNAL_ERROR,
-                message: "latitude must be a finite number between -90 and 90."
-            )
-        }
-
-        if !coords.longitude.isFinite || coords.longitude < -180 || coords.longitude > 180 {
-            return createLocationError(
-                code: INTERNAL_ERROR,
-                message: "longitude must be a finite number between -180 and 180."
-            )
-        }
-
-        return nil
-    }
-
-    private func isNoGeocoderResult(_ error: Error) -> Bool {
-        guard let clError = error as? CLError else {
-            return false
-        }
-
-        return clError.code == .geocodeFoundNoResult
-    }
-
-    private func createGeocoderError(_ error: Error, messagePrefix: String) -> LocationError {
-        if let clError = error as? CLError {
-            switch clError.code {
-            case .denied:
-                return createLocationError(
-                    code: PERMISSION_DENIED,
-                    message: "\(messagePrefix): geocoder access denied."
-                )
-            case .network:
-                return createLocationError(
-                    code: POSITION_UNAVAILABLE,
-                    message: "\(messagePrefix): network unavailable."
-                )
-            default:
-                return createLocationError(
-                    code: POSITION_UNAVAILABLE,
-                    message: "\(messagePrefix): \(error.localizedDescription)"
-                )
-            }
-        }
-
-        return createLocationError(
-            code: POSITION_UNAVAILABLE,
-            message: "\(messagePrefix): \(error.localizedDescription)"
-        )
-    }
 
 }

--- a/scripts/check-source-lines.mjs
+++ b/scripts/check-source-lines.mjs
@@ -91,23 +91,6 @@ const budgets = [
   }
 ];
 
-const exceptions = new Map([
-  [
-    "packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt",
-    {
-      limit: 1453,
-      reason: "existing native adapter exception"
-    }
-  ],
-  [
-    "packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift",
-    {
-      limit: 1096,
-      reason: "existing native adapter exception"
-    }
-  ]
-]);
-
 const gitFiles = spawnSync("git", ["ls-files"], {
   cwd: root,
   encoding: "utf8"
@@ -140,9 +123,8 @@ for (const file of trackedFiles) {
 if (failures.length > 0) {
   console.error("Source line-count guard failed:");
   for (const { file, lines, budget } of failures) {
-    const suffix = budget.reason ? ` (${budget.reason})` : "";
     console.error(
-      `- ${file}: ${lines} lines > ${budget.limit} ${budget.name} budget${suffix}`
+      `- ${file}: ${lines} lines > ${budget.limit} ${budget.name} budget`
     );
   }
   process.exit(1);
@@ -162,15 +144,6 @@ function isExcluded(file) {
 }
 
 function budgetFor(file) {
-  const exception = exceptions.get(file);
-  if (exception) {
-    return {
-      name: "exception",
-      limit: exception.limit,
-      reason: exception.reason
-    };
-  }
-
   return budgets.find((budget) => budget.matches(file));
 }
 


### PR DESCRIPTION
## What changed
- removes the Android and iOS file-specific source-line exemptions
- applies the shared 900-line native-adapter budget uniformly
- extracts Android current-position and watch orchestration into focused managers
- extracts iOS geocoding and permission/accuracy conversions into focused helpers
- preserves the existing public API and runtime behavior
- adds an empty Changeset because this internal behavior-preserving refactor must not bump the package

## RED -> GREEN
- RED: removing the exemptions reported Android NitroGeolocation at 1376 lines and iOS NitroGeolocation at 1088 lines against the shared 900-line budget
- GREEN: all 158 tracked guarded files pass with no per-file exception path
- final native sizes: Android facade 820, current manager 279, watch manager 264; iOS facade 895, geocoder 131, conversions 187

## Validation
- `yarn test:unit` (16 files, 151 tests)
- `yarn format:check && yarn lint`
- `yarn build:all`
- `yarn deadcode && yarn deadcode:prod`
- `yarn pack:check && yarn source-lines:check`
- Android Release assemble and install
- iOS Release simulator build and install
- Android affected Maestro: current position, cancellable current position, watch position, last-known position, request-options watch contracts, watch observability
- iOS affected Maestro: permission details, current position, watch position, accuracy presets, accuracy authorization, geocoding, last-known position
- adversarial review: two exact-head reviews report no remaining P1/P2 findings