### PR TITLE
feat: add consumer E2E contract kit

### DIFF
--- a/.changeset/brave-dingos-test.md
+++ b/.changeset/brave-dingos-test.md
@@ -1,0 +1,6 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add a copyable consumer E2E contract page and Maestro happy-path and
+permission-denied flows, with guidance for release-build CI verification.

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -7,6 +7,7 @@
   "community-migration",
   "service-migration",
   "gps-offline-recipe",
+  "consumer-e2e-contract-kit",
   "expo-development-build",
   "react-native-directory",
   "modern-api",

--- a/docs/docs/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/guide/consumer-e2e-contract-kit.md
@@ -4,13 +4,20 @@ This kit gives a consuming React Native app one small product page and two
 black-box contracts:
 
 - a granted user receives and renders a real native location;
-- a denied user does not start a location request and receives an actionable
-  permission remedy.
+- a denied user does not call the public position API and receives an
+  actionable permission remedy.
 
 It deliberately uses the public API directly. There is no test-only provider,
 hidden retry, fixture branch, or library policy change.
 
 ## Copy the page
+
+Complete the foreground location setup in [Quick Start](/guide/quick-start)
+before copying the kit. Android needs `ACCESS_FINE_LOCATION` and
+`ACCESS_COARSE_LOCATION`; iOS needs `NSLocationWhenInUseUsageDescription`.
+Include `authorizationLevel: 'whenInUse'` in the app's single, complete startup
+`setConfiguration()` call. The copied screen deliberately does not mutate that
+app-wide policy.
 
 Copy
 [`ConsumerLocationContractScreen.tsx`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx)
@@ -62,18 +69,19 @@ Keep these test IDs stable in the copied page:
 | Test ID | Contract |
 | --- | --- |
 | `consumer-location-run` | Starts the same user action exercised in production |
-| `consumer-location-status` | Exposes `passed`, `permission-required`, or `failed` |
-| `consumer-location-permission` | Exposes the permission observed before a request |
-| `consumer-location-native-requests` | Proves denied permission did not reach the native request |
-| `consumer-location-position` | Exists only after a valid position is rendered |
+| `consumer-location-status-<state>` | Exposes `passed`, `permission-required`, or `failed` without localized text |
+| `consumer-location-permission-<status>` | Exposes the permission observed before a request |
+| `consumer-location-api-attempts-<count>` | Counts this page's calls to the public position API |
+| `consumer-location-position-<latitude-e6>-<longitude-e6>` | Encodes the rendered position without presentation text |
 | `consumer-location-request-permission` | Gives a denied user an explicit next action |
 | `consumer-location-open-settings` | Leaves the app for settings when another prompt cannot recover access |
 
 The page reads `getPermissionDetails()` before `getCurrentPosition()`. It does
-not prompt on mount. Its foreground request explicitly selects `whenInUse`, and
-its remediation follows `settingsGuidance`: request again when possible, open
-app settings when required, or explain a managed restriction. Adapt the
-presentation to the product, but preserve those behavioral boundaries.
+not prompt on mount or change global configuration. Its remediation follows
+`settingsGuidance`: request again when possible, open app settings when
+required, or explain a managed restriction. Adapt and localize the presentation,
+but preserve the machine-readable IDs and those behavioral boundaries. The API
+attempt ID is page-owned observability, not native telemetry.
 
 ## Copy the contracts
 
@@ -83,22 +91,22 @@ Copy the two Maestro flows:
 - [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
 
 Change `appId` and the `nitrogeolocation://app` deep-link prefix to the consumer
-app's registered values. Keep the location injection, native-request count, and
-coordinate assertion in the happy flow: asserting only `Status: passed` can
+app's registered values. Keep the location injection, API-attempt count, and
+coordinate ID assertion in the happy flow: asserting only a passed status can
 hide a page that never rendered the native result. Keep the denied flow separate
-so CI proves the native request count stays zero and reports which contract
-failed.
+so CI proves this page never called the public position API and reports which
+contract failed.
 
 ## RED to GREEN
 
 Register a minimal reachable page with the stable selectors first, but leave its
 button without location behavior. The happy flow should fail on the native
-request and coordinate assertions. Implement the granted path through the public
-API and make that flow green before committing it.
+API-attempt and coordinate assertions. Implement the granted path through the
+public API and make that flow green before committing it.
 
 Next run the denied flow against a page that calls `getCurrentPosition()`
-without a permission gate. It should fail because the native request count is
-one and no actionable remediation appears. Add the read-only permission gate
+without a permission gate. It should fail because the API-attempt count is one
+and no actionable remediation appears. Add the read-only permission gate
 and guidance-driven remediation, then make the denied flow green:
 
 ```bash

--- a/docs/docs/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/guide/consumer-e2e-contract-kit.md
@@ -90,12 +90,17 @@ Copy the two Maestro flows:
 - [`consumer-location-contract-happy.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml)
 - [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
 
-Change `appId` and the `nitrogeolocation://app` deep-link prefix to the consumer
-app's registered values. Keep the location injection, API-attempt count, and
-coordinate ID assertion in the happy flow: asserting only a passed status can
-hide a page that never rendered the native result. Keep the denied flow separate
-so CI proves this page never called the public position API and reports which
-contract failed.
+In both flows, change `appId` and the `nitrogeolocation://app` deep-link prefix
+to the consumer app's registered values. Also set
+`CONSUMER_APP_DISPLAY_NAME` in the denied flow. The flows reset unrelated
+permissions to `unset`, then select only the location boundary under test:
+Android `allow`/`deny` and iOS `inuse`/`never`. Keep the location injection,
+API-attempt count, and coordinate ID assertion in the happy flow: asserting only
+a passed status can hide a page that never rendered the native result. Keep the
+denied flow separate so CI proves this page never called the public position API
+and reports which contract failed. Its final platform-specific assertion must
+identify the consumer app in the system settings UI; adapt that selector if the
+consumer's display name or supported OS UI differs.
 
 ## RED to GREEN
 

--- a/docs/docs/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/guide/consumer-e2e-contract-kit.md
@@ -1,0 +1,82 @@
+# Consumer E2E contract kit
+
+This kit gives a consuming React Native app one small product page and two
+black-box contracts:
+
+- a granted user receives and renders a real native location;
+- a denied user does not start a location request and sees a permission action.
+
+It deliberately uses the public API directly. There is no test-only provider,
+hidden retry, fixture branch, or library policy change.
+
+## Copy the page
+
+Copy
+[`ConsumerLocationContractScreen.tsx`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx)
+into the consuming app, then register it at a deterministic test route. The
+repository example uses this React Navigation linking entry:
+
+```ts
+const linking = {
+  prefixes: ['myapp://app'],
+  config: {
+    screens: {
+      ConsumerLocationContract: 'consumer-location-contract'
+    }
+  }
+};
+```
+
+Keep these test IDs stable in the copied page:
+
+| Test ID | Contract |
+| --- | --- |
+| `consumer-location-run` | Starts the same user action exercised in production |
+| `consumer-location-status` | Exposes `passed`, `permission-required`, or `failed` |
+| `consumer-location-permission` | Exposes the permission observed before a request |
+| `consumer-location-position` | Exists only after a valid position is rendered |
+| `consumer-location-request-permission` | Gives a denied user an explicit next action |
+
+The page checks permission before `getCurrentPosition()`. It does not prompt on
+mount, and it requests permission only after a user presses the permission
+button. Adapt the presentation to the product, but preserve those behavioral
+boundaries.
+
+## Copy the contracts
+
+Copy the two Maestro flows:
+
+- [`consumer-location-contract-happy.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml)
+- [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
+
+Change `appId` and the `nitrogeolocation://app` deep-link prefix to the
+consumer app's values. Keep the location injection and coordinate assertion in
+the happy flow: asserting only `Status: passed` can hide a page that never
+rendered the native result. Keep the denied flow separate so CI reports which
+contract failed.
+
+## RED to GREEN
+
+Add and run the flows before registering the page. Both should fail because the
+route or selectors do not exist. Then add the page and make the cases pass one
+at a time:
+
+```bash
+maestro test .maestro/consumer-location-contract-happy.yaml
+maestro test .maestro/consumer-location-contract-denied.yaml
+```
+
+Run both again against the same release build before committing. Do not replace
+the denied case with a mocked JavaScript rejection: the flow controls the real
+OS permission state.
+
+## CI boundary
+
+Build and install the release variant before Maestro so the contract covers the
+artifact shipped to users. Run Android and iOS jobs separately; their permission
+stores and system dialogs are mutually exclusive environments. Use a dedicated
+emulator or simulator and inject a location only for the happy path.
+
+These two smoke contracts are intentionally small. Add product-specific edge
+cases such as provider disabled, approximate permission, timeout, or background
+delivery only when the consuming feature depends on them.

--- a/docs/docs/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/guide/consumer-e2e-contract-kit.md
@@ -4,7 +4,8 @@ This kit gives a consuming React Native app one small product page and two
 black-box contracts:
 
 - a granted user receives and renders a real native location;
-- a denied user does not start a location request and sees a permission action.
+- a denied user does not start a location request and receives an actionable
+  permission remedy.
 
 It deliberately uses the public API directly. There is no test-only provider,
 hidden retry, fixture branch, or library policy change.
@@ -27,6 +28,35 @@ const linking = {
 };
 ```
 
+Register the same scheme with each operating system. Add an intent filter to
+the Android activity that owns the React Native route:
+
+```xml
+<intent-filter>
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="myapp" />
+</intent-filter>
+```
+
+Add the scheme to the iOS app's `Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+If the app already has a deterministic native route, adapt the flows to use it
+instead of adding another scheme.
+
 Keep these test IDs stable in the copied page:
 
 | Test ID | Contract |
@@ -34,13 +64,16 @@ Keep these test IDs stable in the copied page:
 | `consumer-location-run` | Starts the same user action exercised in production |
 | `consumer-location-status` | Exposes `passed`, `permission-required`, or `failed` |
 | `consumer-location-permission` | Exposes the permission observed before a request |
+| `consumer-location-native-requests` | Proves denied permission did not reach the native request |
 | `consumer-location-position` | Exists only after a valid position is rendered |
 | `consumer-location-request-permission` | Gives a denied user an explicit next action |
+| `consumer-location-open-settings` | Leaves the app for settings when another prompt cannot recover access |
 
-The page checks permission before `getCurrentPosition()`. It does not prompt on
-mount, and it requests permission only after a user presses the permission
-button. Adapt the presentation to the product, but preserve those behavioral
-boundaries.
+The page reads `getPermissionDetails()` before `getCurrentPosition()`. It does
+not prompt on mount. Its foreground request explicitly selects `whenInUse`, and
+its remediation follows `settingsGuidance`: request again when possible, open
+app settings when required, or explain a managed restriction. Adapt the
+presentation to the product, but preserve those behavioral boundaries.
 
 ## Copy the contracts
 
@@ -49,17 +82,24 @@ Copy the two Maestro flows:
 - [`consumer-location-contract-happy.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml)
 - [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
 
-Change `appId` and the `nitrogeolocation://app` deep-link prefix to the
-consumer app's values. Keep the location injection and coordinate assertion in
-the happy flow: asserting only `Status: passed` can hide a page that never
-rendered the native result. Keep the denied flow separate so CI reports which
-contract failed.
+Change `appId` and the `nitrogeolocation://app` deep-link prefix to the consumer
+app's registered values. Keep the location injection, native-request count, and
+coordinate assertion in the happy flow: asserting only `Status: passed` can
+hide a page that never rendered the native result. Keep the denied flow separate
+so CI proves the native request count stays zero and reports which contract
+failed.
 
 ## RED to GREEN
 
-Add and run the flows before registering the page. Both should fail because the
-route or selectors do not exist. Then add the page and make the cases pass one
-at a time:
+Register a minimal reachable page with the stable selectors first, but leave its
+button without location behavior. The happy flow should fail on the native
+request and coordinate assertions. Implement the granted path through the public
+API and make that flow green before committing it.
+
+Next run the denied flow against a page that calls `getCurrentPosition()`
+without a permission gate. It should fail because the native request count is
+one and no actionable remediation appears. Add the read-only permission gate
+and guidance-driven remediation, then make the denied flow green:
 
 ```bash
 maestro test .maestro/consumer-location-contract-happy.yaml

--- a/docs/docs/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/guide/consumer-e2e-contract-kit.md
@@ -91,16 +91,18 @@ Copy the two Maestro flows:
 - [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
 
 In both flows, change `appId` and the `nitrogeolocation://app` deep-link prefix
-to the consumer app's registered values. Also set
-`CONSUMER_APP_DISPLAY_NAME` in the denied flow. The flows reset unrelated
+to the consumer app's registered values. In the denied flow, also set
+`CONSUMER_APP_DISPLAY_NAME_PATTERN`, `ANDROID_APP_SETTINGS_TITLE_PATTERN`, and
+`IOS_SETTINGS_TITLE_PATTERN`. These values are regular expressions, so escape
+metacharacters in app names such as `Foo \(Dev\)`. The flows reset unrelated
 permissions to `unset`, then select only the location boundary under test:
 Android `allow`/`deny` and iOS `inuse`/`never`. Keep the location injection,
 API-attempt count, and coordinate ID assertion in the happy flow: asserting only
 a passed status can hide a page that never rendered the native result. Keep the
 denied flow separate so CI proves this page never called the public position API
-and reports which contract failed. Its final platform-specific assertion must
-identify the consumer app in the system settings UI; adapt that selector if the
-consumer's display name or supported OS UI differs.
+and reports which contract failed. Its final platform-specific assertions must
+identify both the system Settings UI and the consumer app; adapt the title
+patterns for every OS locale the consumer supports.
 
 ## RED to GREEN
 

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -105,8 +105,8 @@ When adding a flow:
 - `consumer-location-contract-happy.yaml` copies into a consumer app and proves
   that granted permission reaches a real native position rendered by the UI
 - `consumer-location-contract-denied.yaml` proves the same product action does
-  not start a location request when permission is denied and leaves a visible
-  remediation action
+  not call the public position API when permission is denied and leaves a
+  working remediation action
 - The standalone `ConsumerLocationContractScreen.tsx` uses only React Native
   and the public package API; see the
   [consumer E2E contract kit](../../../docs/docs/guide/consumer-e2e-contract-kit.md)

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -101,6 +101,17 @@ When adding a flow:
 
 ## Test Files
 
+### Consumer location contract kit
+- `consumer-location-contract-happy.yaml` copies into a consumer app and proves
+  that granted permission reaches a real native position rendered by the UI
+- `consumer-location-contract-denied.yaml` proves the same product action does
+  not start a location request when permission is denied and leaves a visible
+  remediation action
+- The standalone `ConsumerLocationContractScreen.tsx` uses only React Native
+  and the public package API; see the
+  [consumer E2E contract kit](../../../docs/docs/guide/consumer-e2e-contract-kit.md)
+  for the copy and CI workflow
+
 ### `permission-check.yaml`
 - Tests location permission check/request functionality
 - Verifies permission state changes

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -38,6 +38,8 @@ appId: nitrogeolocation.example
       platform: iOS
     file: issue-122-ios.yaml
 - runFlow: permission-check.yaml
+- runFlow: consumer-location-contract-happy.yaml
+- runFlow: consumer-location-contract-denied.yaml
 - runFlow: permission-details.yaml
 - runFlow:
     when:

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -1,6 +1,8 @@
 appId: nitrogeolocation.example
 env:
-  CONSUMER_APP_DISPLAY_NAME: NitroGeolocationExample
+  CONSUMER_APP_DISPLAY_NAME_PATTERN: NitroGeolocationExample
+  ANDROID_APP_SETTINGS_TITLE_PATTERN: App info|앱 정보
+  IOS_SETTINGS_TITLE_PATTERN: Settings|설정
 ---
 # Copyable consumer edge contract: denied permission never starts a request and
 # leaves the user with an explicit permission action.
@@ -86,14 +88,16 @@ env:
       platform: Android
     commands:
       - extendedWaitUntil:
-          visible: "${CONSUMER_APP_DISPLAY_NAME}"
+          visible: "${ANDROID_APP_SETTINGS_TITLE_PATTERN}"
           timeout: 10000
+      - assertVisible: "${CONSUMER_APP_DISPLAY_NAME_PATTERN}"
 - runFlow:
     when:
       platform: iOS
     commands:
       - extendedWaitUntil:
-          visible:
-            id: "breadcrumb"
-            text: ".*${CONSUMER_APP_DISPLAY_NAME}.*"
+          visible: "${IOS_SETTINGS_TITLE_PATTERN}"
           timeout: 10000
+      - assertVisible:
+          id: "breadcrumb"
+          text: ".*${CONSUMER_APP_DISPLAY_NAME_PATTERN}.*"

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -15,10 +15,6 @@ appId: nitrogeolocation.example
     commands:
       - tapOn:
           text: "Wait|대기"
-- extendedWaitUntil:
-    visible: "Geolocation API"
-    timeout: 10000
-
 - stopApp
 
 - openLink:
@@ -59,7 +55,14 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "consumer-location-status"
 - assertVisible: "Permission: denied"
-- assertVisible:
-    id: "consumer-location-request-permission"
+- assertVisible: "Native requests: 0"
 - assertNotVisible:
     id: "consumer-location-position"
+- assertVisible:
+    id: "consumer-location-open-settings"
+
+- tapOn:
+    id: "consumer-location-open-settings"
+- extendedWaitUntil:
+    notVisible: "Use your location"
+    timeout: 10000

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -42,27 +42,30 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Use your location"
+    visible:
+      id: "consumer-location-screen"
     timeout: 10000
 
 - tapOn:
     id: "consumer-location-run"
 
 - extendedWaitUntil:
-    visible: "Status: permission-required"
+    visible:
+      id: "consumer-location-status-permission-required"
     timeout: 10000
 
 - assertVisible:
-    id: "consumer-location-status"
-- assertVisible: "Permission: denied"
-- assertVisible: "Native requests: 0"
+    id: "consumer-location-permission-denied"
+- assertVisible:
+    id: "consumer-location-api-attempts-0"
 - assertNotVisible:
-    id: "consumer-location-position"
+    id: ".*consumer-location-position-.*"
 - assertVisible:
     id: "consumer-location-open-settings"
 
 - tapOn:
     id: "consumer-location-open-settings"
 - extendedWaitUntil:
-    notVisible: "Use your location"
+    notVisible:
+      id: "consumer-location-screen"
     timeout: 10000

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -1,12 +1,28 @@
 appId: nitrogeolocation.example
+env:
+  CONSUMER_APP_DISPLAY_NAME: NitroGeolocationExample
 ---
 # Copyable consumer edge contract: denied permission never starts a request and
 # leaves the user with an explicit permission action.
 
-- launchApp:
-    clearState: true
-    permissions:
-      all: deny
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - launchApp:
+          clearState: true
+          permissions:
+            all: unset
+            location: deny
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - launchApp:
+          clearState: true
+          permissions:
+            all: unset
+            location: never
 
 - runFlow:
     when:
@@ -65,7 +81,19 @@ appId: nitrogeolocation.example
 
 - tapOn:
     id: "consumer-location-open-settings"
-- extendedWaitUntil:
-    notVisible:
-      id: "consumer-location-screen"
-    timeout: 10000
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: "${CONSUMER_APP_DISPLAY_NAME}"
+          timeout: 10000
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "breadcrumb"
+            text: ".*${CONSUMER_APP_DISPLAY_NAME}.*"
+          timeout: 10000

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -1,0 +1,65 @@
+appId: nitrogeolocation.example
+---
+# Copyable consumer edge contract: denied permission never starts a request and
+# leaves the user with an explicit permission action.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: deny
+
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/consumer-location-contract
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/consumer-location-contract
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Use your location"
+    timeout: 10000
+
+- tapOn:
+    id: "consumer-location-run"
+
+- extendedWaitUntil:
+    visible: "Status: permission-required"
+    timeout: 10000
+
+- assertVisible:
+    id: "consumer-location-status"
+- assertVisible: "Permission: denied"
+- assertVisible:
+    id: "consumer-location-request-permission"
+- assertNotVisible:
+    id: "consumer-location-position"

--- a/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml
@@ -33,6 +33,9 @@ env:
     commands:
       - tapOn:
           text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
 - stopApp
 
 - openLink:

--- a/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
@@ -28,6 +28,9 @@ appId: nitrogeolocation.example
     commands:
       - tapOn:
           text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
 - stopApp
 
 - openLink:

--- a/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
@@ -2,10 +2,24 @@ appId: nitrogeolocation.example
 ---
 # Copyable consumer contract: a granted user can request and render a real fix.
 
-- launchApp:
-    clearState: true
-    permissions:
-      all: allow
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - launchApp:
+          clearState: true
+          permissions:
+            all: unset
+            location: allow
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - launchApp:
+          clearState: true
+          permissions:
+            all: unset
+            location: inuse
 
 - runFlow:
     when:

--- a/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
@@ -1,0 +1,69 @@
+appId: nitrogeolocation.example
+---
+# Copyable consumer contract: a granted user can request and render a real fix.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- stopApp
+
+- openLink:
+    link: nitrogeolocation://app/consumer-location-contract
+- runFlow:
+    when:
+      platform: Android
+      visible: ".*isn't responding|.*응답하지 않.*"
+    commands:
+      - tapOn:
+          text: "Wait|대기"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/consumer-location-contract
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Use your location"
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- tapOn:
+    id: "consumer-location-run"
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.978
+
+- extendedWaitUntil:
+    visible: "Status: passed"
+    timeout: 60000
+
+- assertVisible:
+    id: "consumer-location-status"
+- assertVisible: "Permission: granted"
+- assertVisible: "Coordinates: 37.566500, 126.978000"

--- a/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
@@ -41,7 +41,8 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Use your location"
+    visible:
+      id: "consumer-location-screen"
     timeout: 10000
 
 - setLocation:
@@ -56,11 +57,13 @@ appId: nitrogeolocation.example
     longitude: 126.978
 
 - extendedWaitUntil:
-    visible: "Status: passed"
+    visible:
+      id: "consumer-location-status-passed"
     timeout: 60000
 
 - assertVisible:
-    id: "consumer-location-status"
-- assertVisible: "Permission: granted"
-- assertVisible: "Native requests: 1"
-- assertVisible: "Coordinates: 37.566500, 126.978000"
+    id: "consumer-location-permission-granted"
+- assertVisible:
+    id: "consumer-location-api-attempts-1"
+- assertVisible:
+    id: "consumer-location-position-37566500-126978000"

--- a/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
+++ b/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml
@@ -14,10 +14,6 @@ appId: nitrogeolocation.example
     commands:
       - tapOn:
           text: "Wait|대기"
-- extendedWaitUntil:
-    visible: "Geolocation API"
-    timeout: 10000
-
 - stopApp
 
 - openLink:
@@ -66,4 +62,5 @@ appId: nitrogeolocation.example
 - assertVisible:
     id: "consumer-location-status"
 - assertVisible: "Permission: granted"
+- assertVisible: "Native requests: 1"
 - assertVisible: "Coordinates: 37.566500, 126.978000"

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -5,6 +5,7 @@ import {
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";
 import React from "react";
+import { setConfiguration } from "react-native-nitro-geolocation";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import AccuracyPresetsScreen from "./screens/AccuracyPresetsScreen";
 import AndroidRequestOptionsScreen, {
@@ -47,6 +48,12 @@ import ProviderStatusWatcherScreen from "./screens/ProviderStatusWatcherScreen";
 import WatchObservabilityScreen from "./screens/WatchObservabilityScreen";
 import WatchPositionScreen from "./screens/WatchPositionScreen";
 import WebE2EScreen from "./screens/WebE2EScreen";
+
+setConfiguration({
+  authorizationLevel: "whenInUse",
+  enableBackgroundLocationUpdates: false,
+  locationProvider: "auto"
+});
 
 const Tab = createBottomTabNavigator();
 const linking = {

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -17,6 +17,7 @@ import BackgroundE2EScreen from "./screens/BackgroundE2EScreen";
 import CancellableCurrentPositionScreen from "./screens/CancellableCurrentPositionScreen";
 import CompatMetadataScreen from "./screens/CompatMetadataScreen";
 import CompatScreen from "./screens/CompatScreen";
+import ConsumerLocationContractScreen from "./screens/ConsumerLocationContractScreen";
 import CurrentPositionScreen from "./screens/CurrentPositionScreen";
 import DefaultScreen from "./screens/DefaultScreen";
 import GeocodingScreen from "./screens/GeocodingScreen";
@@ -55,6 +56,7 @@ const linking = {
       Default: "",
       Compat: "compat",
       CompatMetadata: "compat-metadata",
+      ConsumerLocationContract: "consumer-location-contract",
       PermissionCheck: "permission-check",
       PermissionDetails: "permission-details",
       CurrentPosition: "current-position",
@@ -134,6 +136,11 @@ export default function App() {
           <Tab.Screen
             name="Issue67"
             component={Issue67Screen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="ConsumerLocationContract"
+            component={ConsumerLocationContractScreen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
+++ b/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
@@ -11,8 +11,7 @@ import {
 import {
   getCurrentPosition,
   getPermissionDetails,
-  requestPermission,
-  setConfiguration
+  requestPermission
 } from "react-native-nitro-geolocation";
 import type {
   GeolocationResponse,
@@ -72,7 +71,7 @@ export default function ConsumerLocationContractScreen() {
   const [permissionGuidance, setPermissionGuidance] =
     useState<PermissionSettingsGuidance>("requestPermission");
   const [position, setPosition] = useState<GeolocationResponse>();
-  const [nativeRequestCount, setNativeRequestCount] = useState(0);
+  const [locationApiAttempts, setLocationApiAttempts] = useState(0);
   const [error, setError] = useState<string>();
 
   const useLocation = async () => {
@@ -89,7 +88,7 @@ export default function ConsumerLocationContractScreen() {
         return;
       }
 
-      setNativeRequestCount((count) => count + 1);
+      setLocationApiAttempts((count) => count + 1);
       const currentPosition = await getCurrentPosition({
         accuracy: { android: "high", ios: "best" },
         maximumAge: 0,
@@ -113,7 +112,6 @@ export default function ConsumerLocationContractScreen() {
     setError(undefined);
 
     try {
-      setConfiguration({ authorizationLevel: "whenInUse" });
       const nextPermission = await requestPermission();
       const details = await getPermissionDetails();
       setPermission(details.status);
@@ -155,15 +153,23 @@ export default function ConsumerLocationContractScreen() {
         </Text>
 
         <View style={styles.card}>
-          <Text testID="consumer-location-status">Status: {status}</Text>
-          <Text testID="consumer-location-permission">
+          <Text testID={`consumer-location-status-${status}`}>
+            Status: {status}
+          </Text>
+          <Text testID={`consumer-location-permission-${permission}`}>
             Permission: {permission}
           </Text>
-          <Text testID="consumer-location-native-requests">
-            Native requests: {nativeRequestCount}
+          <Text
+            testID={`consumer-location-api-attempts-${locationApiAttempts}`}
+          >
+            Location API calls: {locationApiAttempts}
           </Text>
           {position ? (
-            <Text testID="consumer-location-position">
+            <Text
+              testID={`consumer-location-position-${Math.round(
+                position.coords.latitude * 1_000_000
+              )}-${Math.round(position.coords.longitude * 1_000_000)}`}
+            >
               Coordinates: {position.coords.latitude.toFixed(6)},{" "}
               {position.coords.longitude.toFixed(6)}
             </Text>

--- a/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
+++ b/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from "react";
+import {
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View
+} from "react-native";
+import {
+  checkPermission,
+  getCurrentPosition,
+  requestPermission
+} from "react-native-nitro-geolocation";
+import type {
+  GeolocationResponse,
+  PermissionStatus
+} from "react-native-nitro-geolocation";
+
+type ContractStatus =
+  | "idle"
+  | "running"
+  | "ready"
+  | "passed"
+  | "permission-required"
+  | "failed";
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function Button({
+  disabled = false,
+  onPress,
+  testID,
+  title
+}: {
+  disabled?: boolean;
+  onPress: () => void;
+  testID: string;
+  title: string;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      disabled={disabled}
+      onPress={onPress}
+      style={[styles.button, disabled && styles.buttonDisabled]}
+      testID={testID}
+    >
+      <Text style={styles.buttonText}>{title}</Text>
+    </Pressable>
+  );
+}
+
+export default function ConsumerLocationContractScreen() {
+  const [status, setStatus] = useState<ContractStatus>("idle");
+  const [permission, setPermission] =
+    useState<PermissionStatus>("undetermined");
+  const [position, setPosition] = useState<GeolocationResponse>();
+  const [error, setError] = useState<string>();
+
+  const useLocation = async () => {
+    setStatus("running");
+    setPosition(undefined);
+    setError(undefined);
+
+    try {
+      const currentPermission = await checkPermission();
+      setPermission(currentPermission);
+      if (currentPermission !== "granted") {
+        setStatus("permission-required");
+        return;
+      }
+
+      const currentPosition = await getCurrentPosition({
+        accuracy: { android: "high", ios: "best" },
+        maximumAge: 0,
+        timeout: 30_000
+      });
+      const { latitude, longitude } = currentPosition.coords;
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        throw new Error("Location returned invalid coordinates.");
+      }
+
+      setPosition(currentPosition);
+      setStatus("passed");
+    } catch (locationError) {
+      setError(errorMessage(locationError));
+      setStatus("failed");
+    }
+  };
+
+  const askForPermission = async () => {
+    setStatus("running");
+    setError(undefined);
+
+    try {
+      const nextPermission = await requestPermission();
+      setPermission(nextPermission);
+      setStatus(nextPermission === "granted" ? "ready" : "permission-required");
+    } catch (permissionError) {
+      setError(errorMessage(permissionError));
+      setStatus("failed");
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea} testID="consumer-location-screen">
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>Use your location</Text>
+        <Text style={styles.description}>
+          Check permission before requesting a fresh position, and keep denied
+          permission visible so the user can choose the next action.
+        </Text>
+
+        <View style={styles.card}>
+          <Text testID="consumer-location-status">Status: {status}</Text>
+          <Text testID="consumer-location-permission">
+            Permission: {permission}
+          </Text>
+          {position ? (
+            <Text testID="consumer-location-position">
+              Coordinates: {position.coords.latitude.toFixed(6)},{" "}
+              {position.coords.longitude.toFixed(6)}
+            </Text>
+          ) : null}
+          {error ? (
+            <Text style={styles.error} testID="consumer-location-error">
+              Error: {error}
+            </Text>
+          ) : null}
+        </View>
+
+        <Button
+          disabled={status === "running"}
+          onPress={useLocation}
+          testID="consumer-location-run"
+          title={status === "running" ? "Locating…" : "Use my location"}
+        />
+        {status === "permission-required" ? (
+          <Button
+            onPress={askForPermission}
+            testID="consumer-location-request-permission"
+            title="Request location permission"
+          />
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#f4f7fb"
+  },
+  content: {
+    gap: 16,
+    padding: 24
+  },
+  title: {
+    color: "#14213d",
+    fontSize: 28,
+    fontWeight: "700"
+  },
+  description: {
+    color: "#40516f",
+    fontSize: 16,
+    lineHeight: 24
+  },
+  card: {
+    gap: 8,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: "#ffffff"
+  },
+  button: {
+    alignItems: "center",
+    padding: 14,
+    borderRadius: 10,
+    backgroundColor: "#1769e0"
+  },
+  buttonDisabled: {
+    opacity: 0.55
+  },
+  buttonText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontWeight: "600"
+  },
+  error: {
+    color: "#b42318"
+  }
+});

--- a/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
+++ b/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {
+  Linking,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -8,12 +9,14 @@ import {
   View
 } from "react-native";
 import {
-  checkPermission,
   getCurrentPosition,
-  requestPermission
+  getPermissionDetails,
+  requestPermission,
+  setConfiguration
 } from "react-native-nitro-geolocation";
 import type {
   GeolocationResponse,
+  PermissionSettingsGuidance,
   PermissionStatus
 } from "react-native-nitro-geolocation";
 
@@ -66,7 +69,10 @@ export default function ConsumerLocationContractScreen() {
   const [status, setStatus] = useState<ContractStatus>("idle");
   const [permission, setPermission] =
     useState<PermissionStatus>("undetermined");
+  const [permissionGuidance, setPermissionGuidance] =
+    useState<PermissionSettingsGuidance>("requestPermission");
   const [position, setPosition] = useState<GeolocationResponse>();
+  const [nativeRequestCount, setNativeRequestCount] = useState(0);
   const [error, setError] = useState<string>();
 
   const useLocation = async () => {
@@ -75,13 +81,15 @@ export default function ConsumerLocationContractScreen() {
     setError(undefined);
 
     try {
-      const currentPermission = await checkPermission();
-      setPermission(currentPermission);
-      if (currentPermission !== "granted") {
+      const details = await getPermissionDetails();
+      setPermission(details.status);
+      setPermissionGuidance(details.settingsGuidance);
+      if (details.status !== "granted") {
         setStatus("permission-required");
         return;
       }
 
+      setNativeRequestCount((count) => count + 1);
       const currentPosition = await getCurrentPosition({
         accuracy: { android: "high", ios: "best" },
         maximumAge: 0,
@@ -105,14 +113,37 @@ export default function ConsumerLocationContractScreen() {
     setError(undefined);
 
     try {
+      setConfiguration({ authorizationLevel: "whenInUse" });
       const nextPermission = await requestPermission();
-      setPermission(nextPermission);
+      const details = await getPermissionDetails();
+      setPermission(details.status);
+      setPermissionGuidance(details.settingsGuidance);
       setStatus(nextPermission === "granted" ? "ready" : "permission-required");
     } catch (permissionError) {
       setError(errorMessage(permissionError));
       setStatus("failed");
     }
   };
+
+  const openPermissionSettings = async () => {
+    setStatus("running");
+    setError(undefined);
+
+    try {
+      await Linking.openSettings();
+      setStatus("permission-required");
+    } catch (settingsError) {
+      setError(errorMessage(settingsError));
+      setStatus("failed");
+    }
+  };
+
+  const canRequestPermission =
+    permissionGuidance === "requestPermission" ||
+    permissionGuidance === "requestPermissionOrReviewSettings";
+  const canReviewSettings =
+    permissionGuidance === "reviewSettings" ||
+    permissionGuidance === "requestPermissionOrReviewSettings";
 
   return (
     <SafeAreaView style={styles.safeArea} testID="consumer-location-screen">
@@ -127,6 +158,9 @@ export default function ConsumerLocationContractScreen() {
           <Text testID="consumer-location-status">Status: {status}</Text>
           <Text testID="consumer-location-permission">
             Permission: {permission}
+          </Text>
+          <Text testID="consumer-location-native-requests">
+            Native requests: {nativeRequestCount}
           </Text>
           {position ? (
             <Text testID="consumer-location-position">
@@ -147,12 +181,31 @@ export default function ConsumerLocationContractScreen() {
           testID="consumer-location-run"
           title={status === "running" ? "Locating…" : "Use my location"}
         />
-        {status === "permission-required" ? (
+        {status === "permission-required" && canRequestPermission ? (
           <Button
             onPress={askForPermission}
             testID="consumer-location-request-permission"
             title="Request location permission"
           />
+        ) : null}
+        {status === "permission-required" && canReviewSettings ? (
+          <Button
+            onPress={openPermissionSettings}
+            testID="consumer-location-open-settings"
+            title="Open app settings"
+          />
+        ) : null}
+        {status === "permission-required" &&
+        permissionGuidance === "managedRestriction" ? (
+          <Text testID="consumer-location-guidance">
+            Location permission is managed on this device.
+          </Text>
+        ) : null}
+        {status === "permission-required" &&
+        permissionGuidance === "useSupportedEnvironment" ? (
+          <Text testID="consumer-location-guidance">
+            Location is unavailable in this environment.
+          </Text>
         ) : null}
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## Summary\n- add a copyable consumer location contract page that uses only public APIs\n- add separate Release happy-path and permission-denied Maestro contracts for Android and iOS\n- document app-owned routing, stable selectors, RED-to-GREEN workflow, and platform-isolated CI\n- wait for the RN root before deep-link relaunch to avoid cold-launch false greens\n\n## Validation\n- Android Release build/install\n- Android consumer happy + denied flows\n- iOS Release simulator build/install\n- iOS consumer happy + denied flows\n- unit: 16 files / 151 tests\n- format, lint, typecheck, build:all\n- deadcode, production guard, pack, source line guard, diff check\n- changeset status: minor\n- two exact-head adversarial reviews: no P1/P2\n\n## Roadmap\nCloses the consumer E2E contract kit checkbox in #98.