### PR TITLE
feat: add detailed location settings API

### DIFF
--- a/.changeset/bright-settings-report.md
+++ b/.changeset/bright-settings-report.md
@@ -1,0 +1,6 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add `requestLocationSettingsDetailed()` as the explicit detailed-result API for
+Android settings resolution while preserving the v2 deterministic method.

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -245,6 +245,7 @@ import {
   getProviderStatus,
   hasServicesEnabled,
   requestLocationSettings,
+  requestLocationSettingsDetailed,
   unwatch,
   watchProviderStatus
 } from 'react-native-nitro-geolocation';
@@ -263,11 +264,12 @@ async function prepareAccurateLocation() {
   const providerStatus = await getProviderStatus();
 
   if (!availability.available || !servicesEnabled || providerStatus.googleLocationAccuracyEnabled === false) {
-    await requestLocationSettings({
+    const settings = await requestLocationSettingsDetailed({
       accuracy: { android: 'high' },
       interval: 5000,
       fastestInterval: 1000
     });
+    if (settings.outcome !== 'satisfied') return settings;
   }
 
   return getCurrentPosition({
@@ -325,13 +327,17 @@ function ProviderStatusObserver() {
   Google Play Services remediations are returned only when
   `locationProvider: 'playServices'` is explicitly configured; the default
   `auto` and `android` routes can continue through Android platform providers.
-- `requestLocationSettings(options?): Promise<LocationProviderStatus>` -
+- `requestLocationSettingsDetailed(options?): Promise<LocationSettingsResult>` -
   Checks the requested Android location settings and shows Android's native
-  resolution dialog when available. It resolves with the updated provider
-  status after the settings satisfy the request.
+  resolution dialog when available. Expected outcomes resolve as `satisfied`,
+  `cancelled`, `unavailable`, or `activityMissing`, together with the latest
+  provider status. Request failures such as a concurrent request still reject.
+- `requestLocationSettings(options?): Promise<LocationSettingsResult>` - The
+  v2 method returns the same deterministic result. The detailed name is
+  provided for code shared with v1.5 and to make result handling explicit.
 
-`requestLocationSettings()` is Android-focused. On iOS it resolves with the
-current Core Location service status and does not show a settings dialog.
+Both settings methods are Android-focused. On iOS they resolve with the current
+Core Location service status and do not show a settings dialog.
 
 `watchProviderStatus()` only observes readiness: it does not request permission,
 open settings, or start position updates. Android reacts to system provider and

--- a/examples/v0.81.1/.maestro/provider-settings.yaml
+++ b/examples/v0.81.1/.maestro/provider-settings.yaml
@@ -17,6 +17,9 @@ appId: nitrogeolocation.example
     commands:
       - tapOn:
           text: "Wait|대기"
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 30000
 - stopApp
 
 - openLink:

--- a/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
@@ -6,7 +6,7 @@ import {
   getLocationErrorCodeName,
   getProviderStatus,
   hasServicesEnabled,
-  requestLocationSettings
+  requestLocationSettingsDetailed
 } from "react-native-nitro-geolocation";
 import type {
   GeolocationResponse,
@@ -94,7 +94,7 @@ export default function ProviderSettingsScreen() {
         return;
       }
 
-      const result = await requestLocationSettings({
+      const result = await requestLocationSettingsDetailed({
         accuracy: { android: "high" },
         interval: 5000,
         fastestInterval: 1000,

--- a/examples/v0.81.1/src/type-contracts/v2.ts
+++ b/examples/v0.81.1/src/type-contracts/v2.ts
@@ -12,6 +12,7 @@ import type {
 import {
   getLocationReadiness,
   requestLocationSettings,
+  requestLocationSettingsDetailed,
   selectProvider
 } from "react-native-nitro-geolocation";
 import type { GeolocationOptions as CompatGeolocationOptions } from "react-native-nitro-geolocation/compat";
@@ -30,6 +31,8 @@ const modernSettings: LocationSettingsOptions = {
 
 const settingsResultPromise: Promise<LocationSettingsResult> =
   requestLocationSettings();
+const detailedSettingsResultPromise: Promise<LocationSettingsResult> =
+  requestLocationSettingsDetailed();
 const settingsOutcome: LocationSettingsOutcome = "activityMissing";
 
 const compatRequest: CompatGeolocationOptions = {
@@ -58,6 +61,7 @@ void [
   modernRequest,
   modernSettings,
   settingsResultPromise,
+  detailedSettingsResultPromise,
   settingsOutcome,
   compatRequest,
   mergedRequest,

--- a/packages/react-native-nitro-geolocation/src/api/index.ts
+++ b/packages/react-native-nitro-geolocation/src/api/index.ts
@@ -8,6 +8,7 @@ export { watchProviderStatus } from "./watchProviderStatus";
 export { getLocationAvailability } from "./getLocationAvailability";
 export { getLocationReadiness } from "./getLocationReadiness";
 export { requestLocationSettings } from "./requestLocationSettings";
+export { requestLocationSettingsDetailed } from "./requestLocationSettingsDetailed";
 export { getAccuracyAuthorization } from "./getAccuracyAuthorization";
 export { requestTemporaryFullAccuracy } from "./requestTemporaryFullAccuracy";
 export { getCurrentPosition } from "./getCurrentPosition";

--- a/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const native = vi.hoisted(() => ({
+  requestLocationSettings: vi.fn()
+}));
+
+vi.mock("../NitroGeolocationModule", () => ({
+  NitroGeolocationHybridObject: native
+}));
+
+import { requestLocationSettingsDetailed } from "./requestLocationSettingsDetailed";
+
+const satisfiedResult = {
+  outcome: "satisfied" as const,
+  providerStatus: {
+    locationServicesEnabled: true,
+    gpsAvailable: true,
+    networkAvailable: true,
+    passiveAvailable: true,
+    googleLocationAccuracyEnabled: true
+  }
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("requestLocationSettingsDetailed", () => {
+  it("resolves the deterministic native settings result", async () => {
+    native.requestLocationSettings.mockImplementation((success) =>
+      success(satisfiedResult)
+    );
+
+    await expect(
+      requestLocationSettingsDetailed({
+        accuracy: { android: "high" },
+        alwaysShow: true
+      })
+    ).resolves.toEqual(satisfiedResult);
+
+    expect(native.requestLocationSettings).toHaveBeenCalledWith(
+      expect.any(Function),
+      { accuracy: { android: "high" }, alwaysShow: true },
+      expect.any(Function)
+    );
+  });
+
+  it("preserves native request failures", async () => {
+    const concurrentRequestError = new Error(
+      "A location settings request is already in progress."
+    );
+    native.requestLocationSettings.mockImplementation(
+      (_success, _options, reject) => reject(concurrentRequestError)
+    );
+
+    await expect(requestLocationSettingsDetailed()).rejects.toBe(
+      concurrentRequestError
+    );
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.ts
@@ -1,0 +1,15 @@
+import type { LocationSettingsOptions } from "../NitroGeolocation.nitro";
+import type { LocationSettingsResult } from "../publicTypes";
+import { requestLocationSettings } from "./requestLocationSettings";
+
+/**
+ * Returns the detailed, deterministic location-settings outcome.
+ *
+ * This explicit name is an alias for `requestLocationSettings()` in v2, where
+ * the original method already returns `LocationSettingsResult`.
+ */
+export function requestLocationSettingsDetailed(
+  options?: LocationSettingsOptions
+): Promise<LocationSettingsResult> {
+  return requestLocationSettings(options);
+}

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -60,6 +60,7 @@ export {
   getLocationAvailability,
   getLocationReadiness,
   requestLocationSettings,
+  requestLocationSettingsDetailed,
   getAccuracyAuthorization,
   requestTemporaryFullAccuracy,
   getCurrentPosition,

--- a/packages/react-native-nitro-geolocation/src/types.ts
+++ b/packages/react-native-nitro-geolocation/src/types.ts
@@ -140,7 +140,8 @@ export type LocationSettingsOutcome =
   | "activityMissing";
 
 /**
- * Deterministic result from `requestLocationSettings()`.
+ * Deterministic result from `requestLocationSettings()` or
+ * `requestLocationSettingsDetailed()`.
  *
  * Expected platform outcomes resolve through this object. Errors are reserved
  * for failures of the request itself, such as a concurrent request.

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -8,6 +8,7 @@ import {
   getLocationAvailability,
   getLocationReadiness,
   getPermissionDetails,
+  requestLocationSettingsDetailed,
   requestPermission,
   stopObserving,
   unwatch,
@@ -63,6 +64,18 @@ afterEach(() => {
 });
 
 describe("web Modern API", () => {
+  it("returns an unavailable detailed settings result without browser geolocation", async () => {
+    setNavigator(undefined);
+
+    await expect(requestLocationSettingsDetailed()).resolves.toEqual({
+      outcome: "unavailable",
+      providerStatus: {
+        backgroundModeEnabled: false,
+        locationServicesEnabled: false
+      }
+    });
+  });
+
   it("returns undefined from a cold sync module cache without querying the browser", () => {
     const getCurrentPositionMock = vi.fn();
     setNavigator({

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -227,6 +227,13 @@ export function requestLocationSettings(
   }));
 }
 
+/** Detailed alias for the deterministic settings result used by native. */
+export function requestLocationSettingsDetailed(
+  options?: LocationSettingsOptions
+): Promise<LocationSettingsResult> {
+  return requestLocationSettings(options);
+}
+
 export function getAccuracyAuthorization(): Promise<AccuracyAuthorization> {
   return checkPermission().then((status) =>
     status === "granted" ? "full" : "unknown"


### PR DESCRIPTION
Roadmap: #98

Adds the public requestLocationSettingsDetailed() alias while preserving the existing deterministic v2 settings contract on native and Web. The natural provider-settings example screen and its ready/not-ready flows exercise the new entry point.

Changeset: minor (backward-compatible public API addition).

Validation before commit:
- RED: targeted unit test failed on the missing module
- GREEN: unit 17 files / 154 tests
- Relevant native + Web suites: 43/43
- typecheck, lint/format, build, package/dead-code/source-line guards
- Android Release: satisfied and location-disabled/cancelled flows
- iOS Release: satisfied flow
- Two exact-head adversarial reviews: no P1/P2

This PR is independent and based on main.