### PR TITLE
feat: add install doctor

### DIFF
--- a/.changeset/bright-dragons-check.md
+++ b/.changeset/bright-dragons-check.md
@@ -1,0 +1,6 @@
+---
+"react-native-nitro-geolocation": minor
+---
+
+Add the read-only `nitro-geolocation doctor` command for checking React Native,
+Nitro, Android permission, iOS usage-description, and New Architecture setup.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ for iOS and read the
 [Swift Package Manager guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
 before migrating an RN 0.87 app.
 
+After configuring the native projects, inspect the installation without
+changing any files:
+
+```bash
+yarn nitro-geolocation doctor
+```
+
+Use `nitro-geolocation doctor --project apps/mobile --json` for monorepos or
+CI. Missing generated native folders are warnings; rerun it after native
+generation to verify permissions and usage descriptions.
+
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
 downloads the release XCFramework. If the prebuilt asset is unavailable, the

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -1,6 +1,7 @@
 [
   "index",
   "quick-start",
+  "install-doctor",
   "swift-package-manager",
   "migration-assistance",
   "v2-error-migration",

--- a/docs/docs/guide/install-doctor.md
+++ b/docs/docs/guide/install-doctor.md
@@ -1,0 +1,50 @@
+# Install Doctor
+
+`nitro-geolocation doctor` checks a consumer app's installation without
+changing any files. It has no `postinstall` hook and never applies native
+configuration automatically.
+
+Run it from the React Native app root after installing dependencies and after
+generating native projects:
+
+```bash
+yarn nitro-geolocation doctor
+
+# npm projects can use the package's local binary
+npx --no-install nitro-geolocation doctor
+```
+
+The command checks:
+
+- a readable app `package.json`;
+- React Native 0.75 or newer;
+- a declared `react-native-nitro-modules` dependency;
+- Android New Architecture configuration;
+- Android coarse and fine location permissions; and
+- the iOS `NSLocationWhenInUseUsageDescription` value.
+
+Each failure includes a remediation. The process exits with status `1` when
+configuration errors are present and `0` when the project has only passes or
+warnings. Missing generated `ios` or `android` directories are warnings because
+an Expo prebuild or another native generation step may not have run yet. Rerun
+the command after generating them to complete the native checks.
+
+## CI and monorepos
+
+Use `--project` when the app is not the current directory and `--json` for
+machine-readable output:
+
+```bash
+nitro-geolocation doctor --project apps/mobile --json
+```
+
+The JSON report contains `ok`, `project`, `summary`, and the complete `checks`
+array. Do not treat warnings as proof that native setup is complete; they are a
+signal to rerun the doctor when the native project exists.
+
+## Scope
+
+The doctor validates install-time prerequisites that can be determined from
+project files. It does not request device permissions, start location updates,
+or prove that a signed native build can receive a position. Keep device-level
+happy-path and denial tests in the app's own E2E suite.

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -42,6 +42,16 @@ This package requires native Nitro bindings. Expo Go is not supported. For Expo
 apps, use prebuild, a development build, or another custom native build flow;
 see the [Expo development build guide](/guide/expo-development-build).
 
+After configuring the native projects, run the read-only install doctor:
+
+```bash
+yarn nitro-geolocation doctor
+```
+
+It reports dependency, architecture, and permission setup errors without
+editing the app. See the [Install Doctor guide](/guide/install-doctor) for CI,
+monorepo, and JSON output options.
+
 
 ## 2. iOS Setup
 

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -157,6 +157,17 @@ for iOS and read the
 [Swift Package Manager guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
 before migrating an RN 0.87 app.
 
+After configuring the native projects, inspect the installation without
+changing any files:
+
+```bash
+yarn nitro-geolocation doctor
+```
+
+Use `nitro-geolocation doctor --project apps/mobile --json` for monorepos or
+CI. Missing generated native folders are warnings; rerun it after native
+generation to verify permissions and usage descriptions.
+
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
 downloads the release XCFramework. If the prebuilt asset is unavailable, the

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -6,6 +6,9 @@
   "source": "src/index",
   "browser": "src/index.web.tsx",
   "react-native": "src/index.tsx",
+  "bin": {
+    "nitro-geolocation": "scripts/doctor.mjs"
+  },
   "exports": {
     ".": {
       "types": "./src/index.tsx",
@@ -63,6 +66,7 @@
     "src",
     "nitrogen",
     "scripts/*.rb",
+    "scripts/*.mjs",
     "android/build.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",

--- a/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
@@ -1,0 +1,247 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const MINIMUM_REACT_NATIVE = { major: 0, minor: 75 };
+
+function check(code, status, message, remediation) {
+  return { code, status, message, ...(remediation ? { remediation } : {}) };
+}
+
+function readText(file) {
+  try {
+    return readFileSync(file, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function declaredDependency(packageJson, name) {
+  for (const section of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies"
+  ]) {
+    const version = packageJson[section]?.[name];
+    if (typeof version === "string") return version;
+  }
+  return undefined;
+}
+
+function reactNativeVersionStatus(version) {
+  const match = version?.match(/(?:^|[^\d])(\d+)\.(\d+)(?:\.\d+)?/);
+  if (!match) return "unknown";
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  if (
+    major > MINIMUM_REACT_NATIVE.major ||
+    (major === MINIMUM_REACT_NATIVE.major &&
+      minor >= MINIMUM_REACT_NATIVE.minor)
+  ) {
+    return "supported";
+  }
+  return "unsupported";
+}
+
+function findInfoPlists(directory, depth = 0) {
+  if (depth > 4 || !existsSync(directory)) return [];
+
+  const results = [];
+
+  for (const entry of readdirSync(directory)) {
+    if (["build", "Pods", ".git"].includes(entry)) continue;
+    const candidate = path.join(directory, entry);
+    let metadata;
+    try {
+      metadata = statSync(candidate);
+    } catch {
+      continue;
+    }
+    if (metadata.isFile() && entry === "Info.plist") results.push(candidate);
+    if (metadata.isDirectory()) {
+      results.push(...findInfoPlists(candidate, depth + 1));
+    }
+  }
+  return results;
+}
+
+function inspectAndroid(project, checks) {
+  const android = path.join(project, "android");
+  if (!existsSync(android)) {
+    checks.push(
+      check(
+        "android-project",
+        "warning",
+        "No generated android directory was found.",
+        "Run the native prebuild first, then rerun the doctor to verify Android configuration."
+      )
+    );
+    return;
+  }
+
+  const properties = readText(path.join(android, "gradle.properties")) ?? "";
+  const newArchitectureDisabled = /^\s*newArchEnabled\s*=\s*false\s*$/im.test(
+    properties
+  );
+  checks.push(
+    newArchitectureDisabled
+      ? check(
+          "android-new-architecture",
+          "error",
+          "Android explicitly disables React Native's New Architecture.",
+          "Set newArchEnabled=true in android/gradle.properties and rebuild the app."
+        )
+      : check(
+          "android-new-architecture",
+          "pass",
+          "Android does not disable React Native's New Architecture."
+        )
+  );
+
+  const manifest =
+    readText(path.join(android, "app/src/main/AndroidManifest.xml")) ?? "";
+  for (const permission of ["COARSE", "FINE"]) {
+    const name = `android.permission.ACCESS_${permission}_LOCATION`;
+    const code = `android-permission-${permission.toLowerCase()}`;
+    checks.push(
+      manifest.includes(name)
+        ? check(code, "pass", `${name} is declared.`)
+        : check(
+            code,
+            "error",
+            `${name} is missing from the app manifest.`,
+            `Add <uses-permission android:name="${name}" /> to android/app/src/main/AndroidManifest.xml.`
+          )
+    );
+  }
+}
+
+function inspectIos(project, checks) {
+  const ios = path.join(project, "ios");
+  if (!existsSync(ios)) {
+    checks.push(
+      check(
+        "ios-project",
+        "warning",
+        "No generated ios directory was found.",
+        "Run the native prebuild first, then rerun the doctor to verify iOS configuration."
+      )
+    );
+    return;
+  }
+
+  const infoPlists = findInfoPlists(ios);
+  const hasDescription = infoPlists.some((infoPlist) =>
+    readText(infoPlist)?.includes("NSLocationWhenInUseUsageDescription")
+  );
+  checks.push(
+    hasDescription
+      ? check(
+          "ios-when-in-use-description",
+          "pass",
+          "NSLocationWhenInUseUsageDescription is configured."
+        )
+      : check(
+          "ios-when-in-use-description",
+          "error",
+          "NSLocationWhenInUseUsageDescription is missing from the app Info.plist.",
+          "Add a user-facing NSLocationWhenInUseUsageDescription string to the app target's Info.plist."
+        )
+  );
+}
+
+export function inspectProject(projectPath) {
+  const project = path.resolve(projectPath);
+  const checks = [];
+  const packageJsonPath = path.join(project, "package.json");
+  let packageJson;
+
+  try {
+    packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    checks.push(
+      check("project-package", "pass", "Project package.json is readable.")
+    );
+  } catch {
+    checks.push(
+      check(
+        "project-package",
+        "error",
+        `Could not read a valid package.json at ${packageJsonPath}.`,
+        "Pass --project with the React Native app root and fix any package.json syntax errors."
+      )
+    );
+    return createReport(project, checks);
+  }
+
+  const reactNative = declaredDependency(packageJson, "react-native");
+  const versionStatus = reactNativeVersionStatus(reactNative);
+  if (versionStatus === "supported") {
+    checks.push(
+      check(
+        "react-native-version",
+        "pass",
+        `React Native ${reactNative} satisfies the 0.75+ requirement.`
+      )
+    );
+  } else if (versionStatus === "unsupported") {
+    checks.push(
+      check(
+        "react-native-version",
+        "error",
+        `React Native ${reactNative} is below the supported 0.75+ range.`,
+        "Upgrade React Native to 0.75 or newer before installing Nitro Geolocation."
+      )
+    );
+  } else {
+    checks.push(
+      check(
+        "react-native-version",
+        "warning",
+        reactNative
+          ? `Could not determine the React Native version from ${reactNative}.`
+          : "react-native is not declared in package.json.",
+        "Declare a concrete React Native 0.75+ version and rerun the doctor."
+      )
+    );
+  }
+
+  const nitro = declaredDependency(packageJson, "react-native-nitro-modules");
+  checks.push(
+    nitro
+      ? check(
+          "nitro-modules-dependency",
+          "pass",
+          `react-native-nitro-modules ${nitro} is declared.`
+        )
+      : check(
+          "nitro-modules-dependency",
+          "error",
+          "react-native-nitro-modules is not declared.",
+          "Install react-native-nitro-modules alongside react-native-nitro-geolocation."
+        )
+  );
+
+  inspectAndroid(project, checks);
+  inspectIos(project, checks);
+  return createReport(project, checks);
+}
+
+function createReport(project, checks) {
+  const summary = { pass: 0, warning: 0, error: 0 };
+  for (const item of checks) summary[item.status] += 1;
+  return { ok: summary.error === 0, project, summary, checks };
+}
+
+export function formatReport(report) {
+  const marker = { pass: "PASS", warning: "WARN", error: "FAIL" };
+  const lines = [`Nitro Geolocation doctor: ${report.project}`, ""];
+  for (const item of report.checks) {
+    lines.push(`[${marker[item.status]}] ${item.message}`);
+    if (item.remediation) lines.push(`       ${item.remediation}`);
+  }
+  lines.push(
+    "",
+    `${report.summary.pass} passed, ${report.summary.warning} warnings, ${report.summary.error} errors`
+  );
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
@@ -154,6 +154,13 @@ function parsePbxObjects(contents) {
   const lines = contents.split(/\r?\n/);
   const objects = new Map();
   for (let index = 0; index < lines.length; index += 1) {
+    const inline = lines[index].match(
+      /^\s*([A-F0-9]{24})(?: \/\*.*\*\/)? = \{(.*)\};\s*$/
+    );
+    if (inline) {
+      objects.set(inline[1], inline[2]);
+      continue;
+    }
     const start = lines[index].match(
       /^(\s+)([A-F0-9]{24})(?: \/\*.*\*\/)? = \{\s*$/
     );
@@ -171,24 +178,18 @@ function parsePbxObjects(contents) {
 
 function buildSetting(block, name) {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = block.match(
-    new RegExp(`^\\s*${escapedName}\\s*=\\s*(.*);\\s*$`, "m")
-  );
-  if (!match) return undefined;
-  const value = match[1].trim();
+  const matches = [
+    ...block.matchAll(new RegExp(`\\b${escapedName}\\s*=\\s*([^;{}]*);`, "g"))
+  ];
+  const value = matches.at(-1)?.[1].trim();
+  if (value === undefined) return undefined;
   if (value.startsWith('"') && value.endsWith('"')) return value.slice(1, -1);
   return value;
 }
 
-function resolvedBuildSetting(
-  block,
-  name,
-  builtIns = {},
-  resolving = new Set()
-) {
-  if (builtIns[name] !== undefined) return builtIns[name];
+function resolvedBuildSetting(settings, name, resolving = new Set()) {
   if (resolving.has(name)) return undefined;
-  const raw = buildSetting(block, name);
+  const raw = settings.get(name);
   if (raw === undefined) return undefined;
   resolving.add(name);
   let unresolved = false;
@@ -196,16 +197,7 @@ function resolvedBuildSetting(
     /\$\(([^)]+)\)|\$\{([^}]+)\}/g,
     (_, first, second) => {
       const variable = String(first ?? second).split(":", 1)[0];
-      if (variable === "inherited") {
-        unresolved = true;
-        return "";
-      }
-      const replacement = resolvedBuildSetting(
-        block,
-        variable,
-        builtIns,
-        resolving
-      );
+      const replacement = resolvedBuildSetting(settings, variable, resolving);
       if (replacement === undefined) {
         unresolved = true;
         return "";
@@ -227,36 +219,91 @@ function configurationList(objects, listId) {
   });
 }
 
-function readXcconfig(file, visited = new Set()) {
-  if (visited.has(file)) return "";
-  visited.add(file);
+function readXcconfig(file, visiting = new Set()) {
+  if (visiting.has(file)) return [];
+  visiting.add(file);
   const contents = readText(file);
-  if (!contents) return "";
+  if (!contents) {
+    visiting.delete(file);
+    return [];
+  }
   const settings = [];
   for (const rawLine of contents.split(/\r?\n/)) {
     const line = rawLine.replace(/\/\/.*$/, "").trim();
     const include = line.match(/^#include\??\s+["<](.*)[">]$/);
     if (include) {
       settings.push(
-        readXcconfig(path.resolve(path.dirname(file), include[1]), visited)
+        ...readXcconfig(path.resolve(path.dirname(file), include[1]), visiting)
       );
       continue;
     }
-    const setting = line.match(/^([A-Za-z0-9_.]+)\s*(?:\?=|=)\s*(.*?)\s*$/);
-    if (setting) settings.push(`${setting[1]} = ${setting[2]};`);
+    const setting = line.match(/^([A-Za-z0-9_.]+)\s*(\?=|=)\s*(.*?)\s*$/);
+    if (setting) {
+      settings.push({
+        name: setting[1],
+        operator: setting[2],
+        value: setting[3]
+      });
+    }
   }
-  return settings.join("\n");
+  visiting.delete(file);
+  return settings;
+}
+
+function pbxAssignments(block) {
+  return [...block.matchAll(/\b([A-Za-z0-9_.]+)\s*=\s*([^;{}]*);/g)].map(
+    (match) => ({ name: match[1], operator: "=", value: match[2].trim() })
+  );
+}
+
+function applyAssignments(settings, assignments) {
+  for (const assignment of assignments) {
+    if (assignment.operator === "?=" && settings.has(assignment.name)) continue;
+    const inherited = settings.get(assignment.name) ?? "";
+    let value = assignment.value.trim();
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+    value = value.replace(/\$\(inherited\)|\$\{inherited\}/g, inherited);
+    settings.set(assignment.name, value);
+  }
+}
+
+function effectiveBuildSettings(layers, builtIns) {
+  const settings = new Map(Object.entries(builtIns));
+  for (const assignments of layers) applyAssignments(settings, assignments);
+  return settings;
+}
+
+function objectRelativePath(objects, identifier, visiting = new Set()) {
+  if (visiting.has(identifier)) return undefined;
+  visiting.add(identifier);
+  const block = objects.get(identifier);
+  if (!block) return undefined;
+  const isGroup = block.includes("isa = PBXGroup;");
+  const ownPath =
+    buildSetting(block, "path") ?? (isGroup ? "" : buildSetting(block, "name"));
+  if (ownPath === undefined) return undefined;
+  const sourceTree = buildSetting(block, "sourceTree");
+  if (sourceTree === "SOURCE_ROOT" || path.isAbsolute(ownPath)) return ownPath;
+  const parent = [...objects.entries()].find(
+    ([, candidate]) =>
+      candidate.includes("isa = PBXGroup;") &&
+      new RegExp(`(?:\\(|,)\\s*${identifier}(?:\\s|,|\\))`).test(candidate)
+  )?.[0];
+  if (!parent) return ownPath;
+  const parentPath = objectRelativePath(objects, parent, visiting) ?? "";
+  return parentPath ? path.join(parentPath, ownPath) : ownPath;
 }
 
 function xcconfigSettings(pbxproj, objects, configuration) {
   const reference = configuration.match(
     /baseConfigurationReference = ([A-F0-9]{24})/
   )?.[1];
-  const fileReference = reference ? objects.get(reference) : undefined;
-  const configuredPath = fileReference
-    ? buildSetting(fileReference, "path")
+  const configuredPath = reference
+    ? objectRelativePath(objects, reference)
     : undefined;
-  if (!configuredPath) return "";
+  if (!configuredPath) return [];
   return readXcconfig(
     path.resolve(path.dirname(path.dirname(pbxproj)), configuredPath)
   );
@@ -289,22 +336,27 @@ function applicationBuildConfigurations(pbxproj) {
       const projectConfiguration = projectConfigurations.find(
         (candidate) => candidate.name === configuration.name
       );
+      const builtIns = {
+        SRCROOT: projectDirectory,
+        PROJECT_DIR: projectDirectory,
+        TARGET_NAME: targetName,
+        PRODUCT_NAME: targetName,
+        EXECUTABLE_NAME: targetName
+      };
       configurations.push({
-        settings: [
-          configuration.block,
-          xcconfigSettings(pbxproj, objects, configuration.block),
-          projectConfiguration?.block ?? "",
-          projectConfiguration
-            ? xcconfigSettings(pbxproj, objects, projectConfiguration.block)
-            : ""
-        ].join("\n"),
-        builtIns: {
-          SRCROOT: projectDirectory,
-          PROJECT_DIR: projectDirectory,
-          TARGET_NAME: targetName,
-          PRODUCT_NAME: targetName,
-          EXECUTABLE_NAME: targetName
-        }
+        settings: effectiveBuildSettings(
+          [
+            projectConfiguration
+              ? xcconfigSettings(pbxproj, objects, projectConfiguration.block)
+              : [],
+            projectConfiguration
+              ? pbxAssignments(projectConfiguration.block)
+              : [],
+            xcconfigSettings(pbxproj, objects, configuration.block),
+            pbxAssignments(configuration.block)
+          ],
+          builtIns
+        )
       });
     }
   }
@@ -338,13 +390,11 @@ function inspectApplicationPlists(ios) {
       const generatesInfoPlist =
         resolvedBuildSetting(
           configuration.settings,
-          "GENERATE_INFOPLIST_FILE",
-          configuration.builtIns
+          "GENERATE_INFOPLIST_FILE"
         )?.toUpperCase() === "YES";
       const generatedDescription = resolvedBuildSetting(
         configuration.settings,
-        "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription",
-        configuration.builtIns
+        "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription"
       );
       if (generatesInfoPlist && generatedDescription?.trim()) {
         results.push(true);
@@ -352,8 +402,7 @@ function inspectApplicationPlists(ios) {
       }
       const setting = resolvedBuildSetting(
         configuration.settings,
-        "INFOPLIST_FILE",
-        configuration.builtIns
+        "INFOPLIST_FILE"
       );
       const infoPlist = setting
         ? resolveInfoPlist(pbxproj, setting)

--- a/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
@@ -81,18 +81,9 @@ function activeAndroidPermission(manifest, name) {
     const removesNode = /\btools:node\s*=\s*["'](?:remove|removeAll)["']/i.test(
       tag
     );
-    return declaresName && !removesNode;
+    const limitsSdk = /\bandroid:maxSdkVersion\s*=/i.test(tag);
+    return declaresName && !removesNode && !limitsSdk;
   });
-}
-
-function mergedAndroidManifests(android) {
-  const intermediates = path.join(android, "app/build/intermediates");
-  if (!existsSync(intermediates)) return [];
-  return readdirSync(intermediates)
-    .filter((entry) => /merged_manifest|packaged_manifest/.test(entry))
-    .flatMap((entry) =>
-      findFiles(path.join(intermediates, entry), "AndroidManifest.xml", 0, 8)
-    );
 }
 
 function inspectAndroid(project, checks, reactNativeVersion) {
@@ -111,57 +102,36 @@ function inspectAndroid(project, checks, reactNativeVersion) {
 
   const properties = readText(path.join(android, "gradle.properties")) ?? "";
   const architectureValues = [
-    ...properties.matchAll(/^\s*newArchEnabled\s*=\s*(true|false)\s*$/gim)
-  ];
-  const configuredArchitecture = architectureValues.at(-1)?.[1].toLowerCase();
-  const defaultArchitectureEnabled =
-    reactNativeVersion &&
-    (reactNativeVersion.major > 0 || reactNativeVersion.minor >= 76);
+    ...properties.matchAll(
+      /^\s*(?:react\.)?newArchEnabled\s*=\s*(true|false)\s*$/gim
+    )
+  ].map((match) => match[1].toLowerCase());
+  const architectureEnabled =
+    architectureValues.length > 0 &&
+    architectureValues.every((value) => value === "true");
   checks.push(
-    configuredArchitecture === "false"
+    architectureEnabled
       ? check(
           "android-new-architecture",
-          "error",
-          "Android explicitly disables React Native's New Architecture.",
-          "Set newArchEnabled=true in android/gradle.properties and rebuild the app."
+          "pass",
+          "Android enables React Native's New Architecture."
         )
-      : configuredArchitecture === "true"
-        ? check(
-            "android-new-architecture",
-            "pass",
-            "Android enables React Native's New Architecture."
-          )
-        : defaultArchitectureEnabled
-          ? check(
-              "android-new-architecture",
-              "pass",
-              "React Native 0.76+ enables the New Architecture by default and Android does not override it."
-            )
-          : check(
-              "android-new-architecture",
-              "error",
-              "Android does not explicitly enable React Native's New Architecture for this React Native version.",
-              "Set newArchEnabled=true in android/gradle.properties and rebuild the app."
-            )
+      : check(
+          "android-new-architecture",
+          "error",
+          `Android does not explicitly enable React Native's New Architecture${reactNativeVersion ? ` for React Native ${reactNativeVersion.major}.${reactNativeVersion.minor}` : ""}.`,
+          "Set newArchEnabled=true or react.newArchEnabled=true in android/gradle.properties, remove conflicting false values, and rebuild the app."
+        )
   );
 
   const sourceManifest = path.join(android, "app/src/main/AndroidManifest.xml");
-  const mergedManifests = mergedAndroidManifests(android);
-  const manifestFiles =
-    mergedManifests.length > 0 ? mergedManifests : [sourceManifest];
+  const manifest = readText(sourceManifest) ?? "";
   for (const permission of ["COARSE", "FINE"]) {
     const name = `android.permission.ACCESS_${permission}_LOCATION`;
     const code = `android-permission-${permission.toLowerCase()}`;
-    const missingFrom = manifestFiles.filter(
-      (file) => !activeAndroidPermission(readText(file) ?? "", name)
-    );
     checks.push(
-      missingFrom.length === 0
-        ? check(
-            code,
-            "pass",
-            `${name} is active in the app manifest${manifestFiles.length > 1 ? "s" : ""}.`
-          )
+      activeAndroidPermission(manifest, name)
+        ? check(code, "pass", `${name} is active in the main app manifest.`)
         : check(
             code,
             "error",
@@ -200,6 +170,37 @@ function buildSetting(block, name) {
   const value = match[1].trim();
   if (value.startsWith('"') && value.endsWith('"')) return value.slice(1, -1);
   return value;
+}
+
+function resolvedBuildSetting(block, name, resolving = new Set()) {
+  if (resolving.has(name)) return undefined;
+  const raw = buildSetting(block, name);
+  if (raw === undefined) return undefined;
+  resolving.add(name);
+  let unresolved = false;
+  const value = raw.replace(
+    /\$\(([^)]+)\)|\$\{([^}]+)\}/g,
+    (_, first, second) => {
+      const variable = String(first ?? second).split(":", 1)[0];
+      if (
+        ["PRODUCT_NAME", "TARGET_NAME", "EXECUTABLE_NAME"].includes(variable)
+      ) {
+        return variable;
+      }
+      if (variable === "inherited") {
+        unresolved = true;
+        return "";
+      }
+      const replacement = resolvedBuildSetting(block, variable, resolving);
+      if (replacement === undefined) {
+        unresolved = true;
+        return "";
+      }
+      return replacement;
+    }
+  );
+  resolving.delete(name);
+  return unresolved ? undefined : value;
 }
 
 function applicationBuildConfigurations(pbxproj) {
@@ -252,11 +253,16 @@ function inspectApplicationPlists(ios) {
   const results = [];
   for (const pbxproj of pbxprojects) {
     for (const configuration of applicationBuildConfigurations(pbxproj)) {
-      const generatedDescription = buildSetting(
+      const generatesInfoPlist =
+        resolvedBuildSetting(
+          configuration,
+          "GENERATE_INFOPLIST_FILE"
+        )?.toUpperCase() === "YES";
+      const generatedDescription = resolvedBuildSetting(
         configuration,
         "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription"
       );
-      if (generatedDescription?.trim()) {
+      if (generatesInfoPlist && generatedDescription?.trim()) {
         results.push(true);
         continue;
       }
@@ -331,7 +337,8 @@ export function inspectProject(projectPath) {
     return createReport(project, checks);
   }
 
-  const reactNative = declaredDependency(packageJson, "react-native");
+  const declaredReactNative = declaredDependency(packageJson, "react-native");
+  const reactNative = resolveReactNativeVersion(project, declaredReactNative);
   const versionStatus = reactNativeVersionStatus(reactNative);
   if (versionStatus === "supported") {
     checks.push(
@@ -355,8 +362,8 @@ export function inspectProject(projectPath) {
       check(
         "react-native-version",
         "warning",
-        reactNative
-          ? `Could not determine the React Native version from ${reactNative}.`
+        declaredReactNative
+          ? `Could not determine the React Native version from ${declaredReactNative}.`
           : "react-native is not declared in package.json.",
         "Declare a concrete React Native 0.75+ version and rerun the doctor."
       )
@@ -382,6 +389,29 @@ export function inspectProject(projectPath) {
   inspectAndroid(project, checks, parseReactNativeVersion(reactNative));
   inspectIos(project, checks);
   return createReport(project, checks);
+}
+
+function resolveReactNativeVersion(project, declaredVersion) {
+  if (parseReactNativeVersion(declaredVersion)) return declaredVersion;
+
+  let directory = project;
+  for (let depth = 0; depth < 6; depth += 1) {
+    const installedPackage = readText(
+      path.join(directory, "node_modules/react-native/package.json")
+    );
+    if (installedPackage) {
+      try {
+        const version = JSON.parse(installedPackage).version;
+        if (typeof version === "string") return version;
+      } catch {
+        return declaredVersion;
+      }
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return declaredVersion;
 }
 
 function createReport(project, checks) {

--- a/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
@@ -29,10 +29,9 @@ function declaredDependency(packageJson, name) {
 }
 
 function reactNativeVersionStatus(version) {
-  const match = version?.match(/(?:^|[^\d])(\d+)\.(\d+)(?:\.\d+)?/);
-  if (!match) return "unknown";
-  const major = Number(match[1]);
-  const minor = Number(match[2]);
+  const parsed = parseReactNativeVersion(version);
+  if (!parsed) return "unknown";
+  const { major, minor } = parsed;
   if (
     major > MINIMUM_REACT_NATIVE.major ||
     (major === MINIMUM_REACT_NATIVE.major &&
@@ -43,11 +42,16 @@ function reactNativeVersionStatus(version) {
   return "unsupported";
 }
 
-function findInfoPlists(directory, depth = 0) {
-  if (depth > 4 || !existsSync(directory)) return [];
+function parseReactNativeVersion(version) {
+  const match = version?.match(/(?:^|[^\d])(\d+)\.(\d+)(?:\.\d+)?/);
+  if (!match) return undefined;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function findFiles(directory, fileName, depth = 0, maxDepth = 6) {
+  if (depth > maxDepth || !existsSync(directory)) return [];
 
   const results = [];
-
   for (const entry of readdirSync(directory)) {
     if (["build", "Pods", ".git"].includes(entry)) continue;
     const candidate = path.join(directory, entry);
@@ -57,15 +61,41 @@ function findInfoPlists(directory, depth = 0) {
     } catch {
       continue;
     }
-    if (metadata.isFile() && entry === "Info.plist") results.push(candidate);
+    if (metadata.isFile() && entry === fileName) results.push(candidate);
     if (metadata.isDirectory()) {
-      results.push(...findInfoPlists(candidate, depth + 1));
+      results.push(...findFiles(candidate, fileName, depth + 1, maxDepth));
     }
   }
   return results;
 }
 
-function inspectAndroid(project, checks) {
+function activeAndroidPermission(manifest, name) {
+  const withoutComments = manifest.replace(/<!--[\s\S]*?-->/g, "");
+  const tags =
+    withoutComments.match(/<uses-permission(?:-sdk-\d+)?\b[^>]*>/gi) ?? [];
+  return tags.some((tag) => {
+    const declaresName = new RegExp(
+      `\\bandroid:name\\s*=\\s*["']${name.replaceAll(".", "\\.")}["']`,
+      "i"
+    ).test(tag);
+    const removesNode = /\btools:node\s*=\s*["'](?:remove|removeAll)["']/i.test(
+      tag
+    );
+    return declaresName && !removesNode;
+  });
+}
+
+function mergedAndroidManifests(android) {
+  const intermediates = path.join(android, "app/build/intermediates");
+  if (!existsSync(intermediates)) return [];
+  return readdirSync(intermediates)
+    .filter((entry) => /merged_manifest|packaged_manifest/.test(entry))
+    .flatMap((entry) =>
+      findFiles(path.join(intermediates, entry), "AndroidManifest.xml", 0, 8)
+    );
+}
+
+function inspectAndroid(project, checks, reactNativeVersion) {
   const android = path.join(project, "android");
   if (!existsSync(android)) {
     checks.push(
@@ -80,32 +110,58 @@ function inspectAndroid(project, checks) {
   }
 
   const properties = readText(path.join(android, "gradle.properties")) ?? "";
-  const newArchitectureDisabled = /^\s*newArchEnabled\s*=\s*false\s*$/im.test(
-    properties
-  );
+  const architectureValues = [
+    ...properties.matchAll(/^\s*newArchEnabled\s*=\s*(true|false)\s*$/gim)
+  ];
+  const configuredArchitecture = architectureValues.at(-1)?.[1].toLowerCase();
+  const defaultArchitectureEnabled =
+    reactNativeVersion &&
+    (reactNativeVersion.major > 0 || reactNativeVersion.minor >= 76);
   checks.push(
-    newArchitectureDisabled
+    configuredArchitecture === "false"
       ? check(
           "android-new-architecture",
           "error",
           "Android explicitly disables React Native's New Architecture.",
           "Set newArchEnabled=true in android/gradle.properties and rebuild the app."
         )
-      : check(
-          "android-new-architecture",
-          "pass",
-          "Android does not disable React Native's New Architecture."
-        )
+      : configuredArchitecture === "true"
+        ? check(
+            "android-new-architecture",
+            "pass",
+            "Android enables React Native's New Architecture."
+          )
+        : defaultArchitectureEnabled
+          ? check(
+              "android-new-architecture",
+              "pass",
+              "React Native 0.76+ enables the New Architecture by default and Android does not override it."
+            )
+          : check(
+              "android-new-architecture",
+              "error",
+              "Android does not explicitly enable React Native's New Architecture for this React Native version.",
+              "Set newArchEnabled=true in android/gradle.properties and rebuild the app."
+            )
   );
 
-  const manifest =
-    readText(path.join(android, "app/src/main/AndroidManifest.xml")) ?? "";
+  const sourceManifest = path.join(android, "app/src/main/AndroidManifest.xml");
+  const mergedManifests = mergedAndroidManifests(android);
+  const manifestFiles =
+    mergedManifests.length > 0 ? mergedManifests : [sourceManifest];
   for (const permission of ["COARSE", "FINE"]) {
     const name = `android.permission.ACCESS_${permission}_LOCATION`;
     const code = `android-permission-${permission.toLowerCase()}`;
+    const missingFrom = manifestFiles.filter(
+      (file) => !activeAndroidPermission(readText(file) ?? "", name)
+    );
     checks.push(
-      manifest.includes(name)
-        ? check(code, "pass", `${name} is declared.`)
+      missingFrom.length === 0
+        ? check(
+            code,
+            "pass",
+            `${name} is active in the app manifest${manifestFiles.length > 1 ? "s" : ""}.`
+          )
         : check(
             code,
             "error",
@@ -114,6 +170,106 @@ function inspectAndroid(project, checks) {
           )
     );
   }
+}
+
+function parsePbxObjects(contents) {
+  const lines = contents.split(/\r?\n/);
+  const objects = new Map();
+  for (let index = 0; index < lines.length; index += 1) {
+    const start = lines[index].match(
+      /^(\s+)([A-F0-9]{24})(?: \/\*.*\*\/)? = \{\s*$/
+    );
+    if (!start) continue;
+    const [, indentation, identifier] = start;
+    const body = [];
+    for (index += 1; index < lines.length; index += 1) {
+      if (lines[index] === `${indentation}};`) break;
+      body.push(lines[index]);
+    }
+    objects.set(identifier, body.join("\n"));
+  }
+  return objects;
+}
+
+function buildSetting(block, name) {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = block.match(
+    new RegExp(`^\\s*${escapedName}\\s*=\\s*(.*);\\s*$`, "m")
+  );
+  if (!match) return undefined;
+  const value = match[1].trim();
+  if (value.startsWith('"') && value.endsWith('"')) return value.slice(1, -1);
+  return value;
+}
+
+function applicationBuildConfigurations(pbxproj) {
+  const contents = readText(pbxproj);
+  if (!contents) return [];
+  const objects = parsePbxObjects(contents);
+  const configurations = [];
+
+  for (const target of objects.values()) {
+    if (
+      !target.includes("isa = PBXNativeTarget;") ||
+      !target.includes('productType = "com.apple.product-type.application";')
+    ) {
+      continue;
+    }
+    const listId = target.match(/buildConfigurationList = ([A-F0-9]{24})/)?.[1];
+    const list = listId ? objects.get(listId) : undefined;
+    const ids = list?.match(/[A-F0-9]{24}/g) ?? [];
+    for (const identifier of ids) {
+      const configuration = objects.get(identifier);
+      if (configuration?.includes("isa = XCBuildConfiguration;")) {
+        configurations.push(configuration);
+      }
+    }
+  }
+  return configurations;
+}
+
+function resolveInfoPlist(pbxproj, setting) {
+  let relative = setting
+    .replace(/^\$\((?:SRCROOT|PROJECT_DIR)\)\/?/, "")
+    .replace(/^\$\{(?:SRCROOT|PROJECT_DIR)\}\/?/, "");
+  if (relative.includes("$(") || relative.includes("${")) return undefined;
+  if (path.isAbsolute(relative)) return relative;
+  relative = relative.replace(/^\.\//, "");
+  return path.resolve(path.dirname(path.dirname(pbxproj)), relative);
+}
+
+function nonEmptyUsageDescription(contents) {
+  if (!contents) return false;
+  const withoutComments = contents.replace(/<!--[\s\S]*?-->/g, "");
+  const match = withoutComments.match(
+    /<key>\s*NSLocationWhenInUseUsageDescription\s*<\/key>\s*<string>([\s\S]*?)<\/string>/i
+  );
+  return Boolean(match?.[1].trim());
+}
+
+function inspectApplicationPlists(ios) {
+  const pbxprojects = findFiles(ios, "project.pbxproj", 0, 3);
+  const results = [];
+  for (const pbxproj of pbxprojects) {
+    for (const configuration of applicationBuildConfigurations(pbxproj)) {
+      const generatedDescription = buildSetting(
+        configuration,
+        "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription"
+      );
+      if (generatedDescription?.trim()) {
+        results.push(true);
+        continue;
+      }
+      const setting = buildSetting(configuration, "INFOPLIST_FILE");
+      const infoPlist = setting
+        ? resolveInfoPlist(pbxproj, setting)
+        : undefined;
+      results.push(
+        nonEmptyUsageDescription(infoPlist ? readText(infoPlist) : undefined)
+      );
+    }
+  }
+  return results;
 }
 
 function inspectIos(project, checks) {
@@ -130,10 +286,10 @@ function inspectIos(project, checks) {
     return;
   }
 
-  const infoPlists = findInfoPlists(ios);
-  const hasDescription = infoPlists.some((infoPlist) =>
-    readText(infoPlist)?.includes("NSLocationWhenInUseUsageDescription")
-  );
+  const applicationResults = inspectApplicationPlists(ios);
+  const hasResolvedApplication = applicationResults.length > 0;
+  const hasDescription =
+    hasResolvedApplication && applicationResults.every((result) => result);
   checks.push(
     hasDescription
       ? check(
@@ -144,8 +300,10 @@ function inspectIos(project, checks) {
       : check(
           "ios-when-in-use-description",
           "error",
-          "NSLocationWhenInUseUsageDescription is missing from the app Info.plist.",
-          "Add a user-facing NSLocationWhenInUseUsageDescription string to the app target's Info.plist."
+          hasResolvedApplication
+            ? "A non-empty NSLocationWhenInUseUsageDescription is missing from an app target build configuration."
+            : "Could not resolve an application target Info.plist or generated usage-description setting.",
+          "Set a user-facing NSLocationWhenInUseUsageDescription for every app target build configuration."
         )
   );
 }
@@ -221,7 +379,7 @@ export function inspectProject(projectPath) {
         )
   );
 
-  inspectAndroid(project, checks);
+  inspectAndroid(project, checks, parseReactNativeVersion(reactNative));
   inspectIos(project, checks);
   return createReport(project, checks);
 }

--- a/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor-core.mjs
@@ -101,14 +101,22 @@ function inspectAndroid(project, checks, reactNativeVersion) {
   }
 
   const properties = readText(path.join(android, "gradle.properties")) ?? "";
-  const architectureValues = [
-    ...properties.matchAll(
-      /^\s*(?:react\.)?newArchEnabled\s*=\s*(true|false)\s*$/gim
-    )
-  ].map((match) => match[1].toLowerCase());
+  function effectiveBooleanProperty(name) {
+    const values = [
+      ...properties.matchAll(
+        new RegExp(
+          `^\\s*${name.replace(".", "\\.")}\\s*=\\s*(true|false)\\s*$`,
+          "gim"
+        )
+      )
+    ];
+    const environment = process.env[`ORG_GRADLE_PROJECT_${name}`];
+    const value = environment ?? values.at(-1)?.[1];
+    return value?.toLowerCase() === "true";
+  }
   const architectureEnabled =
-    architectureValues.length > 0 &&
-    architectureValues.every((value) => value === "true");
+    effectiveBooleanProperty("newArchEnabled") ||
+    effectiveBooleanProperty("react.newArchEnabled");
   checks.push(
     architectureEnabled
       ? check(
@@ -120,7 +128,7 @@ function inspectAndroid(project, checks, reactNativeVersion) {
           "android-new-architecture",
           "error",
           `Android does not explicitly enable React Native's New Architecture${reactNativeVersion ? ` for React Native ${reactNativeVersion.major}.${reactNativeVersion.minor}` : ""}.`,
-          "Set newArchEnabled=true or react.newArchEnabled=true in android/gradle.properties, remove conflicting false values, and rebuild the app."
+          "Set newArchEnabled=true or react.newArchEnabled=true in android/gradle.properties (or the matching ORG_GRADLE_PROJECT_ environment variable) and rebuild the app."
         )
   );
 
@@ -172,7 +180,13 @@ function buildSetting(block, name) {
   return value;
 }
 
-function resolvedBuildSetting(block, name, resolving = new Set()) {
+function resolvedBuildSetting(
+  block,
+  name,
+  builtIns = {},
+  resolving = new Set()
+) {
+  if (builtIns[name] !== undefined) return builtIns[name];
   if (resolving.has(name)) return undefined;
   const raw = buildSetting(block, name);
   if (raw === undefined) return undefined;
@@ -182,16 +196,16 @@ function resolvedBuildSetting(block, name, resolving = new Set()) {
     /\$\(([^)]+)\)|\$\{([^}]+)\}/g,
     (_, first, second) => {
       const variable = String(first ?? second).split(":", 1)[0];
-      if (
-        ["PRODUCT_NAME", "TARGET_NAME", "EXECUTABLE_NAME"].includes(variable)
-      ) {
-        return variable;
-      }
       if (variable === "inherited") {
         unresolved = true;
         return "";
       }
-      const replacement = resolvedBuildSetting(block, variable, resolving);
+      const replacement = resolvedBuildSetting(
+        block,
+        variable,
+        builtIns,
+        resolving
+      );
       if (replacement === undefined) {
         unresolved = true;
         return "";
@@ -203,11 +217,63 @@ function resolvedBuildSetting(block, name, resolving = new Set()) {
   return unresolved ? undefined : value;
 }
 
+function configurationList(objects, listId) {
+  const list = listId ? objects.get(listId) : undefined;
+  const ids = list?.match(/[A-F0-9]{24}/g) ?? [];
+  return ids.flatMap((identifier) => {
+    const block = objects.get(identifier);
+    if (!block?.includes("isa = XCBuildConfiguration;")) return [];
+    return [{ block, name: buildSetting(block, "name") }];
+  });
+}
+
+function readXcconfig(file, visited = new Set()) {
+  if (visited.has(file)) return "";
+  visited.add(file);
+  const contents = readText(file);
+  if (!contents) return "";
+  const settings = [];
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.replace(/\/\/.*$/, "").trim();
+    const include = line.match(/^#include\??\s+["<](.*)[">]$/);
+    if (include) {
+      settings.push(
+        readXcconfig(path.resolve(path.dirname(file), include[1]), visited)
+      );
+      continue;
+    }
+    const setting = line.match(/^([A-Za-z0-9_.]+)\s*(?:\?=|=)\s*(.*?)\s*$/);
+    if (setting) settings.push(`${setting[1]} = ${setting[2]};`);
+  }
+  return settings.join("\n");
+}
+
+function xcconfigSettings(pbxproj, objects, configuration) {
+  const reference = configuration.match(
+    /baseConfigurationReference = ([A-F0-9]{24})/
+  )?.[1];
+  const fileReference = reference ? objects.get(reference) : undefined;
+  const configuredPath = fileReference
+    ? buildSetting(fileReference, "path")
+    : undefined;
+  if (!configuredPath) return "";
+  return readXcconfig(
+    path.resolve(path.dirname(path.dirname(pbxproj)), configuredPath)
+  );
+}
+
 function applicationBuildConfigurations(pbxproj) {
   const contents = readText(pbxproj);
   if (!contents) return [];
   const objects = parsePbxObjects(contents);
   const configurations = [];
+  const project = [...objects.values()].find((block) =>
+    block.includes("isa = PBXProject;")
+  );
+  const projectListId = project?.match(
+    /buildConfigurationList = ([A-F0-9]{24})/
+  )?.[1];
+  const projectConfigurations = configurationList(objects, projectListId);
 
   for (const target of objects.values()) {
     if (
@@ -217,13 +283,29 @@ function applicationBuildConfigurations(pbxproj) {
       continue;
     }
     const listId = target.match(/buildConfigurationList = ([A-F0-9]{24})/)?.[1];
-    const list = listId ? objects.get(listId) : undefined;
-    const ids = list?.match(/[A-F0-9]{24}/g) ?? [];
-    for (const identifier of ids) {
-      const configuration = objects.get(identifier);
-      if (configuration?.includes("isa = XCBuildConfiguration;")) {
-        configurations.push(configuration);
-      }
+    const targetName = buildSetting(target, "name") ?? "App";
+    const projectDirectory = path.dirname(path.dirname(pbxproj));
+    for (const configuration of configurationList(objects, listId)) {
+      const projectConfiguration = projectConfigurations.find(
+        (candidate) => candidate.name === configuration.name
+      );
+      configurations.push({
+        settings: [
+          configuration.block,
+          xcconfigSettings(pbxproj, objects, configuration.block),
+          projectConfiguration?.block ?? "",
+          projectConfiguration
+            ? xcconfigSettings(pbxproj, objects, projectConfiguration.block)
+            : ""
+        ].join("\n"),
+        builtIns: {
+          SRCROOT: projectDirectory,
+          PROJECT_DIR: projectDirectory,
+          TARGET_NAME: targetName,
+          PRODUCT_NAME: targetName,
+          EXECUTABLE_NAME: targetName
+        }
+      });
     }
   }
   return configurations;
@@ -255,18 +337,24 @@ function inspectApplicationPlists(ios) {
     for (const configuration of applicationBuildConfigurations(pbxproj)) {
       const generatesInfoPlist =
         resolvedBuildSetting(
-          configuration,
-          "GENERATE_INFOPLIST_FILE"
+          configuration.settings,
+          "GENERATE_INFOPLIST_FILE",
+          configuration.builtIns
         )?.toUpperCase() === "YES";
       const generatedDescription = resolvedBuildSetting(
-        configuration,
-        "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription"
+        configuration.settings,
+        "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription",
+        configuration.builtIns
       );
       if (generatesInfoPlist && generatedDescription?.trim()) {
         results.push(true);
         continue;
       }
-      const setting = buildSetting(configuration, "INFOPLIST_FILE");
+      const setting = resolvedBuildSetting(
+        configuration.settings,
+        "INFOPLIST_FILE",
+        configuration.builtIns
+      );
       const infoPlist = setting
         ? resolveInfoPlist(pbxproj, setting)
         : undefined;
@@ -392,8 +480,6 @@ export function inspectProject(projectPath) {
 }
 
 function resolveReactNativeVersion(project, declaredVersion) {
-  if (parseReactNativeVersion(declaredVersion)) return declaredVersion;
-
   let directory = project;
   for (let depth = 0; depth < 6; depth += 1) {
     const installedPackage = readText(

--- a/packages/react-native-nitro-geolocation/scripts/doctor.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor.mjs
@@ -24,7 +24,9 @@ function parseArguments(arguments_) {
     else if (argument === "--help" || argument === "-h") result.help = true;
     else if (argument === "--project") {
       const project = args.shift();
-      if (!project) throw new Error("--project requires a path");
+      if (!project || project.startsWith("-")) {
+        throw new Error("--project requires a path");
+      }
       result.project = project;
     } else {
       throw new Error(`Unknown option: ${argument}`);

--- a/packages/react-native-nitro-geolocation/scripts/doctor.mjs
+++ b/packages/react-native-nitro-geolocation/scripts/doctor.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+import { formatReport, inspectProject } from "./doctor-core.mjs";
+
+const HELP = `Usage: nitro-geolocation doctor [--project <path>] [--json]
+
+Read and report React Native, Nitro, Android, and iOS setup issues.
+The command never changes project files.
+`;
+
+function parseArguments(arguments_) {
+  const result = { project: process.cwd(), json: false, help: false };
+  const args = [...arguments_];
+
+  if (args[0] === "doctor") args.shift();
+  else if (args[0] && !args[0].startsWith("-")) {
+    throw new Error(`Unknown command: ${args[0]}`);
+  }
+
+  while (args.length > 0) {
+    const argument = args.shift();
+    if (argument === "--json") result.json = true;
+    else if (argument === "--help" || argument === "-h") result.help = true;
+    else if (argument === "--project") {
+      const project = args.shift();
+      if (!project) throw new Error("--project requires a path");
+      result.project = project;
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+  return result;
+}
+
+try {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  const report = inspectProject(options.project);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, undefined, 2)}\n`
+      : formatReport(report)
+  );
+  process.exit(report.ok ? 0 : 1);
+} catch (error) {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n\n${HELP}`
+  );
+  process.exit(2);
+}

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -13,7 +13,8 @@ function createProject({
   iosPermission = true,
   iosTestPermission = false,
   generatedIosPermission,
-  newArchitecture = true
+  newArchitecture = true,
+  newArchitectureKey = "newArchEnabled"
 }: {
   reactNative?: string;
   nitro?: boolean;
@@ -23,6 +24,7 @@ function createProject({
   iosTestPermission?: boolean;
   generatedIosPermission?: string;
   newArchitecture?: boolean | "absent";
+  newArchitectureKey?: "newArchEnabled" | "react.newArchEnabled";
 } = {}) {
   const project = mkdtempSync(path.join(tmpdir(), "nitro-geolocation-doctor-"));
   const dependencies: Record<string, string> = {
@@ -42,7 +44,7 @@ function createProject({
     path.join(project, "android/gradle.properties"),
     newArchitecture === "absent"
       ? "android.useAndroidX=true\n"
-      : `newArchEnabled=${String(newArchitecture)}\n`
+      : `${newArchitectureKey}=${String(newArchitecture)}\n`
   );
   writeFileSync(
     path.join(project, "android/app/src/main/AndroidManifest.xml"),
@@ -204,13 +206,22 @@ describe("nitro-geolocation doctor", () => {
       reactNative: "0.75.5",
       newArchitecture: "absent",
       androidManifest: `<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-        <!-- <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /> -->
+        <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove" />
       </manifest>`,
       iosPermission: false,
       iosTestPermission: true
     });
     projects.push(project);
+    const staleMergedManifest = path.join(
+      project,
+      "android/app/build/intermediates/merged_manifests/debug/processDebugManifest"
+    );
+    mkdirSync(staleMergedManifest, { recursive: true });
+    writeFileSync(
+      path.join(staleMergedManifest, "AndroidManifest.xml"),
+      '<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /></manifest>'
+    );
 
     const result = spawnSync(
       process.execPath,
@@ -274,6 +285,89 @@ describe("nitro-geolocation doctor", () => {
         expect.objectContaining({
           code: "ios-when-in-use-description",
           status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("does not accept an unresolved generated usage-description variable", () => {
+    const project = createProject({
+      iosPermission: false,
+      generatedIosPermission: "$(LOCATION_USAGE_DESCRIPTION)"
+    });
+    projects.push(project);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "error"
+        })
+      ])
+    );
+  });
+
+  it("resolves an installed React Native version for catalog dependencies", () => {
+    const project = createProject({
+      reactNative: "catalog:",
+      newArchitectureKey: "react.newArchEnabled"
+    });
+    projects.push(project);
+    mkdirSync(path.join(project, "node_modules/react-native"), {
+      recursive: true
+    });
+    writeFileSync(
+      path.join(project, "node_modules/react-native/package.json"),
+      JSON.stringify({ name: "react-native", version: "0.87.0" })
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "react-native-version",
+          status: "pass"
+        }),
+        expect.objectContaining({
+          code: "android-new-architecture",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("does not infer New Architecture from a modern React Native version", () => {
+    const project = createProject({ newArchitecture: "absent" });
+    projects.push(project);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "android-new-architecture",
+          status: "error"
         })
       ])
     );

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -1,0 +1,158 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const cliPath = path.resolve(import.meta.dirname, "../scripts/doctor.mjs");
+
+function createProject({
+  reactNative = "0.87.0",
+  nitro = true,
+  androidPermissions = true,
+  iosPermission = true,
+  newArchitecture = true
+}: {
+  reactNative?: string;
+  nitro?: boolean;
+  androidPermissions?: boolean;
+  iosPermission?: boolean;
+  newArchitecture?: boolean;
+} = {}) {
+  const project = mkdtempSync(path.join(tmpdir(), "nitro-geolocation-doctor-"));
+  const dependencies: Record<string, string> = {
+    "react-native": reactNative,
+    "react-native-nitro-geolocation": "2.0.0-rc.0"
+  };
+
+  if (nitro) dependencies["react-native-nitro-modules"] = "0.35.10";
+
+  writeFileSync(
+    path.join(project, "package.json"),
+    JSON.stringify({ name: "consumer-app", private: true, dependencies })
+  );
+
+  mkdirSync(path.join(project, "android/app/src/main"), { recursive: true });
+  writeFileSync(
+    path.join(project, "android/gradle.properties"),
+    `newArchEnabled=${String(newArchitecture)}\n`
+  );
+  writeFileSync(
+    path.join(project, "android/app/src/main/AndroidManifest.xml"),
+    androidPermissions
+      ? '<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /></manifest>'
+      : '<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>'
+  );
+
+  mkdirSync(path.join(project, "ios/Consumer"), { recursive: true });
+  mkdirSync(path.join(project, "ios/ATests"), { recursive: true });
+  writeFileSync(
+    path.join(project, "ios/ATests/Info.plist"),
+    "<plist><dict></dict></plist>"
+  );
+  writeFileSync(
+    path.join(project, "ios/Consumer/Info.plist"),
+    iosPermission
+      ? "<plist><dict><key>NSLocationWhenInUseUsageDescription</key><string>Show nearby places.</string></dict></plist>"
+      : "<plist><dict></dict></plist>"
+  );
+
+  return project;
+}
+
+describe("nitro-geolocation doctor", () => {
+  const projects: string[] = [];
+
+  afterEach(() => {
+    for (const project of projects.splice(0)) {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it("passes a naturally configured RN 0.87 consumer project", () => {
+    const project = createProject();
+    projects.push(project);
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.summary).toEqual({ pass: 7, warning: 0, error: 0 });
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "react-native-version",
+          status: "pass"
+        }),
+        expect.objectContaining({
+          code: "android-permission-fine",
+          status: "pass"
+        }),
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("reports every actionable error instead of stopping at the first one", () => {
+    const project = createProject({
+      reactNative: "0.74.7",
+      nitro: false,
+      androidPermissions: false,
+      iosPermission: false,
+      newArchitecture: false
+    });
+    projects.push(project);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.ok).toBe(false);
+    expect(
+      report.checks.filter(
+        ({ status }: { status: string }) => status === "error"
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "react-native-version" }),
+        expect.objectContaining({ code: "nitro-modules-dependency" }),
+        expect.objectContaining({ code: "android-new-architecture" }),
+        expect.objectContaining({ code: "android-permission-coarse" }),
+        expect.objectContaining({ code: "android-permission-fine" }),
+        expect.objectContaining({ code: "ios-when-in-use-description" })
+      ])
+    );
+  });
+
+  it("keeps projects without generated native folders actionable but valid", () => {
+    const project = createProject();
+    projects.push(project);
+    rmSync(path.join(project, "android"), { recursive: true });
+    rmSync(path.join(project, "ios"), { recursive: true });
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "android-project", status: "warning" }),
+        expect.objectContaining({ code: "ios-project", status: "warning" })
+      ])
+    );
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -416,6 +416,152 @@ describe("nitro-geolocation doctor", () => {
     );
   });
 
+  it("resolves one-line group-relative xcconfig file references", () => {
+    const project = createProject({ iosPermission: false });
+    projects.push(project);
+    const configDirectory = path.join(
+      project,
+      "ios/Pods/Target Support Files/Consumer"
+    );
+    mkdirSync(configDirectory, { recursive: true });
+    writeFileSync(
+      path.join(configDirectory, "Location.xcconfig"),
+      "GENERATE_INFOPLIST_FILE = YES\nINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = Allow location.\n"
+    );
+    writeFileSync(
+      path.join(project, "ios/Consumer.xcodeproj/project.pbxproj"),
+      `// !$*UTF8*$!
+{
+  objects = {
+		AAAAAAAAAAAAAAAAAAAAAAAA /* Consumer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB;
+			name = Consumer;
+			productType = "com.apple.product-type.application";
+		};
+		BBBBBBBBBBBBBBBBBBBBBBBB = {isa = XCConfigurationList; buildConfigurations = (CCCCCCCCCCCCCCCCCCCCCCCC,); };
+		CCCCCCCCCCCCCCCCCCCCCCCC = {isa = XCBuildConfiguration; baseConfigurationReference = FFFFFFFFFFFFFFFFFFFFFFFF; buildSettings = {}; name = Release; };
+		DDDDDDDDDDDDDDDDDDDDDDDD /* Pods */ = {isa = PBXGroup; children = (FFFFFFFFFFFFFFFFFFFFFFFF,); path = Pods; sourceTree = "<group>"; };
+		FFFFFFFFFFFFFFFFFFFFFFFF /* Location.xcconfig */ = {isa = PBXFileReference; path = "Target Support Files/Consumer/Location.xcconfig"; sourceTree = "<group>"; };
+  };
+}
+`
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("honors xcconfig includes, conditional assignments, and inherited values", () => {
+    const project = createProject({ iosPermission: false });
+    projects.push(project);
+    mkdirSync(path.join(project, "ios/Config"), { recursive: true });
+    writeFileSync(
+      path.join(project, "ios/Config/Base.xcconfig"),
+      "GENERATE_INFOPLIST_FILE = YES\nINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = Allow inherited location.\n"
+    );
+    writeFileSync(
+      path.join(project, "ios/Config/Target.xcconfig"),
+      '#include "Base.xcconfig"\nGENERATE_INFOPLIST_FILE ?= NO\nINFOPLIST_KEY_NSLocationWhenInUseUsageDescription ?= Wrong fallback.\n'
+    );
+    writeFileSync(
+      path.join(project, "ios/Consumer.xcodeproj/project.pbxproj"),
+      `// !$*UTF8*$!
+{
+  objects = {
+		AAAAAAAAAAAAAAAAAAAAAAAA = {isa = PBXNativeTarget; buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB; name = Consumer; productType = "com.apple.product-type.application"; };
+		BBBBBBBBBBBBBBBBBBBBBBBB = {isa = XCConfigurationList; buildConfigurations = (CCCCCCCCCCCCCCCCCCCCCCCC,); };
+		CCCCCCCCCCCCCCCCCCCCCCCC = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FFFFFFFFFFFFFFFFFFFFFFFF;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = $(inherited);
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = $(inherited);
+			};
+			name = Release;
+		};
+		FFFFFFFFFFFFFFFFFFFFFFFF = {isa = PBXFileReference; path = Config/Target.xcconfig; sourceTree = SOURCE_ROOT; };
+  };
+}
+`
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("rejects a later empty xcconfig override", () => {
+    const project = createProject({ iosPermission: false });
+    projects.push(project);
+    mkdirSync(path.join(project, "ios/Config"), { recursive: true });
+    writeFileSync(
+      path.join(project, "ios/Config/Base.xcconfig"),
+      "GENERATE_INFOPLIST_FILE = YES\nINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = Allow location.\n"
+    );
+    writeFileSync(
+      path.join(project, "ios/Config/Target.xcconfig"),
+      '#include "Base.xcconfig"\nINFOPLIST_KEY_NSLocationWhenInUseUsageDescription =\n'
+    );
+    writeFileSync(
+      path.join(project, "ios/Consumer.xcodeproj/project.pbxproj"),
+      `// !$*UTF8*$!
+{
+  objects = {
+		AAAAAAAAAAAAAAAAAAAAAAAA = {isa = PBXNativeTarget; buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB; name = Consumer; productType = "com.apple.product-type.application"; };
+		BBBBBBBBBBBBBBBBBBBBBBBB = {isa = XCConfigurationList; buildConfigurations = (CCCCCCCCCCCCCCCCCCCCCCCC,); };
+		CCCCCCCCCCCCCCCCCCCCCCCC = {isa = XCBuildConfiguration; baseConfigurationReference = FFFFFFFFFFFFFFFFFFFFFFFF; buildSettings = {}; name = Release; };
+		FFFFFFFFFFFFFFFFFFFFFFFF = {isa = PBXFileReference; path = Config/Target.xcconfig; sourceTree = SOURCE_ROOT; };
+  };
+}
+`
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "error"
+        })
+      ])
+    );
+  });
+
   it("resolves an installed React Native version for catalog dependencies", () => {
     const project = createProject({
       reactNative: "catalog:",

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -13,6 +13,7 @@ function createProject({
   iosPermission = true,
   iosTestPermission = false,
   generatedIosPermission,
+  generateInfoPlist = true,
   newArchitecture = true,
   newArchitectureKey = "newArchEnabled"
 }: {
@@ -23,6 +24,7 @@ function createProject({
   iosPermission?: boolean;
   iosTestPermission?: boolean;
   generatedIosPermission?: string;
+  generateInfoPlist?: boolean;
   newArchitecture?: boolean | "absent";
   newArchitectureKey?: "newArchEnabled" | "react.newArchEnabled";
 } = {}) {
@@ -77,6 +79,7 @@ function createProject({
 		AAAAAAAAAAAAAAAAAAAAAAAA /* Consumer */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB;
+			name = Consumer;
 			productType = "com.apple.product-type.application";
 		};
 		BBBBBBBBBBBBBBBBBBBBBBBB /* Build configuration list for PBXNativeTarget "Consumer" */ = {
@@ -90,8 +93,8 @@ function createProject({
 			buildSettings = {
 ${
   generatedIosPermission
-    ? `\t\t\t\tGENERATE_INFOPLIST_FILE = YES;\n\t\t\t\tINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${generatedIosPermission}";`
-    : "\t\t\t\tINFOPLIST_FILE = Consumer/Info.plist;"
+    ? `\t\t\t\tGENERATE_INFOPLIST_FILE = ${generateInfoPlist ? "YES" : "NO"};\n\t\t\t\tINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${generatedIosPermission}";`
+    : "\t\t\t\tINFOPLIST_FILE = $(TARGET_NAME)/Info.plist;"
 }
 			};
 			name = Release;
@@ -206,6 +209,7 @@ describe("nitro-geolocation doctor", () => {
       reactNative: "0.75.5",
       newArchitecture: "absent",
       androidManifest: `<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+        <!-- <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /> -->
         <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove" />
       </manifest>`,
@@ -315,6 +319,103 @@ describe("nitro-geolocation doctor", () => {
     );
   });
 
+  it("does not accept a generated key when Info.plist generation is disabled", () => {
+    const project = createProject({
+      iosPermission: false,
+      generatedIosPermission: "Allow location while using the app.",
+      generateInfoPlist: false
+    });
+    projects.push(project);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "error"
+        })
+      ])
+    );
+  });
+
+  it("resolves project-level and target xcconfig build settings", () => {
+    const project = createProject({ iosPermission: false });
+    projects.push(project);
+    mkdirSync(path.join(project, "ios/Config"), { recursive: true });
+    writeFileSync(
+      path.join(project, "ios/Config/Location.xcconfig"),
+      "INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = Allow $(PRODUCT_NAME) to use location.\n"
+    );
+    writeFileSync(
+      path.join(project, "ios/Consumer.xcodeproj/project.pbxproj"),
+      `// !$*UTF8*$!
+{
+  objects = {
+		AAAAAAAAAAAAAAAAAAAAAAAA /* Consumer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB;
+			name = Consumer;
+			productType = "com.apple.product-type.application";
+		};
+		BBBBBBBBBBBBBBBBBBBBBBBB = {
+			isa = XCConfigurationList;
+			buildConfigurations = (CCCCCCCCCCCCCCCCCCCCCCCC,);
+		};
+		CCCCCCCCCCCCCCCCCCCCCCCC = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FFFFFFFFFFFFFFFFFFFFFFFF;
+			buildSettings = {};
+			name = Release;
+		};
+		DDDDDDDDDDDDDDDDDDDDDDDD = {
+			isa = PBXProject;
+			buildConfigurationList = EEEEEEEEEEEEEEEEEEEEEEEE;
+		};
+		EEEEEEEEEEEEEEEEEEEEEEEE = {
+			isa = XCConfigurationList;
+			buildConfigurations = (111111111111111111111111,);
+		};
+		FFFFFFFFFFFFFFFFFFFFFFFF = {
+			isa = PBXFileReference;
+			path = Config/Location.xcconfig;
+		};
+		111111111111111111111111 = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+			};
+			name = Release;
+		};
+  };
+}
+`
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
   it("resolves an installed React Native version for catalog dependencies", () => {
     const project = createProject({
       reactNative: "catalog:",
@@ -368,6 +469,81 @@ describe("nitro-geolocation doctor", () => {
         expect.objectContaining({
           code: "android-new-architecture",
           status: "error"
+        })
+      ])
+    );
+  });
+
+  it("uses Gradle's OR semantics for legacy and scoped New Architecture keys", () => {
+    const project = createProject();
+    projects.push(project);
+    writeFileSync(
+      path.join(project, "android/gradle.properties"),
+      "newArchEnabled=false\nreact.newArchEnabled=true\n"
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "android-new-architecture",
+          status: "pass"
+        })
+      ])
+    );
+  });
+
+  it("recognizes the Gradle project-property environment override", () => {
+    const project = createProject({ newArchitecture: "absent" });
+    projects.push(project);
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ORG_GRADLE_PROJECT_newArchEnabled: "true"
+        }
+      }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+  });
+
+  it("prefers the installed React Native version over an ambiguous range", () => {
+    const project = createProject({ reactNative: ">=0.74 <0.88" });
+    projects.push(project);
+    mkdirSync(path.join(project, "node_modules/react-native"), {
+      recursive: true
+    });
+    writeFileSync(
+      path.join(project, "node_modules/react-native/package.json"),
+      JSON.stringify({ name: "react-native", version: "0.87.0" })
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "react-native-version",
+          status: "pass"
         })
       ])
     );

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -9,14 +9,20 @@ function createProject({
   reactNative = "0.87.0",
   nitro = true,
   androidPermissions = true,
+  androidManifest,
   iosPermission = true,
+  iosTestPermission = false,
+  generatedIosPermission,
   newArchitecture = true
 }: {
   reactNative?: string;
   nitro?: boolean;
   androidPermissions?: boolean;
+  androidManifest?: string;
   iosPermission?: boolean;
-  newArchitecture?: boolean;
+  iosTestPermission?: boolean;
+  generatedIosPermission?: string;
+  newArchitecture?: boolean | "absent";
 } = {}) {
   const project = mkdtempSync(path.join(tmpdir(), "nitro-geolocation-doctor-"));
   const dependencies: Record<string, string> = {
@@ -34,26 +40,63 @@ function createProject({
   mkdirSync(path.join(project, "android/app/src/main"), { recursive: true });
   writeFileSync(
     path.join(project, "android/gradle.properties"),
-    `newArchEnabled=${String(newArchitecture)}\n`
+    newArchitecture === "absent"
+      ? "android.useAndroidX=true\n"
+      : `newArchEnabled=${String(newArchitecture)}\n`
   );
   writeFileSync(
     path.join(project, "android/app/src/main/AndroidManifest.xml"),
-    androidPermissions
-      ? '<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /></manifest>'
-      : '<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>'
+    androidManifest ??
+      (androidPermissions
+        ? '<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /></manifest>'
+        : '<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>')
   );
 
   mkdirSync(path.join(project, "ios/Consumer"), { recursive: true });
   mkdirSync(path.join(project, "ios/ATests"), { recursive: true });
   writeFileSync(
     path.join(project, "ios/ATests/Info.plist"),
-    "<plist><dict></dict></plist>"
+    iosTestPermission
+      ? "<plist><dict><key>NSLocationWhenInUseUsageDescription</key><string>Only the tests use this.</string></dict></plist>"
+      : "<plist><dict></dict></plist>"
   );
   writeFileSync(
     path.join(project, "ios/Consumer/Info.plist"),
     iosPermission
       ? "<plist><dict><key>NSLocationWhenInUseUsageDescription</key><string>Show nearby places.</string></dict></plist>"
       : "<plist><dict></dict></plist>"
+  );
+  mkdirSync(path.join(project, "ios/Consumer.xcodeproj"), { recursive: true });
+  writeFileSync(
+    path.join(project, "ios/Consumer.xcodeproj/project.pbxproj"),
+    `// !$*UTF8*$!
+{
+  objects = {
+		AAAAAAAAAAAAAAAAAAAAAAAA /* Consumer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BBBBBBBBBBBBBBBBBBBBBBBB;
+			productType = "com.apple.product-type.application";
+		};
+		BBBBBBBBBBBBBBBBBBBBBBBB /* Build configuration list for PBXNativeTarget "Consumer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CCCCCCCCCCCCCCCCCCCCCCCC,
+			);
+		};
+		CCCCCCCCCCCCCCCCCCCCCCCC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+${
+  generatedIosPermission
+    ? `\t\t\t\tGENERATE_INFOPLIST_FILE = YES;\n\t\t\t\tINFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "${generatedIosPermission}";`
+    : "\t\t\t\tINFOPLIST_FILE = Consumer/Info.plist;"
+}
+			};
+			name = Release;
+		};
+  };
+}
+`
   );
 
   return project;
@@ -152,6 +195,86 @@ describe("nitro-geolocation doctor", () => {
       expect.arrayContaining([
         expect.objectContaining({ code: "android-project", status: "warning" }),
         expect.objectContaining({ code: "ios-project", status: "warning" })
+      ])
+    );
+  });
+
+  it("rejects false evidence from legacy defaults, comments, removals, and test targets", () => {
+    const project = createProject({
+      reactNative: "0.75.5",
+      newArchitecture: "absent",
+      androidManifest: `<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+        <!-- <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /> -->
+        <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove" />
+      </manifest>`,
+      iosPermission: false,
+      iosTestPermission: true
+    });
+    projects.push(project);
+
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "android-new-architecture",
+          status: "error"
+        }),
+        expect.objectContaining({
+          code: "android-permission-coarse",
+          status: "error"
+        }),
+        expect.objectContaining({
+          code: "android-permission-fine",
+          status: "error"
+        }),
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "error"
+        })
+      ])
+    );
+  });
+
+  it("rejects a missing --project value as CLI usage error", () => {
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", "--json"],
+      { encoding: "utf8" }
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("--project requires a path");
+  });
+
+  it("accepts a non-empty generated Info.plist build setting", () => {
+    const project = createProject({
+      iosPermission: false,
+      generatedIosPermission: "Allow location while using the app."
+    });
+    projects.push(project);
+
+    const output = execFileSync(
+      process.execPath,
+      [cliPath, "doctor", "--project", project, "--json"],
+      { encoding: "utf8" }
+    );
+    const report = JSON.parse(output);
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "ios-when-in-use-description",
+          status: "pass"
+        })
       ])
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12785,6 +12785,8 @@ __metadata:
     react: ">=18.0.0"
     react-native: ">=0.75.0"
     react-native-nitro-modules: "*"
+  bin:
+    nitro-geolocation: scripts/doctor.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- add the read-only `nitro-geolocation doctor` CLI with human and JSON reports
- validate the installed React Native/Nitro requirements plus effective Android and iOS app configuration
- document CI and local usage without postinstall hooks or native-file mutation

## RED -> GREEN
- added natural RN 0.87 consumer, aggregated failure, missing native folders, generated plist, xcconfig, Gradle, package-range, and CLI edge fixtures
- captured RED for missing CLI behavior and false-positive native evidence
- hardened the resolver against comments/removals/maxSdk, installed-version ambiguity, one-line PBX objects, group-relative xcconfig paths, include ordering, overrides, conditional assignment, and inherited values

## Validation
- `yarn format:check`
- `yarn lint`
- `yarn test:unit` (17 files, 168 tests)
- `yarn typecheck`
- `yarn build:all`
- `yarn deadcode`
- `yarn deadcode:prod`
- `yarn pack:check`
- `yarn source-lines:check`
- doctor against `examples/v0.81.1` (7/7 checks)

Mobile E2E was not run because this PR adds a read-only install-time CLI and documentation; it does not change packaged mobile runtime behavior.

## Release
- minor changeset: new backward-compatible feature

Closes one checkbox in #98.
