### PR TITLE
docs: add privacy and compliance contract

### DIFF
--- a/.changeset/small-cats-document.md
+++ b/.changeset/small-cats-document.md
@@ -1,0 +1,5 @@
+---
+---
+
+Document runtime data flows, privacy responsibilities, dependency disclosure,
+SBOM generation, license review, and vulnerability-scanner guidance.

--- a/.changeset/small-cats-document.md
+++ b/.changeset/small-cats-document.md
@@ -1,5 +1,7 @@
 ---
+"react-native-nitro-geolocation": patch
 ---
 
-Document runtime data flows, privacy responsibilities, dependency disclosure,
-SBOM generation, license review, and vulnerability-scanner guidance.
+Ship the iOS SDK privacy manifest and document runtime data flows, retention,
+permission ownership, dependency disclosure, SBOM generation, and license and
+vulnerability review.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,9 @@ jobs:
             --console=plain \
             :react-native-nitro-geolocation:testDebugUnitTest
 
+      - name: Verify Android prebuilt checksums
+        run: scripts/test-android-prebuilt-checksum.sh
+
   guardrails:
     name: Dead Code / Package Guardrails
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           scripts/test-ios-location-lifecycle.sh
 
+      - name: Verify iOS prebuilt checksums
+        run: ruby tests/ruby/prebuilt_ios_checksum_test.rb
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -15,17 +15,26 @@ before shipping.
 - Foreground location, heading, provider, and lifecycle results stay between
   the platform location service and the app unless the app sends them onward.
 - Background location is opt-in. A started background session stores records on
-  the device by default unless the app sets `persist: false`. The app controls
-  storage caps and can clear retained records.
+  the device by default unless the app sets `persist: false`. Configuration and
+  geofences remain persisted independently until the app removes them or calls
+  `resetBackgroundLocation()`. App-private storage can participate in OS backup
+  unless the integrating app excludes it.
 - Native HTTP sync runs only when the app supplies `sync.url`. It sends the
   configured location payload to that app-selected URL, never to a project
   endpoint.
 - Geocoding uses the operating system geocoder. Its implementation may contact
   Apple, Google, or another platform service under the device's platform terms.
+- Android debug builds log exact background coordinates to logcat by default;
+  release builds disable verbose logs by default. Treat collected debug logs as
+  precise-location data.
 - Native prebuilt binaries may be downloaded from this project's GitHub
   Releases during the native build. This build-time request contains no app
   user's location data and can be disabled with
   `NITRO_GEOLOCATION_USE_PREBUILT=0`.
+
+The iOS SDK ships its own privacy manifest declaring its app-private
+`UserDefaults` access. Consumer apps still need to audit the final Xcode privacy
+report and maintain declarations for their own code and other dependencies.
 
 ## Reporting
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -33,8 +33,10 @@ before shipping.
   `NITRO_GEOLOCATION_USE_PREBUILT=0`.
 
 The iOS SDK ships its own privacy manifest declaring its app-private
-`UserDefaults` access. Consumer apps still need to audit the final Xcode privacy
-report and maintain declarations for their own code and other dependencies.
+`UserDefaults` access and the opt-in sync feature's linked precise-location
+collection for app functionality, with tracking disabled. Consumer apps still
+need to audit the final Xcode privacy report and maintain declarations for their
+own code and other dependencies.
 
 ## Reporting
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,33 @@
+# Privacy Statement
+
+`react-native-nitro-geolocation` is a library, not a hosted location service.
+The project does not operate a telemetry endpoint, create advertising IDs, sell
+location data, or automatically send app or device data to the maintainers.
+
+The app integrating the library remains the data controller. It decides when
+to request permission, when to start location APIs, whether to persist
+background records, and whether to configure a destination for native HTTP
+sync. Review the complete [privacy and compliance guide](https://react-native-nitro-geolocation.pages.dev/guide/privacy-compliance)
+before shipping.
+
+## Data flows
+
+- Foreground location, heading, provider, and lifecycle results stay between
+  the platform location service and the app unless the app sends them onward.
+- Background location is opt-in. A started background session stores records on
+  the device by default unless the app sets `persist: false`. The app controls
+  storage caps and can clear retained records.
+- Native HTTP sync runs only when the app supplies `sync.url`. It sends the
+  configured location payload to that app-selected URL, never to a project
+  endpoint.
+- Geocoding uses the operating system geocoder. Its implementation may contact
+  Apple, Google, or another platform service under the device's platform terms.
+- Native prebuilt binaries may be downloaded from this project's GitHub
+  Releases during the native build. This build-time request contains no app
+  user's location data and can be disabled with
+  `NITRO_GEOLOCATION_USE_PREBUILT=0`.
+
+## Reporting
+
+Report a suspected security or privacy issue privately through the repository's
+[security advisory form](https://github.com/jingjing2222/react-native-nitro-geolocation/security/advisories/new).

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ alone does not mutate native files. See the
 [Expo development build guide](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build)
 for foreground and explicit background options.
 
+Before release, review the project's [privacy statement](./PRIVACY.md) and the
+[privacy and compliance guide](https://react-native-nitro-geolocation.pages.dev/guide/privacy-compliance)
+for runtime data flows, permission disclosures, dependency inventory, SBOM, and
+scanner guidance.
+
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
 downloads the release XCFramework. If the prebuilt asset is unavailable, the

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -10,6 +10,7 @@
   "gps-offline-recipe",
   "consumer-e2e-contract-kit",
   "expo-development-build",
+  "privacy-compliance",
   "react-native-directory",
   "modern-api",
   "watch-observability",

--- a/docs/docs/guide/privacy-compliance.md
+++ b/docs/docs/guide/privacy-compliance.md
@@ -1,0 +1,111 @@
+# Privacy and Compliance
+
+This page describes the library's behavior and gives integrators an audit
+starting point. It is not legal advice. Your app determines its purposes,
+retention, recipients, disclosures, and lawful basis for location processing.
+
+## Project statement
+
+`react-native-nitro-geolocation` has no maintainer-operated telemetry or
+analytics endpoint. It does not create an advertising identifier, sell location
+data, or automatically transmit runtime data to the maintainers. Installing the
+package does not request location permission and does not start location
+collection.
+
+The source-of-truth short statement is also available in the repository's
+[`PRIVACY.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/PRIVACY.md).
+
+## Data-flow inventory
+
+| Feature | Activation | Data and destination | Retention |
+| --- | --- | --- | --- |
+| Current position, foreground watch, heading, provider and lifecycle APIs | An app calls the API after handling permission | Platform results are returned to the app process. The library does not send them to a project server. | No library-managed durable storage for foreground-only calls. |
+| Background location | An app calls `startBackgroundLocation()` | Location records and enabled background events are processed by the native app. | Records are stored on device by default unless `persist: false`; configure `maxStoredLocations` and `maxStoredEvents`, then clear records with the storage APIs. |
+| Native HTTP sync | An app explicitly supplies `sync.url` | Stored location payloads, configured headers, and `bodyTemplate` values go to the app-selected URL. No project URL is supplied. | `autoClear` and the app's storage calls control local cleanup; the receiving service controls remote retention. |
+| Forward and reverse geocoding | An app calls a geocoding API | The operating-system geocoder may contact Apple, Google, or another platform provider. | Governed by the platform service and the app's own handling of returned results. |
+| Prebuilt native artifacts | Native dependency installation/build | Gradle or CocoaPods may download a matching binary from this project's GitHub Releases. No end-user location is present in this build-time request. | Build-tool and package caches. Set `NITRO_GEOLOCATION_USE_PREBUILT=0` to build from source. |
+
+Do not put long-lived secrets in `sync.headers` unless your threat model accepts
+native app configuration storage. Prefer short-lived credentials and TLS, and
+validate the configured URL before enabling sync.
+
+## Permissions and store disclosures
+
+The host app owns all permission prompts and declarations. Use purpose-specific
+copy in iOS `Info.plist`; declare only the Android foreground/background
+permissions the app actually needs; and request permission from a user action.
+Background access needs a separate, clear explanation.
+
+Before release, reconcile the implementation with:
+
+- the app's privacy notice and consent or lawful-basis flow;
+- Apple App Privacy answers and any app-level `PrivacyInfo.xcprivacy` manifest;
+- Google Play Data safety answers, foreground-service declarations, and the
+  background-location review form when applicable;
+- retention/deletion controls for on-device records and the app's sync server;
+- child, health, workforce, precise-location, and regional rules applicable to
+  the app.
+
+The example app privacy manifest is an example for that app, not a declaration
+that can be copied blindly into every consumer. Audit the final app and all of
+its dependencies together.
+
+## Dependency and license disclosure
+
+The published JavaScript package is MIT licensed and ships its `LICENSE`. It has
+no direct npm runtime dependencies. Its peer dependencies are React, React
+Native, and `react-native-nitro-modules`; the consumer chooses their resolved
+versions. Native builds also use React Native platform artifacts, Nitro Modules,
+Apple system frameworks, Android platform APIs, and Google Play Services
+location on Android where configured by the build.
+
+Treat the resolved app lockfile and final native artifacts as the auditable
+inventory. A package manifest alone cannot disclose transitive dependencies
+selected by the consuming app. Preserve third-party notices required by the
+versions and binaries you actually ship.
+
+## Reproducible audit checklist
+
+Run these from a clean checkout of the exact release commit:
+
+```bash
+yarn install --immutable
+yarn pack:check
+yarn npm audit --all --recursive
+```
+
+`pack:check` verifies the intended npm payload. The audit command checks the
+resolved Yarn dependency graph against npm advisories; review findings rather
+than suppressing them solely because they are development dependencies.
+
+For an independent vulnerability scan of the committed lockfile, install
+[OSV-Scanner](https://google.github.io/osv-scanner/installation/) and run:
+
+```bash
+osv-scanner scan -L yarn.lock
+```
+
+For a release SBOM, first create the same package archive that will be reviewed,
+then scan both the archive and the final consumer app. For example, with
+[Syft](https://github.com/anchore/syft):
+
+```bash
+mkdir -p artifacts
+npm pack ./packages/react-native-nitro-geolocation --pack-destination artifacts
+syft artifacts/react-native-nitro-geolocation-*.tgz \
+  -o cyclonedx-json=artifacts/react-native-nitro-geolocation.cdx.json
+```
+
+Also produce an SBOM from the final Android AAB/APK and iOS archive because
+those artifacts contain the consumer's resolved native dependency graph. Feed
+the resulting CycloneDX or SPDX document into the organization's license and
+vulnerability scanner, review unknown licenses manually, and archive the SBOM,
+scanner version, advisory database timestamp, and disposition with the release.
+
+## Incident response
+
+If a release changes a data flow, permission, default persistence behavior,
+sync payload, or dependency, update this page and the app's disclosures before
+shipping. Report suspected library security or privacy issues through the
+[private security advisory form](https://github.com/jingjing2222/react-native-nitro-geolocation/security/advisories/new),
+not a public issue containing user data.

--- a/docs/docs/guide/privacy-compliance.md
+++ b/docs/docs/guide/privacy-compliance.md
@@ -124,10 +124,13 @@ URL/checksum/provenance, and applicable license notices. Final AAB/APK/XCArchive
 scanning is a useful cross-check, but generally cannot reconstruct original
 Maven/CocoaPods coordinates, transitive graph, versions, or license obligations.
 
-The default prebuilt installers fetch each release asset's `.sha256` sidecar,
-reject malformed or mismatched sidecars, and verify cached and newly downloaded
-artifacts before extraction. The sidecar and artifact share the same GitHub
-Release/TLS trust boundary; this detects corruption and cache tampering but is
+On first use, the default prebuilt installers fetch each release asset's
+`.sha256` sidecar, reject malformed or mismatched sidecars, and persist it next
+to the verified artifact. Later installs verify that local pair without network
+access; an integrity mismatch removes only the invalid artifact and downloads a
+fresh copy. The sidecar and artifact share the same GitHub Release/TLS trust
+boundary, and the cached sidecar shares the artifact cache's filesystem trust
+boundary. This detects ordinary corruption and one-sided cache tampering but is
 not an independent signature. Pin or independently attest release digests when
 your supply-chain policy requires stronger publisher authentication.
 

--- a/docs/docs/guide/privacy-compliance.md
+++ b/docs/docs/guide/privacy-compliance.md
@@ -20,21 +20,67 @@ The source-of-truth short statement is also available in the repository's
 | Feature | Activation | Data and destination | Retention |
 | --- | --- | --- | --- |
 | Current position, foreground watch, heading, provider and lifecycle APIs | An app calls the API after handling permission | Platform results are returned to the app process. The library does not send them to a project server. | No library-managed durable storage for foreground-only calls. |
-| Background location | An app calls `startBackgroundLocation()` | Location records and enabled background events are processed by the native app. | Records are stored on device by default unless `persist: false`; configure `maxStoredLocations` and `maxStoredEvents`, then clear records with the storage APIs. |
-| Native HTTP sync | An app explicitly supplies `sync.url` | Stored location payloads, configured headers, and `bodyTemplate` values go to the app-selected URL. No project URL is supplied. | `autoClear` and the app's storage calls control local cleanup; the receiving service controls remote retention. |
+| Background records and events | An app configures and starts background location | Location records and enabled background events are processed by the native app. | Android stores records in an app-private SQLite database; iOS uses app-private `UserDefaults`. Records are retained by default unless `persist: false`; configure `maxStoredLocations` and `maxStoredEvents`, then use `clearStoredBackgroundLocations()` and `clearStoredBackgroundEvents()`. |
+| Background configuration | An app calls `configureBackgroundLocation()` or starts with options | The complete configuration, including a sync URL, headers, and `bodyTemplate`, is stored in Android app-private `SharedPreferences` or iOS app-private `UserDefaults`. These stores are not credential vaults. | This happens independently of `persist: false`, record clearing, and sync `autoClear`. `resetBackgroundLocation()` removes the configuration and all library-managed background state. |
+| Geofences | An app calls `addGeofences()` | Region coordinates, radii, transitions, and metadata are stored in Android SQLite or iOS `UserDefaults`. | Independent of `persist: false`. Call `removeGeofences()` (without identifiers to remove all) or `resetBackgroundLocation()`. |
+| Native HTTP sync | An app explicitly supplies `sync.url` | Stored location payloads, configured headers, and `bodyTemplate` values go to the app-selected URL. No project URL is supplied. | `autoClear` removes successfully uploaded location records, not configuration, events, or geofences. The receiving service controls remote retention. |
 | Forward and reverse geocoding | An app calls a geocoding API | The operating-system geocoder may contact Apple, Google, or another platform provider. | Governed by the platform service and the app's own handling of returned results. |
+| Android debug logging | A debug build handles a background location | Debug logging is enabled by default and writes the exact latitude and longitude to the app's logcat stream under `NitroGeolocation`. Release builds disable verbose logs by default. | Governed by logcat access, collection tooling, and the app's log retention. Do not distribute debug builds or collect debug logs without treating them as precise-location data. |
 | Prebuilt native artifacts | Native dependency installation/build | Gradle or CocoaPods may download a matching binary from this project's GitHub Releases. No end-user location is present in this build-time request. | Build-tool and package caches. Set `NITRO_GEOLOCATION_USE_PREBUILT=0` to build from source. |
 
 Do not put long-lived secrets in `sync.headers` unless your threat model accepts
-native app configuration storage. Prefer short-lived credentials and TLS, and
-validate the configured URL before enabling sync.
+plain app-private preferences as storage. Prefer short-lived credentials and
+TLS, and validate the configured URL before enabling sync. Android Auto Backup
+and iOS device backup or transfer may include these stores unless the app's
+backup policy excludes them. Test restore and deletion on every supported OS.
 
 ## Permissions and store disclosures
 
-The host app owns all permission prompts and declarations. Use purpose-specific
-copy in iOS `Info.plist`; declare only the Android foreground/background
-permissions the app actually needs; and request permission from a user action.
+The host app owns permission prompts and the final merged declarations. Use
+purpose-specific copy in iOS `Info.plist`, declare Android location permissions
+for the access the app needs, and request permission from a user action.
 Background access needs a separate, clear explanation.
+
+The Android library manifest unconditionally merges these declarations into a
+consumer: `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION`,
+`RECEIVE_BOOT_COMPLETED`, `ACTIVITY_RECOGNITION`, and `WAKE_LOCK`, plus its
+background services and receivers. They support the opt-in background,
+start-on-boot, geofence, and activity-recognition APIs; they do not grant
+location access by themselves. A foreground-only app that never imports or
+calls the background entry point should remove every unused declaration with
+Android manifest-merger markers and inspect the final merged manifest. For
+example:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"
+    tools:node="remove" />
+  <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"
+    tools:node="remove" />
+
+  <application>
+    <receiver
+      android:name="com.margelo.nitro.nitrogeolocation.background.NitroBootReceiver"
+      tools:node="remove" />
+    <!-- Remove the other Nitro background components the app does not use. -->
+  </application>
+</manifest>
+```
+
+Use the exact entries in the published library `AndroidManifest.xml` as the
+removal checklist. Removing a permission or component while calling its feature
+is unsupported. See Android's [manifest-merger marker reference](https://developer.android.com/build/manage-manifests#merge_rule_markers).
+
+The iOS implementation uses `UserDefaults.standard` for app-private background
+state. The SDK therefore ships `PrivacyInfo.xcprivacy` with
+`NSPrivacyAccessedAPICategoryUserDefaults` reason `CA92.1`; CocoaPods packages it
+as the SDK's privacy resource, and release XCFrameworks include it in each
+framework slice. This is the SDK's required-reason declaration, not a substitute
+for the app's own manifest. Verify the manifest in the installed Pods resource
+bundle or XCFramework and in Xcode's final privacy report. Apple does not allow
+a third-party SDK to rely on the host manifest for its own required-reason API
+use; see [Apple's required-reason guidance](https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api).
 
 Before release, reconcile the implementation with:
 
@@ -46,23 +92,32 @@ Before release, reconcile the implementation with:
 - child, health, workforce, precise-location, and regional rules applicable to
   the app.
 
-The example app privacy manifest is an example for that app, not a declaration
-that can be copied blindly into every consumer. Audit the final app and all of
-its dependencies together.
+The example app privacy manifest describes that app and cannot be copied
+blindly into every consumer. Audit the final app and all dependencies together.
 
 ## Dependency and license disclosure
 
 The published JavaScript package is MIT licensed and ships its `LICENSE`. It has
 no direct npm runtime dependencies. Its peer dependencies are React, React
 Native, and `react-native-nitro-modules`; the consumer chooses their resolved
-versions. Native builds also use React Native platform artifacts, Nitro Modules,
-Apple system frameworks, Android platform APIs, and Google Play Services
-location on Android where configured by the build.
+versions.
 
-Treat the resolved app lockfile and final native artifacts as the auditable
-inventory. A package manifest alone cannot disclose transitive dependencies
-selected by the consuming app. Preserve third-party notices required by the
-versions and binaries you actually ship.
+Android always declares direct `implementation` dependencies on React Android,
+the Kotlin standard library, the Nitro Modules project, Google Play Services
+Base (default `18.5.0`), and Google Play Services Location (default `21.3.0`).
+Consumers can override the Google versions with root-project ext properties
+`playServicesBaseVersion` and `playServicesLocationVersion`, or Gradle properties
+`NitroGeolocation_playServicesBaseVersion` and
+`NitroGeolocation_playServicesLocationVersion`. iOS uses React/Nitro CocoaPods
+dependencies plus Apple system frameworks; source and prebuilt installation
+have different artifact provenance.
+
+Do not treat an npm lockfile or final binary scan as a complete native dependency
+inventory. Archive Gradle's resolved dependency report and verification
+metadata, `Podfile.lock` (and `Package.resolved` when using SPM), prebuilt release
+URL/checksum/provenance, and applicable license notices. Final AAB/APK/XCArchive
+scanning is a useful cross-check, but generally cannot reconstruct original
+Maven/CocoaPods coordinates, transitive graph, versions, or license obligations.
 
 ## Reproducible audit checklist
 
@@ -96,11 +151,12 @@ syft artifacts/react-native-nitro-geolocation-*.tgz \
   -o cyclonedx-json=artifacts/react-native-nitro-geolocation.cdx.json
 ```
 
-Also produce an SBOM from the final Android AAB/APK and iOS archive because
-those artifacts contain the consumer's resolved native dependency graph. Feed
-the resulting CycloneDX or SPDX document into the organization's license and
-vulnerability scanner, review unknown licenses manually, and archive the SBOM,
-scanner version, advisory database timestamp, and disposition with the release.
+Build a native SBOM from the recorded Gradle/CocoaPods resolution inputs, then
+scan the final Android AAB/APK and iOS archive as a complementary artifact
+check. Feed the resulting CycloneDX or SPDX documents into the organization's
+license and vulnerability scanner, review unknown licenses manually, and
+archive the resolution reports, SBOM, scanner version, advisory database
+timestamp, and disposition with the release.
 
 ## Incident response
 

--- a/docs/docs/guide/privacy-compliance.md
+++ b/docs/docs/guide/privacy-compliance.md
@@ -76,11 +76,16 @@ The iOS implementation uses `UserDefaults.standard` for app-private background
 state. The SDK therefore ships `PrivacyInfo.xcprivacy` with
 `NSPrivacyAccessedAPICategoryUserDefaults` reason `CA92.1`; CocoaPods packages it
 as the SDK's privacy resource, and release XCFrameworks include it in each
-framework slice. This is the SDK's required-reason declaration, not a substitute
-for the app's own manifest. Verify the manifest in the installed Pods resource
-bundle or XCFramework and in Xcode's final privacy report. Apple does not allow
-a third-party SDK to rely on the host manifest for its own required-reason API
-use; see [Apple's required-reason guidance](https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api).
+framework slice. Because the opt-in sync API can transmit exact coordinates to
+an app-selected server and configured headers or body values can associate that
+payload with an account, the manifest conservatively declares linked precise
+location for app functionality, with tracking disabled. This is the SDK's
+declaration, not a substitute for the app's own manifest or App Privacy answers.
+Verify the manifest in the installed Pods resource bundle or XCFramework and in
+Xcode's final privacy report. Apple does not allow a third-party SDK to rely on
+the host manifest for its own required-reason API use; see [Apple's
+required-reason guidance](https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api)
+and [collected-data guidance](https://developer.apple.com/documentation/bundleresources/describing-data-use-in-privacy-manifests).
 
 Before release, reconcile the implementation with:
 
@@ -118,6 +123,13 @@ metadata, `Podfile.lock` (and `Package.resolved` when using SPM), prebuilt relea
 URL/checksum/provenance, and applicable license notices. Final AAB/APK/XCArchive
 scanning is a useful cross-check, but generally cannot reconstruct original
 Maven/CocoaPods coordinates, transitive graph, versions, or license obligations.
+
+The default prebuilt installers fetch each release asset's `.sha256` sidecar,
+reject malformed or mismatched sidecars, and verify cached and newly downloaded
+artifacts before extraction. The sidecar and artifact share the same GitHub
+Release/TLS trust boundary; this detects corruption and cache tampering but is
+not an independent signature. Pin or independently attest release digests when
+your supply-chain policy requires stronger publisher authentication.
 
 ## Reproducible audit checklist
 

--- a/packages/react-native-nitro-geolocation/NitroGeolocation.podspec
+++ b/packages/react-native-nitro-geolocation/NitroGeolocation.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'
+  s.resource_bundles = {
+    "NitroGeolocationPrivacy" => ["ios/PrivacyInfo.xcprivacy"]
+  }
 
   if prebuilt_available
     s.vendored_frameworks = "prebuilds/ios/NitroGeolocation.xcframework"

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -174,6 +174,12 @@ alone does not mutate native files. See the
 [Expo development build guide](https://react-native-nitro-geolocation.pages.dev/guide/expo-development-build)
 for foreground and explicit background options.
 
+Before release, review the project's
+[privacy statement](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/PRIVACY.md)
+and [privacy and compliance guide](https://react-native-nitro-geolocation.pages.dev/guide/privacy-compliance)
+for runtime data flows, permission disclosures, dependency inventory, SBOM, and
+scanner guidance.
+
 Released npm builds try to use the matching GitHub Release prebuilts first:
 Android downloads the release AAR and reuses its native `.so` files, while iOS
 downloads the release XCFramework. If the prebuilt asset is unavailable, the

--- a/packages/react-native-nitro-geolocation/android/build.gradle
+++ b/packages/react-native-nitro-geolocation/android/build.gradle
@@ -1,3 +1,5 @@
+import java.security.MessageDigest
+
 buildscript {
   ext.getExtOrDefault = {name ->
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['NitroGeolocation_' + name]
@@ -106,6 +108,7 @@ def prebuiltUrlBase = getNitroGeolocationStringProperty(
   "https://github.com/jingjing2222/react-native-nitro-geolocation/releases/download/${encodedPrebuiltTag}"
 )
 def prebuiltUrl = "${prebuiltUrlBase}/${prebuiltAssetName}"
+def prebuiltChecksumUrl = "${prebuiltUrl}.sha256"
 def prebuiltCacheDir = new File(gradle.gradleUserHomeDir, "caches/react-native-nitro-geolocation/${packageVersion}")
 def prebuiltAarFile = new File(prebuiltCacheDir, prebuiltAssetName)
 def prebuiltJniDir = file("${buildDir}/generated/prebuilt-jni")
@@ -119,14 +122,38 @@ def isAndroidPrebuiltAbiCompatible = {
     parseMajorMinor(consumerNitroModulesVersion) == parseMajorMinor(bundledNitroModulesVersion)
 }
 
+def sha256File = { target ->
+  def digest = MessageDigest.getInstance("SHA-256")
+  target.eachByte(8192) { buffer, count -> digest.update(buffer, 0, count) }
+  return digest.digest().encodeHex().toString()
+}
+
+def expectedPrebuiltChecksum = {
+  def parts = new URL(prebuiltChecksumUrl).text.trim().split(/\s+/, 2)
+  if (parts.length == 0 || !(parts[0] ==~ /(?i)[0-9a-f]{64}/)) {
+    throw new GradleException("Invalid SHA-256 file for ${prebuiltAssetName}")
+  }
+  if (parts.length > 1 && new File(parts[1].replaceFirst(/^\*/, "")).name != prebuiltAssetName) {
+    throw new GradleException("SHA-256 file referenced a different Android asset")
+  }
+  return parts[0].toLowerCase()
+}
+
 def downloadNitroGeolocationPrebuiltIfAvailable = {
   try {
+    def expectedChecksum = expectedPrebuiltChecksum()
+    if (prebuiltAarFile.exists() && sha256File(prebuiltAarFile) != expectedChecksum) {
+      prebuiltAarFile.delete()
+    }
     if (!prebuiltAarFile.exists()) {
       prebuiltCacheDir.mkdirs()
       logger.lifecycle("[NitroGeolocation] Downloading Android prebuilt AAR: ${prebuiltUrl}")
       new URL(prebuiltUrl).withInputStream { input ->
         prebuiltAarFile.withOutputStream { output -> output << input }
       }
+    }
+    if (sha256File(prebuiltAarFile) != expectedChecksum) {
+      throw new GradleException("SHA-256 mismatch for ${prebuiltAssetName}")
     }
 
     logger.lifecycle("[NitroGeolocation] Using Android prebuilt native libraries from ${prebuiltAarFile}")

--- a/packages/react-native-nitro-geolocation/android/build.gradle
+++ b/packages/react-native-nitro-geolocation/android/build.gradle
@@ -1,5 +1,3 @@
-import java.security.MessageDigest
-
 buildscript {
   ext.getExtOrDefault = {name ->
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['NitroGeolocation_' + name]
@@ -27,6 +25,7 @@ apply plugin: "kotlin-android"
 apply from: '../nitrogen/generated/android/nitrogeolocation+autolinking.gradle'
 
 apply plugin: "com.facebook.react"
+apply from: "prebuilt_checksum.gradle"
 
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["NitroGeolocation_" + name]).toInteger()
@@ -109,8 +108,12 @@ def prebuiltUrlBase = getNitroGeolocationStringProperty(
 )
 def prebuiltUrl = "${prebuiltUrlBase}/${prebuiltAssetName}"
 def prebuiltChecksumUrl = "${prebuiltUrl}.sha256"
-def prebuiltCacheDir = new File(gradle.gradleUserHomeDir, "caches/react-native-nitro-geolocation/${packageVersion}")
+def prebuiltCacheDir = new File(getNitroGeolocationStringProperty(
+  "prebuiltCacheDir",
+  new File(gradle.gradleUserHomeDir, "caches/react-native-nitro-geolocation/${packageVersion}").path
+))
 def prebuiltAarFile = new File(prebuiltCacheDir, prebuiltAssetName)
+def prebuiltChecksumFile = new File(prebuiltCacheDir, "${prebuiltAssetName}.sha256")
 def prebuiltJniDir = file("${buildDir}/generated/prebuilt-jni")
 
 def bundledReactNativeVersion = packageJson.devDependencies["react-native"]
@@ -120,51 +123,6 @@ def consumerNitroModulesVersion = readNodeModuleVersion("react-native-nitro-modu
 def isAndroidPrebuiltAbiCompatible = {
   return parseMajorMinor(consumerReactNativeVersion) == parseMajorMinor(bundledReactNativeVersion) &&
     parseMajorMinor(consumerNitroModulesVersion) == parseMajorMinor(bundledNitroModulesVersion)
-}
-
-def sha256File = { target ->
-  def digest = MessageDigest.getInstance("SHA-256")
-  target.eachByte(8192) { buffer, count -> digest.update(buffer, 0, count) }
-  return digest.digest().encodeHex().toString()
-}
-
-def expectedPrebuiltChecksum = {
-  def parts = new URL(prebuiltChecksumUrl).text.trim().split(/\s+/, 2)
-  if (parts.length == 0 || !(parts[0] ==~ /(?i)[0-9a-f]{64}/)) {
-    throw new GradleException("Invalid SHA-256 file for ${prebuiltAssetName}")
-  }
-  if (parts.length > 1 && new File(parts[1].replaceFirst(/^\*/, "")).name != prebuiltAssetName) {
-    throw new GradleException("SHA-256 file referenced a different Android asset")
-  }
-  return parts[0].toLowerCase()
-}
-
-def downloadNitroGeolocationPrebuiltIfAvailable = {
-  try {
-    def expectedChecksum = expectedPrebuiltChecksum()
-    if (prebuiltAarFile.exists() && sha256File(prebuiltAarFile) != expectedChecksum) {
-      prebuiltAarFile.delete()
-    }
-    if (!prebuiltAarFile.exists()) {
-      prebuiltCacheDir.mkdirs()
-      logger.lifecycle("[NitroGeolocation] Downloading Android prebuilt AAR: ${prebuiltUrl}")
-      new URL(prebuiltUrl).withInputStream { input ->
-        prebuiltAarFile.withOutputStream { output -> output << input }
-      }
-    }
-    if (sha256File(prebuiltAarFile) != expectedChecksum) {
-      throw new GradleException("SHA-256 mismatch for ${prebuiltAssetName}")
-    }
-
-    logger.lifecycle("[NitroGeolocation] Using Android prebuilt native libraries from ${prebuiltAarFile}")
-    return true
-  } catch (Throwable error) {
-    if (prebuiltAarFile.exists()) {
-      prebuiltAarFile.delete()
-    }
-    logger.warn("[NitroGeolocation] Android prebuilt unavailable (${error.message}). Falling back to source build.")
-    return false
-  }
 }
 
 def extractNitroGeolocationPrebuilt = {
@@ -199,11 +157,21 @@ if (shouldAttemptPrebuilt && !isAndroidPrebuiltAbiCompatible()) {
       "assets target React Native ${bundledReactNativeVersion} and NitroModules ${bundledNitroModulesVersion}."
   )
 }
-def usePrebuilt = shouldAttemptPrebuilt && isAndroidPrebuiltAbiCompatible() && downloadNitroGeolocationPrebuiltIfAvailable()
+def prebuiltResolution = shouldAttemptPrebuilt && isAndroidPrebuiltAbiCompatible() ?
+  resolveNitroGeolocationPrebuilt(
+    assetName: prebuiltAssetName,
+    assetUrl: prebuiltUrl,
+    checksumUrl: prebuiltChecksumUrl,
+    cacheDir: prebuiltCacheDir
+  ) : null
+def usePrebuilt = prebuiltResolution != null
 
 def preparePrebuiltTaskProvider = null
 if (usePrebuilt) {
   preparePrebuiltTaskProvider = tasks.register("prepareNitroGeolocationPrebuilt") {
+    inputs.file(prebuiltAarFile)
+    inputs.file(prebuiltChecksumFile)
+    inputs.property("verifiedChecksum", prebuiltResolution.checksum)
     outputs.dir(prebuiltJniDir)
 
     doLast {

--- a/packages/react-native-nitro-geolocation/android/prebuilt_checksum.gradle
+++ b/packages/react-native-nitro-geolocation/android/prebuilt_checksum.gradle
@@ -1,0 +1,82 @@
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+
+def sha256File = { File target ->
+  def digest = MessageDigest.getInstance("SHA-256")
+  target.eachByte(8192) { buffer, count -> digest.update(buffer, 0, count) }
+  digest.digest().encodeHex().toString()
+}
+
+def parseChecksum = { String contents, String assetName ->
+  def parts = contents.trim().split(/\s+/, 2)
+  if (parts.length == 0 || !(parts[0] ==~ /(?i)[0-9a-f]{64}/)) {
+    throw new GradleException("Invalid SHA-256 file for ${assetName}")
+  }
+  if (parts.length > 1 && new File(parts[1].replaceFirst(/^\*/, "")).name != assetName) {
+    throw new GradleException("SHA-256 file referenced a different Android asset")
+  }
+  parts[0].toLowerCase()
+}
+
+def downloadFile = { String url, File destination ->
+  destination.parentFile.mkdirs()
+  def temporary = new File(destination.parentFile, ".${destination.name}.${UUID.randomUUID()}.tmp")
+  try {
+    new URL(url).withInputStream { input ->
+      temporary.withOutputStream { output -> output << input }
+    }
+    Files.move(temporary.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING)
+  } finally {
+    temporary.delete()
+  }
+}
+
+ext.resolveNitroGeolocationPrebuilt = { Map options ->
+  File cacheDir = options.cacheDir
+  File assetFile = new File(cacheDir, options.assetName)
+  File checksumFile = new File(cacheDir, "${options.assetName}.sha256")
+
+  try {
+    String expectedChecksum = null
+    if (checksumFile.exists()) {
+      try {
+        expectedChecksum = parseChecksum(checksumFile.text, options.assetName)
+      } catch (Throwable ignored) {
+        checksumFile.delete()
+      }
+    }
+
+    if (expectedChecksum != null && assetFile.exists()) {
+      if (sha256File(assetFile) == expectedChecksum) {
+        logger.lifecycle("[NitroGeolocation] Using verified Android prebuilt cache: ${assetFile}")
+        return [assetFile: assetFile, checksumFile: checksumFile, checksum: expectedChecksum]
+      }
+      assetFile.delete()
+    }
+
+    if (expectedChecksum == null) {
+      logger.lifecycle("[NitroGeolocation] Fetching Android prebuilt checksum: ${options.checksumUrl}")
+      downloadFile(options.checksumUrl, checksumFile)
+      expectedChecksum = parseChecksum(checksumFile.text, options.assetName)
+    }
+
+    if (assetFile.exists() && sha256File(assetFile) != expectedChecksum) {
+      assetFile.delete()
+    }
+    if (!assetFile.exists()) {
+      logger.lifecycle("[NitroGeolocation] Downloading Android prebuilt AAR: ${options.assetUrl}")
+      downloadFile(options.assetUrl, assetFile)
+    }
+    if (sha256File(assetFile) != expectedChecksum) {
+      assetFile.delete()
+      throw new GradleException("SHA-256 mismatch for ${options.assetName}")
+    }
+
+    logger.lifecycle("[NitroGeolocation] Using Android prebuilt native libraries from ${assetFile}")
+    [assetFile: assetFile, checksumFile: checksumFile, checksum: expectedChecksum]
+  } catch (Throwable error) {
+    logger.warn("[NitroGeolocation] Android prebuilt unavailable (${error.message}). Falling back to source build.")
+    null
+  }
+}

--- a/packages/react-native-nitro-geolocation/android/prebuilt_checksum.gradle
+++ b/packages/react-native-nitro-geolocation/android/prebuilt_checksum.gradle
@@ -70,6 +70,7 @@ ext.resolveNitroGeolocationPrebuilt = { Map options ->
     }
     if (sha256File(assetFile) != expectedChecksum) {
       assetFile.delete()
+      checksumFile.delete()
       throw new GradleException("SHA-256 mismatch for ${options.assetName}")
     }
 

--- a/packages/react-native-nitro-geolocation/ios/PrivacyInfo.xcprivacy
+++ b/packages/react-native-nitro-geolocation/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/react-native-nitro-geolocation/ios/PrivacyInfo.xcprivacy
+++ b/packages/react-native-nitro-geolocation/ios/PrivacyInfo.xcprivacy
@@ -14,7 +14,20 @@
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePreciseLocation</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -70,6 +70,7 @@
     "scripts/*.rb",
     "scripts/*.mjs",
     "android/build.gradle",
+    "android/prebuilt_checksum.gradle",
     "android/gradle.properties",
     "android/CMakeLists.txt",
     "android/src/**/*",

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -79,6 +79,7 @@
     "ios/**/*.mm",
     "ios/**/*.cpp",
     "ios/**/*.swift",
+    "ios/PrivacyInfo.xcprivacy",
     "!src/**/*.test.ts",
     "!src/**/*.test.tsx",
     "!src/**/*.spec.ts",

--- a/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
+++ b/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "digest"
 require "json"
 require "open-uri"
 require "uri"
@@ -39,35 +40,63 @@ module NitroGeolocationPrebuiltIOS
     value.nil? || value.empty? ? default_value : value
   end
 
+  def read_url(url)
+    uri = URI.parse(url)
+    return File.binread(uri.path) if uri.scheme == "file"
+
+    URI.open(url, &:read)
+  end
+
+  def download(url, path)
+    uri = URI.parse(url)
+    if uri.scheme == "file"
+      FileUtils.cp(uri.path, path)
+    else
+      URI.open(url) do |input|
+        File.open(path, "wb") { |output| IO.copy_stream(input, output) }
+      end
+    end
+  end
+
+  def expected_checksum(contents, asset_name)
+    checksum, referenced_path = contents.strip.split(/\s+/, 2)
+    unless checksum&.match?(/\A[0-9a-fA-F]{64}\z/)
+      raise "invalid SHA-256 file for #{asset_name}"
+    end
+    if referenced_path && File.basename(referenced_path.delete_prefix("*")) != asset_name
+      raise "SHA-256 file referenced a different asset"
+    end
+
+    checksum.downcase
+  end
+
   def ensure_framework(package_dir, package)
     version = package.fetch("version")
     tag = "react-native-nitro-geolocation@#{version}"
     encoded_tag = URI.encode_www_form_component(tag)
     asset_name = "react-native-nitro-geolocation-#{version}-ios.xcframework.zip"
+    checksum_name = "#{asset_name}.sha256"
     default_url_base = "https://github.com/jingjing2222/react-native-nitro-geolocation/releases/download/#{encoded_tag}"
     url = "#{string_config('prebuiltUrlBase', default_url_base)}/#{asset_name}"
+    checksum_url = "#{string_config('prebuiltUrlBase', default_url_base)}/#{checksum_name}"
 
     destination_dir = File.join(package_dir, "prebuilds", "ios")
     framework_path = File.join(destination_dir, FRAMEWORK_NAME)
     marker_path = File.join(destination_dir, ".version")
-    if File.directory?(framework_path) && File.exist?(marker_path) && File.read(marker_path).strip == version
-      return true
-    end
-
     cache_dir = File.expand_path("~/Library/Caches/react-native-nitro-geolocation/#{version}")
     zip_path = File.join(cache_dir, asset_name)
 
     FileUtils.mkdir_p(cache_dir)
+    checksum = expected_checksum(read_url(checksum_url), asset_name)
+    if File.exist?(zip_path) && Digest::SHA256.file(zip_path).hexdigest != checksum
+      FileUtils.rm_f(zip_path)
+    end
     unless File.exist?(zip_path)
       Pod::UI.puts "[NitroGeolocation] Downloading iOS prebuilt XCFramework: #{url}"
-      uri = URI.parse(url)
-      if uri.scheme == "file"
-        FileUtils.cp(uri.path, zip_path)
-      else
-        URI.open(url) do |input|
-          File.open(zip_path, "wb") { |output| IO.copy_stream(input, output) }
-        end
-      end
+      download(url, zip_path)
+    end
+    unless Digest::SHA256.file(zip_path).hexdigest == checksum
+      raise "SHA-256 mismatch for #{asset_name}"
     end
 
     FileUtils.rm_rf(destination_dir)
@@ -78,6 +107,11 @@ module NitroGeolocationPrebuiltIOS
 
     unless File.directory?(framework_path)
       raise "zip did not contain #{FRAMEWORK_NAME}"
+    end
+
+    frameworks = Dir.glob(File.join(framework_path, "**", "*.framework"))
+    unless frameworks.any? && frameworks.all? { |path| File.file?(File.join(path, "PrivacyInfo.xcprivacy")) }
+      raise "prebuilt framework did not contain PrivacyInfo.xcprivacy in every slice"
     end
 
     File.write(marker_path, version)

--- a/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
+++ b/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
@@ -85,17 +85,36 @@ module NitroGeolocationPrebuiltIOS
     marker_path = File.join(destination_dir, ".version")
     cache_dir = File.expand_path("~/Library/Caches/react-native-nitro-geolocation/#{version}")
     zip_path = File.join(cache_dir, asset_name)
+    cached_checksum_path = File.join(cache_dir, checksum_name)
 
     FileUtils.mkdir_p(cache_dir)
-    checksum = expected_checksum(read_url(checksum_url), asset_name)
-    if File.exist?(zip_path) && Digest::SHA256.file(zip_path).hexdigest != checksum
+    checksum = nil
+    if File.exist?(cached_checksum_path)
+      begin
+        checksum = expected_checksum(File.read(cached_checksum_path), asset_name)
+      rescue StandardError
+        FileUtils.rm_f(cached_checksum_path)
+      end
+    end
+
+    if checksum && File.exist?(zip_path) && Digest::SHA256.file(zip_path).hexdigest == checksum
+      Pod::UI.puts "[NitroGeolocation] Using verified iOS prebuilt cache: #{zip_path}"
+    else
       FileUtils.rm_f(zip_path)
+    end
+
+    unless checksum
+      Pod::UI.puts "[NitroGeolocation] Fetching iOS prebuilt checksum: #{checksum_url}"
+      checksum_contents = read_url(checksum_url)
+      checksum = expected_checksum(checksum_contents, asset_name)
+      File.write(cached_checksum_path, checksum_contents)
     end
     unless File.exist?(zip_path)
       Pod::UI.puts "[NitroGeolocation] Downloading iOS prebuilt XCFramework: #{url}"
       download(url, zip_path)
     end
     unless Digest::SHA256.file(zip_path).hexdigest == checksum
+      FileUtils.rm_f(zip_path)
       raise "SHA-256 mismatch for #{asset_name}"
     end
 
@@ -118,7 +137,6 @@ module NitroGeolocationPrebuiltIOS
     Pod::UI.puts "[NitroGeolocation] Using iOS prebuilt XCFramework from #{framework_path}"
     true
   rescue StandardError => error
-    FileUtils.rm_f(zip_path) if defined?(zip_path) && zip_path
     Pod::UI.warn "[NitroGeolocation] iOS prebuilt unavailable (#{error.message}). Falling back to source build."
     false
   end

--- a/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
+++ b/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
@@ -115,6 +115,7 @@ module NitroGeolocationPrebuiltIOS
     end
     unless Digest::SHA256.file(zip_path).hexdigest == checksum
       FileUtils.rm_f(zip_path)
+      FileUtils.rm_f(cached_checksum_path)
       raise "SHA-256 mismatch for #{asset_name}"
     end
 

--- a/scripts/build-prebuilt-ios.sh
+++ b/scripts/build-prebuilt-ios.sh
@@ -52,6 +52,10 @@ xcodebuild -create-xcframework \
   -framework "$BUILD_DIR/ios-simulator.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework" \
   -output "$BUILD_DIR/NitroGeolocation.xcframework"
 
+while IFS= read -r framework; do
+  cp "$PACKAGE_DIR/ios/PrivacyInfo.xcprivacy" "$framework/PrivacyInfo.xcprivacy"
+done < <(find "$BUILD_DIR/NitroGeolocation.xcframework" -type d -name '*.framework')
+
 rm -f "$OUT_DIR/$ASSET_NAME" "$OUT_DIR/$ASSET_NAME.sha256"
 (
   cd "$BUILD_DIR"

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -19,6 +19,14 @@ const prebuiltIOSScript = await readFile(
   path.join(root, "scripts/build-prebuilt-ios.sh"),
   "utf8"
 );
+const prebuiltIOSInstaller = await readFile(
+  path.join(packageDir, "scripts/prebuilt_ios.rb"),
+  "utf8"
+);
+const androidBuild = await readFile(
+  path.join(packageDir, "android/build.gradle"),
+  "utf8"
+);
 
 const globChars = /[*?[\]{}]/;
 const missingEntries = (packageJson.files ?? []).filter((entry) => {
@@ -68,6 +76,14 @@ if (
   failures.push("iOS privacy manifest must declare UserDefaults reason CA92.1");
 }
 if (
+  !privacyManifest.includes("NSPrivacyCollectedDataTypePreciseLocation") ||
+  !privacyManifest.includes("NSPrivacyCollectedDataTypePurposeAppFunctionality")
+) {
+  failures.push(
+    "iOS privacy manifest must disclose opt-in precise-location sync"
+  );
+}
+if (
   !podspec.includes('"NitroGeolocationPrivacy"') ||
   !podspec.includes('"ios/PrivacyInfo.xcprivacy"')
 ) {
@@ -76,6 +92,20 @@ if (
 if (!prebuiltIOSScript.includes('"$framework/PrivacyInfo.xcprivacy"')) {
   failures.push(
     "Prebuilt iOS frameworks must package the SDK privacy manifest"
+  );
+}
+if (
+  !prebuiltIOSInstaller.includes("Digest::SHA256.file") ||
+  !prebuiltIOSInstaller.includes('"#{asset_name}.sha256"')
+) {
+  failures.push("iOS prebuilt installation must verify the published SHA-256");
+}
+if (
+  !androidBuild.includes('MessageDigest.getInstance("SHA-256")') ||
+  !androidBuild.includes("prebuiltChecksumUrl")
+) {
+  failures.push(
+    "Android prebuilt installation must verify the published SHA-256"
   );
 }
 

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -55,7 +55,14 @@ const packedTests = packedFiles.filter((file) =>
   /(^|\/)([^/]+\.)?(test|spec)\.[cm]?[jt]sx?$/.test(file)
 );
 const requiredPrivacyFiles = ["ios/PrivacyInfo.xcprivacy"];
+const requiredPrebuiltFiles = [
+  "android/prebuilt_checksum.gradle",
+  "scripts/prebuilt_ios.rb"
+];
 const missingPrivacyFiles = requiredPrivacyFiles.filter(
+  (file) => !packedFiles.includes(file)
+);
+const missingPrebuiltFiles = requiredPrebuiltFiles.filter(
   (file) => !packedFiles.includes(file)
 );
 
@@ -71,6 +78,11 @@ if (packedTests.length > 0) {
 if (missingPrivacyFiles.length > 0) {
   failures.push(
     `Privacy manifest missing from npm pack: ${missingPrivacyFiles.join(", ")}`
+  );
+}
+if (missingPrebuiltFiles.length > 0) {
+  failures.push(
+    `Prebuilt installers missing from npm pack: ${missingPrebuiltFiles.join(", ")}`
   );
 }
 if (

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -27,6 +27,10 @@ const androidBuild = await readFile(
   path.join(packageDir, "android/build.gradle"),
   "utf8"
 );
+const androidChecksumInstaller = await readFile(
+  path.join(packageDir, "android/prebuilt_checksum.gradle"),
+  "utf8"
+);
 
 const globChars = /[*?[\]{}]/;
 const missingEntries = (packageJson.files ?? []).filter((entry) => {
@@ -101,8 +105,9 @@ if (
   failures.push("iOS prebuilt installation must verify the published SHA-256");
 }
 if (
-  !androidBuild.includes('MessageDigest.getInstance("SHA-256")') ||
-  !androidBuild.includes("prebuiltChecksumUrl")
+  !androidChecksumInstaller.includes('MessageDigest.getInstance("SHA-256")') ||
+  !androidBuild.includes("prebuiltChecksumUrl") ||
+  !androidBuild.includes("inputs.file(prebuiltAarFile)")
 ) {
   failures.push(
     "Android prebuilt installation must verify the published SHA-256"

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -7,6 +7,18 @@ const root = process.cwd();
 const packageDir = path.join(root, "packages/react-native-nitro-geolocation");
 const packageJsonPath = path.join(packageDir, "package.json");
 const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+const privacyManifest = await readFile(
+  path.join(packageDir, "ios/PrivacyInfo.xcprivacy"),
+  "utf8"
+);
+const podspec = await readFile(
+  path.join(packageDir, "NitroGeolocation.podspec"),
+  "utf8"
+);
+const prebuiltIOSScript = await readFile(
+  path.join(root, "scripts/build-prebuilt-ios.sh"),
+  "utf8"
+);
 
 const globChars = /[*?[\]{}]/;
 const missingEntries = (packageJson.files ?? []).filter((entry) => {
@@ -30,6 +42,10 @@ const packedFiles = metadata.files.map((file) => file.path);
 const packedTests = packedFiles.filter((file) =>
   /(^|\/)([^/]+\.)?(test|spec)\.[cm]?[jt]sx?$/.test(file)
 );
+const requiredPrivacyFiles = ["ios/PrivacyInfo.xcprivacy"];
+const missingPrivacyFiles = requiredPrivacyFiles.filter(
+  (file) => !packedFiles.includes(file)
+);
 
 const failures = [];
 if (missingEntries.length > 0) {
@@ -39,6 +55,28 @@ if (missingEntries.length > 0) {
 }
 if (packedTests.length > 0) {
   failures.push(`Test files included in npm pack: ${packedTests.join(", ")}`);
+}
+if (missingPrivacyFiles.length > 0) {
+  failures.push(
+    `Privacy manifest missing from npm pack: ${missingPrivacyFiles.join(", ")}`
+  );
+}
+if (
+  !privacyManifest.includes("NSPrivacyAccessedAPICategoryUserDefaults") ||
+  !privacyManifest.includes("CA92.1")
+) {
+  failures.push("iOS privacy manifest must declare UserDefaults reason CA92.1");
+}
+if (
+  !podspec.includes('"NitroGeolocationPrivacy"') ||
+  !podspec.includes('"ios/PrivacyInfo.xcprivacy"')
+) {
+  failures.push("CocoaPods must package the SDK privacy manifest");
+}
+if (!prebuiltIOSScript.includes('"$framework/PrivacyInfo.xcprivacy"')) {
+  failures.push(
+    "Prebuilt iOS frameworks must package the SDK privacy manifest"
+  );
 }
 
 if (failures.length > 0) {

--- a/scripts/test-android-prebuilt-checksum.sh
+++ b/scripts/test-android-prebuilt-checksum.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANDROID_DIR="$ROOT_DIR/examples/v0.81.1/android"
+PACKAGE_JSON="$ROOT_DIR/packages/react-native-nitro-geolocation/package.json"
+VERSION="$(node -p "require('$PACKAGE_JSON').version")"
+ASSET_NAME="react-native-nitro-geolocation-${VERSION}-android.aar"
+TEST_ROOT="$(mktemp -d -t nitro-geolocation-android-checksum.XXXXXX)"
+RELEASE_DIR="$TEST_ROOT/release"
+CACHE_DIR="$TEST_ROOT/cache"
+OUTPUT_SO="$ROOT_DIR/packages/react-native-nitro-geolocation/android/build/generated/prebuilt-jni/arm64-v8a/libnitrogeolocation.so"
+
+cleanup() {
+  if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+    rm -rf -- "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+make_asset() {
+  local contents="$1"
+  local payload_dir="$TEST_ROOT/payload"
+  rm -rf -- "$payload_dir"
+  mkdir -p "$payload_dir/jni/arm64-v8a" "$RELEASE_DIR"
+  printf '%s' "$contents" > "$payload_dir/jni/arm64-v8a/libnitrogeolocation.so"
+  (
+    cd "$payload_dir"
+    zip -q -r "$RELEASE_DIR/$ASSET_NAME" jni
+  )
+  (
+    cd "$RELEASE_DIR"
+    shasum -a 256 "$ASSET_NAME" > "$ASSET_NAME.sha256"
+  )
+}
+
+run_prebuilt_task() {
+  NITRO_GEOLOCATION_USE_PREBUILT=1 \
+    NITRO_GEOLOCATION_PREBUILT_URL_BASE="file://$RELEASE_DIR" \
+    NITRO_GEOLOCATION_PREBUILT_CACHE_DIR="$CACHE_DIR" \
+    "$ANDROID_DIR/gradlew" -p "$ANDROID_DIR" \
+    :react-native-nitro-geolocation:prepareNitroGeolocationPrebuilt \
+    -PNitroGeolocation_usePrebuilt=true --console=plain "$@"
+}
+
+run_configuration_only() {
+  local scenario_cache="$1"
+  NITRO_GEOLOCATION_USE_PREBUILT=1 \
+    NITRO_GEOLOCATION_PREBUILT_URL_BASE="file://$RELEASE_DIR" \
+    NITRO_GEOLOCATION_PREBUILT_CACHE_DIR="$scenario_cache" \
+    "$ANDROID_DIR/gradlew" -p "$ANDROID_DIR" help \
+    -PNitroGeolocation_usePrebuilt=true --console=plain
+}
+
+make_asset "native-v1"
+cp "$RELEASE_DIR/$ASSET_NAME" "$TEST_ROOT/$ASSET_NAME.v1"
+cp "$RELEASE_DIR/$ASSET_NAME.sha256" "$TEST_ROOT/$ASSET_NAME.v1.sha256"
+run_prebuilt_task
+test "$(<"$OUTPUT_SO")" = "native-v1"
+
+rm -rf -- "$RELEASE_DIR"
+run_prebuilt_task --rerun-tasks
+test "$(<"$OUTPUT_SO")" = "native-v1"
+
+mkdir -p "$RELEASE_DIR"
+cp "$TEST_ROOT/$ASSET_NAME.v1" "$RELEASE_DIR/$ASSET_NAME"
+cp "$TEST_ROOT/$ASSET_NAME.v1.sha256" "$RELEASE_DIR/$ASSET_NAME.sha256"
+printf 'tampered' > "$CACHE_DIR/$ASSET_NAME"
+run_prebuilt_task --rerun-tasks
+cmp "$RELEASE_DIR/$ASSET_NAME" "$CACHE_DIR/$ASSET_NAME"
+
+make_asset "native-v2"
+cp "$RELEASE_DIR/$ASSET_NAME.sha256" "$CACHE_DIR/$ASSET_NAME.sha256"
+run_prebuilt_task
+test "$(<"$OUTPUT_SO")" = "native-v2"
+
+MISMATCH_CACHE="$TEST_ROOT/mismatch-cache"
+printf '%064d  %s\n' 0 "$ASSET_NAME" > "$RELEASE_DIR/$ASSET_NAME.sha256"
+run_configuration_only "$MISMATCH_CACHE" 2>&1 | tee "$TEST_ROOT/mismatch.log"
+grep -q "SHA-256 mismatch" "$TEST_ROOT/mismatch.log"
+test ! -e "$MISMATCH_CACHE/$ASSET_NAME"
+
+MALFORMED_CACHE="$TEST_ROOT/malformed-cache"
+printf 'not-a-checksum\n' > "$RELEASE_DIR/$ASSET_NAME.sha256"
+run_configuration_only "$MALFORMED_CACHE" 2>&1 | tee "$TEST_ROOT/malformed.log"
+grep -q "Invalid SHA-256" "$TEST_ROOT/malformed.log"
+test ! -e "$MALFORMED_CACHE/$ASSET_NAME"
+
+echo "Android prebuilt checksum tests passed."

--- a/scripts/test-android-prebuilt-checksum.sh
+++ b/scripts/test-android-prebuilt-checksum.sh
@@ -79,6 +79,15 @@ printf '%064d  %s\n' 0 "$ASSET_NAME" > "$RELEASE_DIR/$ASSET_NAME.sha256"
 run_configuration_only "$MISMATCH_CACHE" 2>&1 | tee "$TEST_ROOT/mismatch.log"
 grep -q "SHA-256 mismatch" "$TEST_ROOT/mismatch.log"
 test ! -e "$MISMATCH_CACHE/$ASSET_NAME"
+test ! -e "$MISMATCH_CACHE/$ASSET_NAME.sha256"
+
+(
+  cd "$RELEASE_DIR"
+  shasum -a 256 "$ASSET_NAME" > "$ASSET_NAME.sha256"
+)
+CACHE_DIR="$MISMATCH_CACHE"
+run_prebuilt_task --rerun-tasks
+test "$(<"$OUTPUT_SO")" = "native-v2"
 
 MALFORMED_CACHE="$TEST_ROOT/malformed-cache"
 printf 'not-a-checksum\n' > "$RELEASE_DIR/$ASSET_NAME.sha256"

--- a/tests/ruby/prebuilt_ios_checksum_test.rb
+++ b/tests/ruby/prebuilt_ios_checksum_test.rb
@@ -45,6 +45,15 @@ class PrebuiltIOSChecksumTest < Minitest::Test
       Digest::SHA256.file(cache_path).hexdigest
   end
 
+  def test_reuses_verified_cache_without_release_network
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    FileUtils.rm_rf(release_directory)
+    FileUtils.rm_rf(File.join(package_directory, "prebuilds"))
+
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    assert_path_exists privacy_manifest_path
+  end
+
   def test_rejects_a_mismatched_release_checksum
     File.write(checksum_path, "#{'0' * 64}  #{asset_name}\n")
 

--- a/tests/ruby/prebuilt_ios_checksum_test.rb
+++ b/tests/ruby/prebuilt_ios_checksum_test.rb
@@ -1,0 +1,83 @@
+require "digest"
+require "fileutils"
+require "minitest/autorun"
+require "tmpdir"
+
+module Pod
+  module UI
+    module_function
+
+    def puts(_message); end
+    def warn(_message); end
+  end
+end
+
+require_relative "../../packages/react-native-nitro-geolocation/scripts/prebuilt_ios"
+
+class PrebuiltIOSChecksumTest < Minitest::Test
+  def setup
+    @temporary_directory = Dir.mktmpdir("nitro-prebuilt-ios-test")
+    @original_home = ENV.fetch("HOME")
+    @original_url_base = ENV["NITRO_GEOLOCATION_PREBUILT_URL_BASE"]
+    ENV["HOME"] = File.join(@temporary_directory, "home")
+    ENV["NITRO_GEOLOCATION_PREBUILT_URL_BASE"] = "file://#{release_directory}"
+    FileUtils.mkdir_p(package_directory)
+    create_release_asset
+  end
+
+  def teardown
+    ENV["HOME"] = @original_home
+    ENV["NITRO_GEOLOCATION_PREBUILT_URL_BASE"] = @original_url_base
+    FileUtils.rm_rf(@temporary_directory)
+  end
+
+  def test_extracts_an_asset_with_a_matching_checksum
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    assert_path_exists privacy_manifest_path
+  end
+
+  def test_replaces_a_tampered_cached_archive_before_extraction
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    File.binwrite(cache_path, "tampered")
+
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    assert_equal Digest::SHA256.file(asset_path).hexdigest,
+      Digest::SHA256.file(cache_path).hexdigest
+  end
+
+  def test_rejects_a_mismatched_release_checksum
+    File.write(checksum_path, "#{'0' * 64}  #{asset_name}\n")
+
+    refute NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
+    refute_path_exists cache_path
+  end
+
+  private
+
+  def package = { "version" => version }
+  def version = "9.9.9"
+  def package_directory = File.join(@temporary_directory, "package")
+  def release_directory = File.join(@temporary_directory, "release")
+  def asset_name = "react-native-nitro-geolocation-#{version}-ios.xcframework.zip"
+  def asset_path = File.join(release_directory, asset_name)
+  def checksum_path = "#{asset_path}.sha256"
+  def cache_path = File.join(ENV.fetch("HOME"), "Library", "Caches",
+    "react-native-nitro-geolocation", version, asset_name)
+  def privacy_manifest_path = File.join(package_directory, "prebuilds", "ios",
+    "NitroGeolocation.xcframework", "ios-arm64", "NitroGeolocation.framework",
+    "PrivacyInfo.xcprivacy")
+
+  def create_release_asset
+    framework = File.join(@temporary_directory, "archive",
+      "NitroGeolocation.xcframework", "ios-arm64", "NitroGeolocation.framework")
+    FileUtils.mkdir_p(framework)
+    File.write(File.join(framework, "NitroGeolocation"), "binary")
+    File.write(File.join(framework, "PrivacyInfo.xcprivacy"), "privacy")
+    FileUtils.mkdir_p(release_directory)
+    system("/usr/bin/ditto", "-c", "-k", "--keepParent",
+      File.join(@temporary_directory, "archive", "NitroGeolocation.xcframework"),
+      asset_path, exception: true)
+    digest = Digest::SHA256.file(asset_path).hexdigest
+    File.write(checksum_path, "#{digest}  #{asset_name}\n")
+  end
+end

--- a/tests/ruby/prebuilt_ios_checksum_test.rb
+++ b/tests/ruby/prebuilt_ios_checksum_test.rb
@@ -59,6 +59,10 @@ class PrebuiltIOSChecksumTest < Minitest::Test
 
     refute NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
     refute_path_exists cache_path
+    refute_path_exists cached_checksum_path
+
+    write_release_checksum
+    assert NitroGeolocationPrebuiltIOS.ensure_framework(package_directory, package)
   end
 
   private
@@ -72,6 +76,7 @@ class PrebuiltIOSChecksumTest < Minitest::Test
   def checksum_path = "#{asset_path}.sha256"
   def cache_path = File.join(ENV.fetch("HOME"), "Library", "Caches",
     "react-native-nitro-geolocation", version, asset_name)
+  def cached_checksum_path = "#{cache_path}.sha256"
   def privacy_manifest_path = File.join(package_directory, "prebuilds", "ios",
     "NitroGeolocation.xcframework", "ios-arm64", "NitroGeolocation.framework",
     "PrivacyInfo.xcprivacy")
@@ -86,6 +91,10 @@ class PrebuiltIOSChecksumTest < Minitest::Test
     system("/usr/bin/ditto", "-c", "-k", "--keepParent",
       File.join(@temporary_directory, "archive", "NitroGeolocation.xcframework"),
       asset_path, exception: true)
+    write_release_checksum
+  end
+
+  def write_release_checksum
     digest = Digest::SHA256.file(asset_path).hexdigest
     File.write(checksum_path, "#{digest}  #{asset_name}\n")
   end


### PR DESCRIPTION
## Summary
- document privacy, telemetry, storage, dependency, SBOM, scanner, and platform disclosure responsibilities
- ship the iOS privacy manifest through CocoaPods, npm, and every prebuilt framework slice
- verify Android and iOS prebuilts with persisted SHA-256 sidecars, offline reuse, tamper recovery, and package guards

## Changeset
- patch: compliance metadata and prebuilt integrity are additive packaging fixes

## Validation
- `yarn format:check`
- `yarn lint`
- `yarn test:unit` (16 files / 151 tests, prior feature head)
- `yarn typecheck`
- `yarn build:all`
- `yarn deadcode`
- `yarn pack:check` (544 packed files)
- `yarn source-lines:check`
- `ruby tests/ruby/prebuilt_ios_checksum_test.rb` (4 tests / 12 assertions)
- `scripts/test-android-prebuilt-checksum.sh` (actual Gradle valid/offline/tamper/replacement/mismatch/recovery/malformed paths)
- Android library unit tests and example `:app:assembleDebug`
- `yarn install --immutable`
- `plutil -lint packages/react-native-nitro-geolocation/ios/PrivacyInfo.xcprivacy`
- `git diff --check`

Mobile E2E was not run because this checkbox changes documentation and packaging/install-time integrity, not runtime location behavior. Affected package, installer, native build, and checksum paths were exercised instead.

## Review
Two adversarial reviews of exact HEAD `cefc647cbfa144ee88a4d31b1999f482f780569c` report no P1/P2 findings.