### PR TITLE
feat: make Watch Manager delivery subscription-aware

### DIFF
--- a/.changeset/curvy-watches-listen.md
+++ b/.changeset/curvy-watches-listen.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": major
+---
+
+Make Watch Manager v2 delivery semantics the default: native acquisition stays
+shared, while each Modern API watch independently enforces its own callback
+thresholds and cleanup lifecycle.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Verify iOS prebuilt checksums
         run: ruby tests/ruby/prebuilt_ios_checksum_test.rb
 
+      - name: Verify iOS watch delivery policy
+        run: scripts/test-ios-watch-delivery.sh
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/docs/docs/guide/watch-observability.md
+++ b/docs/docs/guide/watch-observability.md
@@ -85,10 +85,10 @@ measured from its last delivered position; suppressed native updates do not move
 the baseline or count toward `maxUpdates`. `fastestInterval` still contributes
 to the shared native request, while `interval` is the per-watch minimum callback
 period. Position watch registration, removal, native restart decisions, and
-callback delivery are serialized on Android's main looper. A callback may safely
-remove itself or another watch; a watch removed before its turn in the current
-native update is skipped. Heading watches use the Android sensor manager
-separately and apply each subscription's `headingFilter` independently.
+callback delivery are serialized on Android's main looper. `unwatch()` prevents
+delivery from subsequent native updates, but a callback already handed to the
+asynchronous JS bridge may still finish. Heading watches use the Android sensor
+manager separately and apply each subscription's `headingFilter` independently.
 
 ### iOS
 

--- a/docs/docs/guide/watch-observability.md
+++ b/docs/docs/guide/watch-observability.md
@@ -57,11 +57,13 @@ unsupported web heading requests are not reported as active.
   shared `CLLocationManager`; it restarts only when the selected Core Location
   mode changes.
 
-## Current native merge policy
+## Watch Manager v2 default
 
 Multiple position watches share native resources. Options are merged to serve
-the most demanding active consumers; this is observable behavior, not a new
-Watch Manager policy.
+the most demanding active acquisition, while callback delivery is evaluated
+against each subscription's own thresholds. A one-shot request or a second
+watch may make native acquisition more demanding, but cannot lower an existing
+watch's delivery threshold or move its last-delivered baseline.
 
 ### Android
 
@@ -76,9 +78,14 @@ native request uses:
   when any watch explicitly requires fine, otherwise permission granularity.
 
 `maxUpdates` remains per subscription. Reaching the limit removes only that
-watch, then stops or restarts the shared request as needed. Heading watches use
-the Android sensor manager separately and apply each subscription's
-`headingFilter` independently.
+watch, then stops or restarts the shared request as needed. For callback
+delivery, the first native position establishes each watch's baseline. Later
+positions must satisfy that watch's own `interval` and `distanceFilter`, both
+measured from its last delivered position; suppressed native updates do not move
+the baseline or count toward `maxUpdates`. `fastestInterval` still contributes
+to the shared native request, while `interval` is the per-watch minimum callback
+period. Heading watches use the Android sensor manager separately and apply each
+subscription's `headingFilter` independently.
 
 ### iOS
 
@@ -92,12 +99,25 @@ Position watches and pending one-shot position requests share one
   for it.
 
 Changing significant-change mode stops and restarts Core Location. Other
-position option changes reconfigure the existing manager. Heading watches share
-the same manager's heading sensor separately and use the smallest active heading
-filter.
+position option changes reconfigure the existing manager. Each position watch
+receives its first native position, then applies its own `distanceFilter` from
+the last position delivered to that watch. A nearby update accepted for a more
+demanding watch or one-shot request no longer leaks into a less frequent watch.
+Core Location does not expose the Android `interval` option. Heading watches
+share the same manager's heading sensor separately and apply each subscription's
+`headingFilter` independently.
 
 ### Web
 
 Each position watch maps to its own `navigator.geolocation.watchPosition()`
 call. Browser watches are not merged. The package applies each watch's
 `distanceFilter` in JavaScript.
+
+## Migration note
+
+The v1.x native managers delivered every shared native position to every watch,
+so adding a more demanding watch or one-shot request could increase callbacks
+for existing consumers. In v2, code that intentionally relied on that leakage
+must lower the affected watch's own `interval` or `distanceFilter`. Continue to
+call `unwatch(token)` for component-local cleanup and reserve `stopObserving()`
+for session-wide cleanup.

--- a/docs/docs/guide/watch-observability.md
+++ b/docs/docs/guide/watch-observability.md
@@ -84,8 +84,11 @@ positions must satisfy that watch's own `interval` and `distanceFilter`, both
 measured from its last delivered position; suppressed native updates do not move
 the baseline or count toward `maxUpdates`. `fastestInterval` still contributes
 to the shared native request, while `interval` is the per-watch minimum callback
-period. Heading watches use the Android sensor manager separately and apply each
-subscription's `headingFilter` independently.
+period. Position watch registration, removal, native restart decisions, and
+callback delivery are serialized on Android's main looper. A callback may safely
+remove itself or another watch; a watch removed before its turn in the current
+native update is skipped. Heading watches use the Android sensor manager
+separately and apply each subscription's `headingFilter` independently.
 
 ### iOS
 

--- a/examples/v0.81.1/.maestro/all-tests.yaml
+++ b/examples/v0.81.1/.maestro/all-tests.yaml
@@ -70,6 +70,7 @@ appId: nitrogeolocation.example
 - runFlow: cancellable-current-position.yaml
 - runFlow: watch-position.yaml
 - runFlow: watch-observability.yaml
+- runFlow: watch-manager-v2.yaml
 - runFlow: location-simulation.yaml
 - runFlow: accuracy-presets.yaml
 - runFlow: last-known-position.yaml

--- a/examples/v0.81.1/.maestro/watch-manager-v2.yaml
+++ b/examples/v0.81.1/.maestro/watch-manager-v2.yaml
@@ -56,6 +56,13 @@ appId: nitrogeolocation.example
 - assertVisible:
     text: "Near move: passed"
 
+# Android's slow watch uses a 25 s interval. Wait until that subscription's
+# threshold has elapsed before injecting the candidate it must receive.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - runScript: scripts/wait-15s.js
 - setLocation:
     latitude: 37.5765
     longitude: 126.9780

--- a/examples/v0.81.1/.maestro/watch-manager-v2.yaml
+++ b/examples/v0.81.1/.maestro/watch-manager-v2.yaml
@@ -1,0 +1,79 @@
+appId: nitrogeolocation.example
+---
+# Proves that two natural Modern API consumers keep independent delivery
+# thresholds and that removing one subscription leaves the other alive.
+
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+
+- extendedWaitUntil:
+    visible: "Geolocation API"
+    timeout: 10000
+
+- setLocation:
+    latitude: 37.5665
+    longitude: 126.9780
+
+- stopApp
+- openLink:
+    link: nitrogeolocation://app/watch-manager-v2
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Cancel|취소"
+    commands:
+      - tapOn:
+          text: "Open|열기"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: nitrogeolocation://app/watch-manager-v2
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Independent delivery thresholds and exact cleanup"
+    timeout: 10000
+- tapOn:
+    id: "e2e-action-watch-manager-v2-start-button"
+- extendedWaitUntil:
+    visible: "Initial delivery: passed"
+    timeout: 15000
+- tapOn:
+    id: "e2e-action-watch-manager-v2-baseline-button"
+- assertVisible:
+    text: "Baseline: passed"
+
+- setLocation:
+    latitude: 37.5668
+    longitude: 126.9780
+- runScript: scripts/wait-15s.js
+- tapOn:
+    id: "e2e-action-watch-manager-v2-near-button"
+- assertVisible:
+    text: "Near move: passed"
+
+- setLocation:
+    latitude: 37.5765
+    longitude: 126.9780
+- runScript: scripts/wait-15s.js
+- tapOn:
+    id: "e2e-action-watch-manager-v2-far-button"
+- assertVisible:
+    text: "Far move: passed"
+
+- tapOn:
+    id: "e2e-action-watch-manager-v2-cleanup-button"
+- assertVisible:
+    text: "Selective cleanup: passed"
+- setLocation:
+    latitude: 37.5865
+    longitude: 126.9780
+- runScript: scripts/wait-15s.js
+- tapOn:
+    id: "e2e-action-watch-manager-v2-remaining-button"
+- assertVisible:
+    text: "Remaining watch: passed"

--- a/examples/v0.81.1/.maestro/watch-manager-v2.yaml
+++ b/examples/v0.81.1/.maestro/watch-manager-v2.yaml
@@ -74,8 +74,9 @@ appId: nitrogeolocation.example
 
 - tapOn:
     id: "e2e-action-watch-manager-v2-cleanup-button"
-- assertVisible:
-    text: "Selective cleanup: passed"
+- extendedWaitUntil:
+    visible: "Selective cleanup: passed"
+    timeout: 5000
 - setLocation:
     latitude: 37.5865
     longitude: 126.9780

--- a/examples/v0.81.1/src/App.tsx
+++ b/examples/v0.81.1/src/App.tsx
@@ -45,6 +45,7 @@ import PermissionCheckScreen from "./screens/PermissionCheckScreen";
 import PermissionDetailsScreen from "./screens/PermissionDetailsScreen";
 import ProviderSettingsScreen from "./screens/ProviderSettingsScreen";
 import ProviderStatusWatcherScreen from "./screens/ProviderStatusWatcherScreen";
+import WatchManagerV2Screen from "./screens/WatchManagerV2Screen";
 import WatchObservabilityScreen from "./screens/WatchObservabilityScreen";
 import WatchPositionScreen from "./screens/WatchPositionScreen";
 import WebE2EScreen from "./screens/WebE2EScreen";
@@ -70,6 +71,7 @@ const linking = {
       CancellableCurrentPosition: "cancellable-current-position",
       WatchPosition: "watch-position",
       WatchObservability: "watch-observability",
+      WatchManagerV2: "watch-manager-v2",
       LocationSimulation: "location-simulation",
       MockedMetadata: "mocked-metadata",
       ProviderSettings: "provider-settings",
@@ -178,6 +180,11 @@ export default function App() {
           <Tab.Screen
             name="WatchObservability"
             component={WatchObservabilityScreen}
+            options={hiddenTabOptions}
+          />
+          <Tab.Screen
+            name="WatchManagerV2"
+            component={WatchManagerV2Screen}
             options={hiddenTabOptions}
           />
           <Tab.Screen

--- a/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
+++ b/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Text } from "react-native";
+import {
+  getActiveWatches,
+  requestPermission,
+  unwatch,
+  watchPosition
+} from "react-native-nitro-geolocation";
+import {
+  ResultBlock,
+  ScenarioButton,
+  ScenarioScreen,
+  ScenarioSection,
+  createScenarioResults,
+  getDisplayErrorMessage,
+  useScenarioResults
+} from "./scenario";
+
+const PREFIX = "watch-manager-v2";
+const initialResults = createScenarioResults([
+  "start",
+  "baseline",
+  "near",
+  "far",
+  "cleanup",
+  "remaining"
+] as const);
+type Counts = { eager: number; filtered: number };
+
+export default function WatchManagerV2Screen() {
+  const { results, setResult } = useScenarioResults(initialResults);
+  const tokensRef = useRef<{ eager?: string; filtered?: string }>({});
+  const countsRef = useRef<Counts>({ eager: 0, filtered: 0 });
+  const baselineRef = useRef<Counts | undefined>(undefined);
+  const nearRef = useRef<Counts | undefined>(undefined);
+  const cleanupRef = useRef<Counts | undefined>(undefined);
+  const mountedRef = useRef(true);
+  const [counts, setCounts] = useState(countsRef.current);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      for (const token of Object.values(tokensRef.current)) {
+        if (token) unwatch(token);
+      }
+      tokensRef.current = {};
+    };
+  }, []);
+
+  const recordUpdate = (kind: keyof Counts) => {
+    if (!mountedRef.current) return;
+    const next = { ...countsRef.current, [kind]: countsRef.current[kind] + 1 };
+    countsRef.current = next;
+    setCounts(next);
+    if (next.eager > 0 && next.filtered > 0) {
+      setResult("start", {
+        status: "passed",
+        message: "Both independent watches received their initial position."
+      });
+    }
+  };
+
+  const startWatches = async () => {
+    if (Object.values(tokensRef.current).some(Boolean)) {
+      setResult("start", {
+        status: "failed",
+        message: "Clean up the current watches before starting again."
+      });
+      return;
+    }
+
+    setResult("start", {
+      status: "running",
+      message: "Requesting permission and waiting for both initial positions"
+    });
+    try {
+      const permission = await requestPermission();
+      if (permission !== "granted") {
+        throw new Error(`Permission was not granted: ${permission}`);
+      }
+      const onError = (error: { message: string }) => {
+        if (mountedRef.current) {
+          setResult("start", { status: "failed", message: error.message });
+        }
+      };
+      tokensRef.current.eager = watchPosition(
+        () => recordUpdate("eager"),
+        onError,
+        { distanceFilter: 0, interval: 100, fastestInterval: 100 }
+      );
+      tokensRef.current.filtered = watchPosition(
+        () => recordUpdate("filtered"),
+        onError,
+        { distanceFilter: 500, interval: 100, fastestInterval: 100 }
+      );
+    } catch (error) {
+      setResult("start", {
+        status: "failed",
+        message: getDisplayErrorMessage(error)
+      });
+    }
+  };
+
+  const captureBaseline = () => {
+    const current = countsRef.current;
+    const ready = current.eager > 0 && current.filtered > 0;
+    if (ready) baselineRef.current = { ...current };
+    setResult("baseline", {
+      status: ready ? "passed" : "failed",
+      message: ready
+        ? "Captured both subscription baselines."
+        : "Wait for both initial watch callbacks."
+    });
+  };
+
+  const verifyNearUpdate = () => {
+    const baseline = baselineRef.current;
+    const current = countsRef.current;
+    const passed =
+      baseline !== undefined &&
+      current.eager > baseline.eager &&
+      current.filtered === baseline.filtered;
+    if (passed) nearRef.current = { ...current };
+    setResult("near", {
+      status: passed ? "passed" : "failed",
+      message: passed
+        ? "The eager watch advanced while the 500 m watch stayed filtered."
+        : "Expected only the eager watch to advance after the near move."
+    });
+  };
+
+  const verifyFarUpdate = () => {
+    const near = nearRef.current;
+    const current = countsRef.current;
+    const passed =
+      near !== undefined &&
+      current.eager > near.eager &&
+      current.filtered > near.filtered;
+    setResult("far", {
+      status: passed ? "passed" : "failed",
+      message: passed
+        ? "Both watches advanced after crossing the 500 m threshold."
+        : "Expected both watches to advance after the far move."
+    });
+  };
+
+  const removeEagerWatch = () => {
+    const eagerToken = tokensRef.current.eager;
+    if (!eagerToken) {
+      setResult("cleanup", {
+        status: "failed",
+        message: "The eager watch is not active."
+      });
+      return;
+    }
+    unwatch(eagerToken);
+    unwatch(eagerToken);
+    unwatch("watch-manager-v2-unknown-token");
+    tokensRef.current.eager = undefined;
+    cleanupRef.current = { ...countsRef.current };
+    const filteredToken = tokensRef.current.filtered;
+    const active = getActiveWatches();
+    const passed =
+      filteredToken !== undefined &&
+      active.some(({ token }) => token === filteredToken) &&
+      !active.some(({ token }) => token === eagerToken);
+    setResult("cleanup", {
+      status: passed ? "passed" : "failed",
+      message: passed
+        ? "Repeated cleanup removed only the eager watch."
+        : "Cleanup did not leave exactly the owned filtered watch."
+    });
+  };
+
+  const verifyRemainingWatch = () => {
+    const baseline = cleanupRef.current;
+    const current = countsRef.current;
+    const passed =
+      baseline !== undefined &&
+      current.eager === baseline.eager &&
+      current.filtered > baseline.filtered;
+    const filteredToken = tokensRef.current.filtered;
+    if (filteredToken) unwatch(filteredToken);
+    tokensRef.current.filtered = undefined;
+    const fullyCleaned = getActiveWatches().length === 0;
+    setResult("remaining", {
+      status: passed && fullyCleaned ? "passed" : "failed",
+      message:
+        passed && fullyCleaned
+          ? "The remaining watch delivered, then all resources stopped."
+          : "The removed watch fired again or final cleanup was incomplete."
+    });
+  };
+
+  return (
+    <ScenarioScreen
+      prefix={PREFIX}
+      title="Watch Manager v2"
+      subtitle="Independent delivery thresholds and exact cleanup"
+    >
+      <ScenarioSection index={1} title="Start independent watches">
+        <ScenarioButton
+          title="Start Eager + 500 m Watches"
+          onPress={startWatches}
+          testID={`${PREFIX}-start-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="start"
+          label="Initial delivery"
+          result={results.start}
+        />
+        <Text testID={`${PREFIX}-eager-count`}>
+          Eager updates: {counts.eager}
+        </Text>
+        <Text testID={`${PREFIX}-filtered-count`}>
+          Filtered updates: {counts.filtered}
+        </Text>
+        <ScenarioButton
+          title="Capture Baseline"
+          onPress={captureBaseline}
+          testID={`${PREFIX}-baseline-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="baseline"
+          label="Baseline"
+          result={results.baseline}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={2} title="Per-watch filtering" divided>
+        <ScenarioButton
+          title="Verify Near Move"
+          onPress={verifyNearUpdate}
+          testID={`${PREFIX}-near-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="near"
+          label="Near move"
+          result={results.near}
+        />
+        <ScenarioButton
+          title="Verify Far Move"
+          onPress={verifyFarUpdate}
+          testID={`${PREFIX}-far-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="far"
+          label="Far move"
+          result={results.far}
+        />
+      </ScenarioSection>
+
+      <ScenarioSection index={3} title="Cleanup isolation" divided>
+        <ScenarioButton
+          title="Remove Eager Watch Twice"
+          onPress={removeEagerWatch}
+          testID={`${PREFIX}-cleanup-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="cleanup"
+          label="Selective cleanup"
+          result={results.cleanup}
+        />
+        <ScenarioButton
+          title="Verify Remaining + Stop"
+          onPress={verifyRemainingWatch}
+          testID={`${PREFIX}-remaining-button`}
+        />
+        <ResultBlock
+          prefix={PREFIX}
+          id="remaining"
+          label="Remaining watch"
+          result={results.remaining}
+        />
+      </ScenarioSection>
+    </ScenarioScreen>
+  );
+}

--- a/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
+++ b/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Text } from "react-native";
+import { Platform, Text } from "react-native";
 import {
   getActiveWatches,
   requestPermission,
@@ -25,12 +25,16 @@ const initialResults = createScenarioResults([
   "cleanup",
   "remaining"
 ] as const);
-type Counts = { eager: number; filtered: number };
+type Counts = { eager: number; filtered: number; slow: number };
 
 export default function WatchManagerV2Screen() {
   const { results, setResult } = useScenarioResults(initialResults);
-  const tokensRef = useRef<{ eager?: string; filtered?: string }>({});
-  const countsRef = useRef<Counts>({ eager: 0, filtered: 0 });
+  const tokensRef = useRef<{
+    eager?: string;
+    filtered?: string;
+    slow?: string;
+  }>({});
+  const countsRef = useRef<Counts>({ eager: 0, filtered: 0, slow: 0 });
   const baselineRef = useRef<Counts | undefined>(undefined);
   const nearRef = useRef<Counts | undefined>(undefined);
   const cleanupRef = useRef<Counts | undefined>(undefined);
@@ -52,10 +56,14 @@ export default function WatchManagerV2Screen() {
     const next = { ...countsRef.current, [kind]: countsRef.current[kind] + 1 };
     countsRef.current = next;
     setCounts(next);
-    if (next.eager > 0 && next.filtered > 0) {
+    const allReady =
+      next.eager > 0 &&
+      next.filtered > 0 &&
+      (Platform.OS !== "android" || next.slow > 0);
+    if (allReady) {
       setResult("start", {
         status: "passed",
-        message: "Both independent watches received their initial position."
+        message: "Every independent watch received its initial position."
       });
     }
   };
@@ -93,6 +101,13 @@ export default function WatchManagerV2Screen() {
         onError,
         { distanceFilter: 500, interval: 100, fastestInterval: 100 }
       );
+      if (Platform.OS === "android") {
+        tokensRef.current.slow = watchPosition(
+          () => recordUpdate("slow"),
+          onError,
+          { distanceFilter: 0, interval: 25_000, fastestInterval: 100 }
+        );
+      }
     } catch (error) {
       setResult("start", {
         status: "failed",
@@ -103,7 +118,10 @@ export default function WatchManagerV2Screen() {
 
   const captureBaseline = () => {
     const current = countsRef.current;
-    const ready = current.eager > 0 && current.filtered > 0;
+    const ready =
+      current.eager > 0 &&
+      current.filtered > 0 &&
+      (Platform.OS !== "android" || current.slow > 0);
     if (ready) baselineRef.current = { ...current };
     setResult("baseline", {
       status: ready ? "passed" : "failed",
@@ -119,12 +137,13 @@ export default function WatchManagerV2Screen() {
     const passed =
       baseline !== undefined &&
       current.eager > baseline.eager &&
-      current.filtered === baseline.filtered;
+      current.filtered === baseline.filtered &&
+      (Platform.OS !== "android" || current.slow === baseline.slow);
     if (passed) nearRef.current = { ...current };
     setResult("near", {
       status: passed ? "passed" : "failed",
       message: passed
-        ? "The eager watch advanced while the 500 m watch stayed filtered."
+        ? "Only the eager watch advanced before distance and interval thresholds."
         : "Expected only the eager watch to advance after the near move."
     });
   };
@@ -135,12 +154,13 @@ export default function WatchManagerV2Screen() {
     const passed =
       near !== undefined &&
       current.eager > near.eager &&
-      current.filtered > near.filtered;
+      current.filtered > near.filtered &&
+      (Platform.OS !== "android" || current.slow > near.slow);
     setResult("far", {
       status: passed ? "passed" : "failed",
       message: passed
-        ? "Both watches advanced after crossing the 500 m threshold."
-        : "Expected both watches to advance after the far move."
+        ? "Distance and Android interval thresholds advanced their own watches."
+        : "Expected every eligible watch to advance after the far move."
     });
   };
 
@@ -159,10 +179,14 @@ export default function WatchManagerV2Screen() {
     tokensRef.current.eager = undefined;
     cleanupRef.current = { ...countsRef.current };
     const filteredToken = tokensRef.current.filtered;
+    const slowToken = tokensRef.current.slow;
     const active = getActiveWatches();
     const passed =
       filteredToken !== undefined &&
       active.some(({ token }) => token === filteredToken) &&
+      (Platform.OS !== "android" ||
+        (slowToken !== undefined &&
+          active.some(({ token }) => token === slowToken))) &&
       !active.some(({ token }) => token === eagerToken);
     setResult("cleanup", {
       status: passed ? "passed" : "failed",
@@ -182,6 +206,9 @@ export default function WatchManagerV2Screen() {
     const filteredToken = tokensRef.current.filtered;
     if (filteredToken) unwatch(filteredToken);
     tokensRef.current.filtered = undefined;
+    const slowToken = tokensRef.current.slow;
+    if (slowToken) unwatch(slowToken);
+    tokensRef.current.slow = undefined;
     const fullyCleaned = getActiveWatches().length === 0;
     setResult("remaining", {
       status: passed && fullyCleaned ? "passed" : "failed",
@@ -216,6 +243,11 @@ export default function WatchManagerV2Screen() {
         <Text testID={`${PREFIX}-filtered-count`}>
           Filtered updates: {counts.filtered}
         </Text>
+        {Platform.OS === "android" ? (
+          <Text testID={`${PREFIX}-slow-count`}>
+            Slow updates: {counts.slow}
+          </Text>
+        ) : null}
         <ScenarioButton
           title="Capture Baseline"
           onPress={captureBaseline}

--- a/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
+++ b/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
@@ -190,6 +190,7 @@ export default function WatchManagerV2Screen() {
           active.some(({ token }) => token === slowToken))) &&
       !active.some(({ token }) => token === eagerToken);
     await waitForBridgeDrain();
+    if (!mountedRef.current) return;
     cleanupRef.current = { ...countsRef.current };
     setResult("cleanup", {
       status: passed ? "passed" : "failed",

--- a/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
+++ b/examples/v0.81.1/src/screens/WatchManagerV2Screen.tsx
@@ -26,6 +26,8 @@ const initialResults = createScenarioResults([
   "remaining"
 ] as const);
 type Counts = { eager: number; filtered: number; slow: number };
+const waitForBridgeDrain = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, 1_000));
 
 export default function WatchManagerV2Screen() {
   const { results, setResult } = useScenarioResults(initialResults);
@@ -164,7 +166,7 @@ export default function WatchManagerV2Screen() {
     });
   };
 
-  const removeEagerWatch = () => {
+  const removeEagerWatch = async () => {
     const eagerToken = tokensRef.current.eager;
     if (!eagerToken) {
       setResult("cleanup", {
@@ -177,7 +179,6 @@ export default function WatchManagerV2Screen() {
     unwatch(eagerToken);
     unwatch("watch-manager-v2-unknown-token");
     tokensRef.current.eager = undefined;
-    cleanupRef.current = { ...countsRef.current };
     const filteredToken = tokensRef.current.filtered;
     const slowToken = tokensRef.current.slow;
     const active = getActiveWatches();
@@ -188,10 +189,12 @@ export default function WatchManagerV2Screen() {
         (slowToken !== undefined &&
           active.some(({ token }) => token === slowToken))) &&
       !active.some(({ token }) => token === eagerToken);
+    await waitForBridgeDrain();
+    cleanupRef.current = { ...countsRef.current };
     setResult("cleanup", {
       status: passed ? "passed" : "failed",
       message: passed
-        ? "Repeated cleanup removed only the eager watch."
+        ? "Repeated cleanup removed only the eager watch; in-flight callbacks drained."
         : "Cleanup did not leave exactly the owned filtered watch."
     });
   };

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidGeolocationOptions.kt
@@ -65,7 +65,8 @@ internal data class WatchSubscription(
     val success: (GeolocationResponse) -> Unit,
     val error: ((LocationError) -> Unit)?,
     val options: ParsedOptions,
-    var deliveredUpdates: Int = 0
+    var deliveredUpdates: Int = 0,
+    var deliveryState: AndroidWatchDeliveryState? = null
 )
 
 internal sealed interface PositionResult {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
@@ -4,12 +4,11 @@ import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Looper
+import android.os.SystemClock
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationResult
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
 
 internal class AndroidPositionWatchManager(
     private val locationManager: LocationManager,
@@ -19,12 +18,13 @@ internal class AndroidPositionWatchManager(
     private val configuredProvider: () -> LocationProvider?,
     private val getValidProvider: (ParsedOptions) -> String?,
     private val getNoProviderMessage: (ParsedOptions) -> String,
-    private val locationToPosition: (Location, LocationProviderUsed?) -> GeolocationResponse
+    private val locationToPosition: (Location, LocationProviderUsed?) -> GeolocationResponse,
+    private val dispatcher: AndroidWatchSerialDispatcher = createAndroidMainWatchDispatcher()
 ) {
-    private val subscriptions = ConcurrentHashMap<String, WatchSubscription>()
+    private val subscriptions = AndroidWatchCollection<WatchSubscription>()
     private var platformListener: LocationListener? = null
     private var fusedCallback: LocationCallback? = null
-    private val generation = AtomicLong(0L)
+    private var generation = 0L
 
     fun watch(
         success: (GeolocationResponse) -> Unit,
@@ -32,29 +32,34 @@ internal class AndroidPositionWatchManager(
         options: ParsedOptions
     ): String {
         val token = UUID.randomUUID().toString()
-        subscriptions[token] = WatchSubscription(token, success, error, options)
-        if (subscriptions.size == 1) start() else restart()
+        dispatcher.sync {
+            applyTransition(subscriptions.add(
+                token,
+                WatchSubscription(token, success, error, options)
+            ))
+        }
         return token
     }
 
-    fun unwatch(token: String): Boolean {
-        if (subscriptions.remove(token) == null) return false
-        if (subscriptions.isEmpty()) stop() else restart()
-        return true
+    fun unwatch(token: String): Boolean = dispatcher.sync {
+        val transition = subscriptions.remove(token)
+        applyTransition(transition)
+        transition != AndroidWatchTransition.NONE
     }
 
-    fun activeWatches(): Array<ActiveWatch> = subscriptions.keys
-        .map { ActiveWatch(token = it, kind = ActiveWatchKind.POSITION) }
-        .sortedBy { it.token }
-        .toTypedArray()
+    fun activeWatches(): Array<ActiveWatch> = dispatcher.sync {
+        subscriptions.tokens()
+            .map { ActiveWatch(token = it, kind = ActiveWatchKind.POSITION) }
+            .sortedBy { it.token }
+            .toTypedArray()
+    }
 
     fun stopObserving() {
-        subscriptions.clear()
-        stop()
+        dispatcher.sync { applyTransition(subscriptions.clear()) }
     }
 
     private fun start() {
-        val activeGeneration = generation.get()
+        val activeGeneration = generation
         if (providerRoute() == AndroidProviderRoute.FUSED) {
             startFused(activeGeneration)
         } else {
@@ -63,7 +68,7 @@ internal class AndroidPositionWatchManager(
     }
 
     private fun isActive(activeGeneration: Long): Boolean =
-        subscriptions.isNotEmpty() && generation.get() == activeGeneration
+        !subscriptions.isEmpty() && generation == activeGeneration
 
     private fun startPlatform(activeGeneration: Long) {
         if (!isActive(activeGeneration)) return
@@ -76,16 +81,20 @@ internal class AndroidPositionWatchManager(
 
         val listener = object : LocationListener {
             override fun onLocationChanged(location: Location) {
-                if (!isActive(activeGeneration)) return
-                deliver(locationToPosition(location, null))
+                dispatcher.sync {
+                    if (!isActive(activeGeneration)) return@sync
+                    deliver(locationToPosition(location, null))
+                }
             }
 
             override fun onProviderDisabled(provider: String) {
-                if (!isActive(activeGeneration)) return
-                notifyError(LocationError(
-                    code = SETTINGS_NOT_SATISFIED,
-                    message = "Provider disabled: $provider"
-                ))
+                dispatcher.sync {
+                    if (!isActive(activeGeneration)) return@sync
+                    notifyError(LocationError(
+                        code = SETTINGS_NOT_SATISFIED,
+                        message = "Provider disabled: $provider"
+                    ))
+                }
             }
 
             override fun onProviderEnabled(provider: String) = Unit
@@ -121,9 +130,11 @@ internal class AndroidPositionWatchManager(
         val options = mergeOptions()
         val callback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
-                if (!isActive(activeGeneration)) return
                 val location = result.lastLocation ?: return
-                deliver(locationToPosition(location, LocationProviderUsed.FUSED))
+                dispatcher.sync {
+                    if (!isActive(activeGeneration)) return@sync
+                    deliver(locationToPosition(location, LocationProviderUsed.FUSED))
+                }
             }
         }
 
@@ -131,23 +142,27 @@ internal class AndroidPositionWatchManager(
         fusedCallback = callback
 
         fun handleFailure(error: LocationError? = null) {
-            if (!isActive(activeGeneration)) return
-            removeFusedCallback()
-            runAndroidWatchPositionFallbackAfterFusedFailure(
-                locationProvider = configuredProvider(),
-                runPlatformFallback = { startPlatform(activeGeneration) },
-                failWithoutFallback = {
-                    if (error != null) notifyError(error) else notifyProviderUnavailable()
-                }
-            )
+            dispatcher.sync {
+                if (!isActive(activeGeneration)) return@sync
+                removeFusedCallback()
+                runAndroidWatchPositionFallbackAfterFusedFailure(
+                    locationProvider = configuredProvider(),
+                    runPlatformFallback = { startPlatform(activeGeneration) },
+                    failWithoutFallback = {
+                        if (error != null) notifyError(error) else notifyProviderUnavailable()
+                    }
+                )
+            }
         }
 
         fusedLocationProvider.requestWatchUpdates(
             options = options,
             callback = callback,
             onInactiveStart = {
-                if (!isActive(activeGeneration)) {
-                    runCatching { fusedLocationClient.removeLocationUpdates(callback) }
+                dispatcher.sync {
+                    if (!isActive(activeGeneration)) {
+                        runCatching { fusedLocationClient.removeLocationUpdates(callback) }
+                    }
                 }
             },
             onFailure = { error -> handleFailure(error) }
@@ -164,7 +179,7 @@ internal class AndroidPositionWatchManager(
         var maxUpdateAge: Double? = null
         var maxUpdateDelay = Double.MAX_VALUE
 
-        for (subscription in subscriptions.values) {
+        for (subscription in subscriptions.values()) {
             androidAccuracy = mostDemandingAndroidAccuracy(
                 androidAccuracy,
                 subscription.options.androidAccuracy
@@ -196,23 +211,35 @@ internal class AndroidPositionWatchManager(
     }
 
     private fun deliver(position: GeolocationResponse) {
-        val finishedTokens = mutableListOf<String>()
-        for ((token, subscription) in subscriptions) {
-            subscription.success(position)
+        var removedFinishedWatch = false
+        val elapsedRealtimeMillis = SystemClock.elapsedRealtime()
+        subscriptions.forEachCurrent { token, subscription ->
+            val decision = evaluateAndroidWatchDelivery(
+                previous = subscription.deliveryState,
+                latitude = position.coords.latitude,
+                longitude = position.coords.longitude,
+                elapsedRealtimeMillis = elapsedRealtimeMillis,
+                minimumIntervalMillis = subscription.options.interval,
+                distanceFilterMeters = subscription.options.distanceFilter
+            )
+            if (!decision.shouldDeliver) return@forEachCurrent
+
+            subscription.deliveryState = decision.nextState
             subscription.deliveredUpdates += 1
+            subscription.success(position)
             val maxUpdates = subscription.options.maxUpdates
             if (maxUpdates != null && subscription.deliveredUpdates >= maxUpdates) {
-                finishedTokens.add(token)
+                removedFinishedWatch = subscriptions.removeCurrent(token, subscription) ||
+                    removedFinishedWatch
             }
         }
-        finishedTokens.forEach(subscriptions::remove)
-        if (finishedTokens.isNotEmpty()) {
-            if (subscriptions.isEmpty()) stop() else restart()
+        if (removedFinishedWatch) {
+            applyTransition(subscriptions.transitionAfterRemoval())
         }
     }
 
     private fun notifyProviderUnavailable() {
-        for (subscription in subscriptions.values) {
+        subscriptions.forEachCurrent { _, subscription ->
             subscription.error?.invoke(LocationError(
                 code = SETTINGS_NOT_SATISFIED,
                 message = getNoProviderMessage(subscription.options)
@@ -221,7 +248,7 @@ internal class AndroidPositionWatchManager(
     }
 
     private fun notifyError(error: LocationError) {
-        subscriptions.values.forEach { it.error?.invoke(error) }
+        subscriptions.forEachCurrent { _, subscription -> subscription.error?.invoke(error) }
     }
 
     private fun mergeGranularity(
@@ -238,7 +265,7 @@ internal class AndroidPositionWatchManager(
     }
 
     private fun stop() {
-        generation.incrementAndGet()
+        generation += 1
         removePlatformListener()
         removeFusedCallback()
     }
@@ -260,5 +287,14 @@ internal class AndroidPositionWatchManager(
     private fun restart() {
         stop()
         start()
+    }
+
+    private fun applyTransition(transition: AndroidWatchTransition) {
+        when (transition) {
+            AndroidWatchTransition.NONE -> Unit
+            AndroidWatchTransition.START -> start()
+            AndroidWatchTransition.RESTART -> restart()
+            AndroidWatchTransition.STOP -> stop()
+        }
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchDeliveryPolicy.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchDeliveryPolicy.kt
@@ -1,0 +1,56 @@
+package com.margelo.nitro.nitrogeolocation
+
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+internal data class AndroidWatchDeliveryState(
+    val latitude: Double,
+    val longitude: Double,
+    val elapsedRealtimeMillis: Long
+)
+
+internal data class AndroidWatchDeliveryDecision(
+    val shouldDeliver: Boolean,
+    val nextState: AndroidWatchDeliveryState?
+)
+
+internal fun evaluateAndroidWatchDelivery(
+    previous: AndroidWatchDeliveryState?,
+    latitude: Double,
+    longitude: Double,
+    elapsedRealtimeMillis: Long,
+    minimumIntervalMillis: Double,
+    distanceFilterMeters: Double
+): AndroidWatchDeliveryDecision {
+    val candidate = AndroidWatchDeliveryState(latitude, longitude, elapsedRealtimeMillis)
+    if (previous == null) return AndroidWatchDeliveryDecision(true, candidate)
+
+    val elapsed = elapsedRealtimeMillis - previous.elapsedRealtimeMillis
+    val intervalSatisfied = elapsed >= minimumIntervalMillis
+    val distanceSatisfied = distanceFilterMeters == 0.0 ||
+        distanceMeters(previous.latitude, previous.longitude, latitude, longitude) >=
+        distanceFilterMeters
+    return if (intervalSatisfied && distanceSatisfied) {
+        AndroidWatchDeliveryDecision(true, candidate)
+    } else {
+        AndroidWatchDeliveryDecision(false, previous)
+    }
+}
+
+private fun distanceMeters(
+    fromLatitude: Double,
+    fromLongitude: Double,
+    toLatitude: Double,
+    toLongitude: Double
+): Double {
+    val latitudeDelta = Math.toRadians(toLatitude - fromLatitude)
+    val longitudeDelta = Math.toRadians(toLongitude - fromLongitude)
+    val fromLatitudeRadians = Math.toRadians(fromLatitude)
+    val toLatitudeRadians = Math.toRadians(toLatitude)
+    val haversine = sin(latitudeDelta / 2).let { it * it } +
+        cos(fromLatitudeRadians) * cos(toLatitudeRadians) *
+        sin(longitudeDelta / 2).let { it * it }
+    return 2 * 6_371_000.0 * asin(sqrt(haversine.coerceIn(0.0, 1.0)))
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntime.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntime.kt
@@ -1,0 +1,75 @@
+package com.margelo.nitro.nitrogeolocation
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.FutureTask
+
+internal enum class AndroidWatchTransition {
+    NONE,
+    START,
+    RESTART,
+    STOP
+}
+
+internal class AndroidWatchCollection<T> {
+    private val entries = linkedMapOf<String, T>()
+
+    fun add(token: String, value: T): AndroidWatchTransition {
+        val wasEmpty = entries.isEmpty()
+        entries[token] = value
+        return if (wasEmpty) AndroidWatchTransition.START else AndroidWatchTransition.RESTART
+    }
+
+    fun remove(token: String): AndroidWatchTransition {
+        if (entries.remove(token) == null) return AndroidWatchTransition.NONE
+        return transitionAfterRemoval()
+    }
+
+    fun removeCurrent(token: String, value: T): Boolean {
+        if (entries[token] !== value) return false
+        entries.remove(token)
+        return true
+    }
+
+    fun clear(): AndroidWatchTransition {
+        if (entries.isEmpty()) return AndroidWatchTransition.NONE
+        entries.clear()
+        return AndroidWatchTransition.STOP
+    }
+
+    fun transitionAfterRemoval(): AndroidWatchTransition =
+        if (entries.isEmpty()) AndroidWatchTransition.STOP else AndroidWatchTransition.RESTART
+
+    fun isEmpty(): Boolean = entries.isEmpty()
+
+    fun values(): List<T> = entries.values.toList()
+
+    fun tokens(): List<String> = entries.keys.toList()
+
+    fun forEachCurrent(deliver: (String, T) -> Unit) {
+        val snapshot = entries.toList()
+        for ((token, value) in snapshot) {
+            if (entries[token] === value) deliver(token, value)
+        }
+    }
+}
+
+internal class AndroidWatchSerialDispatcher(
+    private val isDispatchThread: () -> Boolean,
+    private val post: ((() -> Unit) -> Unit)
+) {
+    fun <T> sync(action: () -> T): T {
+        if (isDispatchThread()) return action()
+        val task = FutureTask(action)
+        post { task.run() }
+        return task.get()
+    }
+}
+
+internal fun createAndroidMainWatchDispatcher(): AndroidWatchSerialDispatcher {
+    val handler = Handler(Looper.getMainLooper())
+    return AndroidWatchSerialDispatcher(
+        isDispatchThread = { Looper.myLooper() == Looper.getMainLooper() },
+        post = { action -> handler.post(action) }
+    )
+}

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -818,3 +818,4 @@ class NitroGeolocation(
         private const val PERMISSION_REQUEST_CODE = 8947
     }
 }
+

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -818,4 +818,3 @@ class NitroGeolocation(
         private const val PERMISSION_REQUEST_CODE = 8947
     }
 }
-

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchDeliveryPolicyTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchDeliveryPolicyTest.kt
@@ -1,0 +1,85 @@
+package com.margelo.nitro.nitrogeolocation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidWatchDeliveryPolicyTest {
+    @Test
+    fun `first update is delivered and establishes the subscription baseline`() {
+        val decision = evaluateAndroidWatchDelivery(
+            previous = null,
+            latitude = 37.5665,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 1_000,
+            minimumIntervalMillis = 10_000.0,
+            distanceFilterMeters = 500.0
+        )
+
+        assertTrue(decision.shouldDeliver)
+        assertTrue(decision.nextState != null)
+    }
+
+    @Test
+    fun `each watch waits for its own interval and distance threshold`() {
+        val baseline = AndroidWatchDeliveryState(37.5665, 126.9780, 1_000)
+
+        val tooSoon = evaluateAndroidWatchDelivery(
+            baseline,
+            latitude = 37.5765,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 5_000,
+            minimumIntervalMillis = 10_000.0,
+            distanceFilterMeters = 500.0
+        )
+        assertFalse(tooSoon.shouldDeliver)
+        assertSame(baseline, tooSoon.nextState)
+
+        val tooNear = evaluateAndroidWatchDelivery(
+            baseline,
+            latitude = 37.5670,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 12_000,
+            minimumIntervalMillis = 10_000.0,
+            distanceFilterMeters = 500.0
+        )
+        assertFalse(tooNear.shouldDeliver)
+        assertSame(baseline, tooNear.nextState)
+
+        val eligible = evaluateAndroidWatchDelivery(
+            baseline,
+            latitude = 37.5765,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 12_000,
+            minimumIntervalMillis = 10_000.0,
+            distanceFilterMeters = 500.0
+        )
+        assertTrue(eligible.shouldDeliver)
+        assertTrue(eligible.nextState !== baseline)
+    }
+
+    @Test
+    fun `suppressed updates do not move the distance baseline`() {
+        val baseline = AndroidWatchDeliveryState(37.5665, 126.9780, 1_000)
+        val firstNear = evaluateAndroidWatchDelivery(
+            baseline,
+            latitude = 37.5695,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 2_000,
+            minimumIntervalMillis = 0.0,
+            distanceFilterMeters = 500.0
+        )
+        val secondCumulative = evaluateAndroidWatchDelivery(
+            firstNear.nextState,
+            latitude = 37.5725,
+            longitude = 126.9780,
+            elapsedRealtimeMillis = 3_000,
+            minimumIntervalMillis = 0.0,
+            distanceFilterMeters = 500.0
+        )
+
+        assertFalse(firstNear.shouldDeliver)
+        assertTrue(secondCumulative.shouldDeliver)
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntimeTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntimeTest.kt
@@ -1,0 +1,80 @@
+package com.margelo.nitro.nitrogeolocation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+class AndroidWatchRuntimeTest {
+    @Test
+    fun `reentrant cleanup skips a removed callback from the delivery snapshot`() {
+        val watches = AndroidWatchCollection<String>()
+        watches.add("first", "first-value")
+        watches.add("second", "second-value")
+        val delivered = mutableListOf<String>()
+
+        watches.forEachCurrent { token, _ ->
+            delivered += token
+            if (token == "first") watches.remove("second")
+        }
+
+        assertEquals(listOf("first"), delivered)
+        assertEquals(listOf("first"), watches.tokens())
+    }
+
+    @Test
+    fun `concurrent last removal and new watch leave acquisition running`() {
+        val executor = Executors.newSingleThreadExecutor()
+        val dispatchThread = AtomicReference<Thread>()
+        val dispatcher = AndroidWatchSerialDispatcher(
+            isDispatchThread = { Thread.currentThread() === dispatchThread.get() },
+            post = { action ->
+                executor.execute {
+                    dispatchThread.compareAndSet(null, Thread.currentThread())
+                    action()
+                }
+            }
+        )
+
+        try {
+            repeat(100) { iteration ->
+                val watches = AndroidWatchCollection<String>()
+                var acquisitionRunning = false
+                fun apply(transition: AndroidWatchTransition) {
+                    acquisitionRunning = when (transition) {
+                        AndroidWatchTransition.NONE -> acquisitionRunning
+                        AndroidWatchTransition.START,
+                        AndroidWatchTransition.RESTART -> true
+                        AndroidWatchTransition.STOP -> false
+                    }
+                }
+
+                dispatcher.sync { apply(watches.add("old-$iteration", "old")) }
+                val start = CountDownLatch(1)
+                val remove = thread {
+                    start.await()
+                    dispatcher.sync { apply(watches.remove("old-$iteration")) }
+                }
+                val add = thread {
+                    start.await()
+                    dispatcher.sync { apply(watches.add("new-$iteration", "new")) }
+                }
+                start.countDown()
+                remove.join()
+                add.join()
+
+                dispatcher.sync {
+                    assertEquals(listOf("new-$iteration"), watches.tokens())
+                    assertTrue(acquisitionRunning)
+                }
+            }
+        } finally {
+            executor.shutdownNow()
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS))
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntimeTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntimeTest.kt
@@ -11,22 +11,6 @@ import kotlin.concurrent.thread
 
 class AndroidWatchRuntimeTest {
     @Test
-    fun `reentrant cleanup skips a removed callback from the delivery snapshot`() {
-        val watches = AndroidWatchCollection<String>()
-        watches.add("first", "first-value")
-        watches.add("second", "second-value")
-        val delivered = mutableListOf<String>()
-
-        watches.forEachCurrent { token, _ ->
-            delivered += token
-            if (token == "first") watches.remove("second")
-        }
-
-        assertEquals(listOf("first"), delivered)
-        assertEquals(listOf("first"), watches.tokens())
-    }
-
-    @Test
     fun `concurrent last removal and new watch leave acquisition running`() {
         val executor = Executors.newSingleThreadExecutor()
         val dispatchThread = AtomicReference<Thread>()

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
@@ -103,6 +103,7 @@ struct WatchSubscription {
     let success: (GeolocationResponse) -> Void
     let error: ((LocationError) -> Void)?
     let options: ParsedOptions
+    var deliveryState: IOSWatchDeliveryState?
 }
 
 struct PositionRequest {

--- a/packages/react-native-nitro-geolocation/ios/IOSWatchDeliveryPolicy.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSWatchDeliveryPolicy.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct IOSWatchDeliveryState: Equatable {
+    let latitude: Double
+    let longitude: Double
+}
+
+struct IOSWatchDeliveryDecision {
+    let shouldDeliver: Bool
+    let nextState: IOSWatchDeliveryState?
+}
+
+func evaluateIOSWatchDelivery(
+    previous: IOSWatchDeliveryState?,
+    latitude: Double,
+    longitude: Double,
+    distanceFilterMeters: Double
+) -> IOSWatchDeliveryDecision {
+    let candidate = IOSWatchDeliveryState(latitude: latitude, longitude: longitude)
+    guard let previous else {
+        return IOSWatchDeliveryDecision(shouldDeliver: true, nextState: candidate)
+    }
+
+    let distanceSatisfied = distanceFilterMeters <= 0 || distanceMeters(
+        fromLatitude: previous.latitude,
+        fromLongitude: previous.longitude,
+        toLatitude: latitude,
+        toLongitude: longitude
+    ) >= distanceFilterMeters
+    return distanceSatisfied
+        ? IOSWatchDeliveryDecision(shouldDeliver: true, nextState: candidate)
+        : IOSWatchDeliveryDecision(shouldDeliver: false, nextState: previous)
+}
+
+private func distanceMeters(
+    fromLatitude: Double,
+    fromLongitude: Double,
+    toLatitude: Double,
+    toLongitude: Double
+) -> Double {
+    let latitudeDelta = (toLatitude - fromLatitude) * .pi / 180
+    let longitudeDelta = (toLongitude - fromLongitude) * .pi / 180
+    let fromLatitudeRadians = fromLatitude * .pi / 180
+    let toLatitudeRadians = toLatitude * .pi / 180
+    let haversine = pow(sin(latitudeDelta / 2), 2) +
+        cos(fromLatitudeRadians) * cos(toLatitudeRadians) *
+        pow(sin(longitudeDelta / 2), 2)
+    return 2 * 6_371_000 * asin(sqrt(min(max(haversine, 0), 1)))
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -53,7 +53,8 @@ extension NitroGeolocation {
         let subscription = WatchSubscription(
             success: success,
             error: error,
-            options: ParsedOptions.parse(from: options)
+            options: ParsedOptions.parse(from: options),
+            deliveryState: nil
         )
 
         runLocationOperationOnMainSync {

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+WatchDelivery.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+WatchDelivery.swift
@@ -1,0 +1,23 @@
+import CoreLocation
+
+extension NitroGeolocation {
+    func deliverPositionToWatches(
+        location: CLLocation,
+        position: GeolocationResponse
+    ) {
+        for (token, subscription) in Array(watchSubscriptions) {
+            let decision = evaluateIOSWatchDelivery(
+                previous: subscription.deliveryState,
+                latitude: location.coordinate.latitude,
+                longitude: location.coordinate.longitude,
+                distanceFilterMeters: subscription.options.distanceFilter
+            )
+            guard decision.shouldDeliver, watchSubscriptions[token] != nil else { continue }
+
+            var updatedSubscription = subscription
+            updatedSubscription.deliveryState = decision.nextState
+            watchSubscriptions[token] = updatedSubscription
+            subscription.success(position)
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -443,10 +443,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             request.success(position)
         }
 
-        let subscriptions = Array(watchSubscriptions.values)
-        for subscription in subscriptions {
-            subscription.success(position)
-        }
+        deliverPositionToWatches(location: location, position: position)
 
         if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
             stopMonitoring()

--- a/scripts/test-ios-watch-delivery.sh
+++ b/scripts/test-ios-watch-delivery.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_dir="$(mktemp -d /tmp/nitro-ios-watch-delivery.XXXXXX)"
+
+cleanup() {
+  case "$test_dir" in
+    /tmp/nitro-ios-watch-delivery.*) rm -rf -- "$test_dir" ;;
+    *) printf 'Refusing to remove unexpected test directory: %s\n' "$test_dir" >&2 ;;
+  esac
+}
+trap cleanup EXIT
+
+if [[ -z "${DEVELOPER_DIR:-}" && -d /Applications/Xcode.app/Contents/Developer ]]; then
+  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+
+xcrun swiftc \
+  -parse-as-library \
+  "$repo_root/packages/react-native-nitro-geolocation/ios/IOSWatchDeliveryPolicy.swift" \
+  "$repo_root/tests/ios/IOSWatchDeliveryPolicyContract.swift" \
+  -o "$test_dir/ios-watch-delivery-contract"
+
+"$test_dir/ios-watch-delivery-contract"

--- a/tests/ios/IOSWatchDeliveryPolicyContract.swift
+++ b/tests/ios/IOSWatchDeliveryPolicyContract.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@main
+enum IOSWatchDeliveryPolicyContract {
+    static func main() {
+        let first = evaluateIOSWatchDelivery(
+            previous: nil,
+            latitude: 37.5665,
+            longitude: 126.9780,
+            distanceFilterMeters: 500
+        )
+        precondition(first.shouldDeliver, "The first update must establish a baseline")
+
+        let baseline = first.nextState
+        let near = evaluateIOSWatchDelivery(
+            previous: baseline,
+            latitude: 37.5695,
+            longitude: 126.9780,
+            distanceFilterMeters: 500
+        )
+        precondition(!near.shouldDeliver, "A near update must stay subscription-local")
+        precondition(near.nextState == baseline, "Suppression must not move the baseline")
+
+        let cumulative = evaluateIOSWatchDelivery(
+            previous: near.nextState,
+            latitude: 37.5725,
+            longitude: 126.9780,
+            distanceFilterMeters: 500
+        )
+        precondition(cumulative.shouldDeliver, "Distance is measured from last delivery")
+
+        print("iOS watch delivery policy contract passed")
+    }
+}


### PR DESCRIPTION
## Summary

- make Watch Manager v2 subscription-aware on Android and iOS
- enforce each watch's own interval, distance filter, and delivered-update max while retaining the shared native acquisition request
- serialize Android registration, cleanup, native restarts, and callback delivery on the main looper
- add a natural test page covering initial delivery, independent distance/interval thresholds, idempotent selective cleanup, and the remaining watcher
- document merge, filtering, cleanup, and reentrant callback semantics

## Dependency

This PR is intentionally stacked on #170 because the Watch Manager extraction must use the repository-wide 900-line source limit with no per-file exceptions. It can be retargeted to `main` after #170 merges.

## Validation

- Android Release Maestro: `watch-manager-v2.yaml`
- iOS Release Maestro: `watch-manager-v2.yaml`
- Android library `testDebugUnitTest`
- iOS watch delivery policy contract
- 151 JS unit tests
- format, lint, typecheck, source-line guard, build, dead-code, package dry-run
- immutable install and diff check

## Changeset

Major: this intentionally changes default modern Watch Manager delivery semantics for 2.0.

Roadmap: #98
