### PR TITLE
docs: version 1.x and 2.x guides

### DIFF
--- a/.changeset/calm-docs-version.md
+++ b/.changeset/calm-docs-version.md
@@ -1,0 +1,5 @@
+---
+---
+
+Publish separate 1.x and 2.x documentation snapshots without changing runtime
+or package behavior.

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -38,3 +38,4 @@ jobs:
         working-directory: docs
         run: |
           yarn build
+          yarn check:versions

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -5,6 +5,7 @@
   "swift-package-manager",
   "migration-assistance",
   "v2-error-migration",
+  "v2-unified-background-events",
   "community-migration",
   "service-migration",
   "gps-offline-recipe",

--- a/docs/docs/guide/community-migration.md
+++ b/docs/docs/guide/community-migration.md
@@ -60,7 +60,7 @@ Geolocation.getCurrentPosition(
 First install the Nitro packages:
 
 ```bash
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 Then change only the import path:

--- a/docs/docs/guide/expo-development-build.md
+++ b/docs/docs/guide/expo-development-build.md
@@ -22,7 +22,7 @@ Managed Expo apps that cannot rebuild native code should use `expo-location`.
 Install the native dependencies:
 
 ```bash
-npx expo install react-native-nitro-modules react-native-nitro-geolocation
+npx expo install react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 Then generate or update the native projects:

--- a/docs/docs/guide/migration-assistance.md
+++ b/docs/docs/guide/migration-assistance.md
@@ -74,7 +74,8 @@ compatibility fallback.
 | Legacy or compat usage | Modern API target |
 | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
-| cache-first startup location reads | `await getLastKnownPosition(options)` |
+| latest position already observed by this JS module | `getLastKnownPosition()` |
+| cache-first native/provider reads | `await getLastKnownPositionAsync(options)` |
 | `requestAuthorization(success, error)` | `await requestPermission()` |
 | `setRNConfiguration(config)` | `setConfiguration(config)` |
 | `watchPosition` in function components | `useWatchPosition({ enabled, ...options })` |

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -58,12 +58,6 @@ export type GeolocationConfiguration = {
   /** `auto` and `playServices` prefer fused, then platform fallback. */
   locationProvider?: 'playServices' | 'android' | 'auto';
 };
-
-/**
- * @deprecated Use `GeolocationConfiguration` instead.
- * This alias is kept only for backward compatibility.
- */
-export type ModernGeolocationConfiguration = GeolocationConfiguration;
 ```
 
 **When to call**:
@@ -230,8 +224,9 @@ function PermissionButton() {
 
 ### Android Provider and Settings
 
-The provider/settings snapshot helpers are available since `v1.2`.
-`watchProviderStatus()` is available since `v1.5`.
+The provider/settings snapshot helpers introduced before 2.0 remain available.
+`watchProviderStatus()` and the deterministic settings result are available in
+2.0.
 
 Use these helpers before user-facing precise-location flows where the app needs
 to know whether Android device settings can satisfy the request.
@@ -302,7 +297,7 @@ function ProviderStatusObserver() {
   it.
 - `watchProviderStatus(callback): string` - Delivers an asynchronous initial
   provider snapshot and then only distinct readiness changes. Pass its token to
-  `unwatch()` for cleanup. Available since `v1.5`.
+  `unwatch()` for cleanup. Available in 2.0.
 - `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
@@ -334,7 +329,7 @@ function ProviderStatusObserver() {
   provider status. Request failures such as a concurrent request still reject.
 - `requestLocationSettings(options?): Promise<LocationSettingsResult>` - The
   v2 method returns the same deterministic result. The detailed name is
-  provided for code shared with v1.5 and to make result handling explicit.
+  provided to make result handling explicit in code shared across release lines.
 
 Both settings methods are Android-focused. On iOS they resolve with the current
 Core Location service status and do not show a settings dialog.
@@ -355,8 +350,9 @@ when the page becomes visible or active. Provider-specific optional fields stay
   path.
 - Approximate/coarse location flows are supported through permissions and
   Android `granularity`.
-- Use `getLastKnownPosition()` when you want an explicit cached read without
-  starting a fresh native request.
+- Use `getLastKnownPosition()` for a synchronous read of the module cache. Use
+  `getLastKnownPositionAsync()` to query native/provider caches without starting
+  a fresh request.
 - Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
 
@@ -387,8 +383,8 @@ Supported on web:
 
 Web option behavior:
 
-- `enableHighAccuracy`, `timeout`, and `maximumAge` are forwarded to the
-  browser.
+- `accuracy` maps to the browser's high-accuracy boolean. `timeout` and
+  `maximumAge` are forwarded to the browser.
 - `distanceFilter` is applied in JavaScript for watch updates after the first
   emitted position.
 - `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`,
@@ -463,8 +459,7 @@ function LocationButton() {
   aborted prevents native or browser location work from starting. The promise
   rejects with the exact `signal.reason`; runtimes without a reason receive an
   `AbortError` fallback.
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
@@ -685,28 +680,32 @@ The `/compat` API keeps the legacy numeric browser-style contract with only
 `PERMISSION_DENIED` (`1`), `POSITION_UNAVAILABLE` (`2`), and `TIMEOUT` (`3`).
 See [2.0 Error Migration](./v2-error-migration.md) for the 1.x-to-2.x mapping.
 
-### getLastKnownPosition()
+### getLastKnownPosition() and getLastKnownPositionAsync()
 
-Available since `v1.2`.
-
-Read the best cached native location explicitly without starting a fresh
-location request. This is useful for fast app startup, stale-while-refresh UI,
-and cache-only flows where a fresh GPS/network request would be too expensive.
+`getLastKnownPosition()` synchronously reads the latest position observed by
+this JavaScript module. It takes no options, never calls native code, and returns
+`undefined` while that module-local cache is cold.
 
 ```tsx
-import { getLastKnownPosition } from 'react-native-nitro-geolocation';
+import {
+  getLastKnownPosition,
+  getLastKnownPositionAsync
+} from 'react-native-nitro-geolocation';
 
-const cached = await getLastKnownPosition({
+const observed = getLastKnownPosition();
+
+const cached = await getLastKnownPositionAsync({
   maximumAge: 60_000,
   accuracy: { android: 'balanced', ios: 'hundredMeters' }
 });
 ```
 
-`getLastKnownPosition(options?)` uses the same provider and cache-filtering
-options as `getCurrentPosition()`, but it never falls through to a fresh native
-request. If no cached location satisfies `maximumAge` or permission is denied,
-it rejects with the native `LocationError` contract, usually
-`POSITION_UNAVAILABLE` or `PERMISSION_DENIED`.
+`getLastKnownPositionAsync(options?)` queries native/provider cache-only sources
+with the same filtering options as `getCurrentPosition()`, but never falls
+through to a fresh request. It resolves `undefined` when no cached location
+satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
+failures, such as permission denial, reject with the Modern `LocationError`
+contract.
 
 ### Geocoding APIs
 
@@ -878,8 +877,7 @@ function LiveTracker() {
 **Options**:
 
 - `enabled?: boolean` - Start/stop watching (default: `false`)
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
 - `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
@@ -1085,7 +1083,8 @@ import type {
 } from 'react-native-nitro-geolocation';
 ```
 
-`ModernGeolocationConfiguration` is still exported as a deprecated compatibility alias.
+The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
+`GeolocationConfiguration` for the root Modern API.
 
 ### Type Inference
 

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -8,11 +8,11 @@ Before installing the module, make sure your app uses React Native 0.75+ with
 the New Architecture and Nitro Modules enabled.
 
 ```bash
-# Install Nitro core and Geolocation module
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+# Install Nitro core and the 2.0 release candidate
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 
 # or using npm
-npm install react-native-nitro-modules react-native-nitro-geolocation
+npm install react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 After installation, rebuild your native app to ensure the new module is linked.
@@ -127,7 +127,7 @@ from the [Modern API reference](/guide/modern-api).
 
 ```tsx
 import {
-  getLastKnownPosition,
+  getLastKnownPositionAsync,
   requestLocationSettings
 } from 'react-native-nitro-geolocation';
 
@@ -135,7 +135,7 @@ await requestLocationSettings({
   accuracy: { android: 'high' }
 });
 
-const cached = await getLastKnownPosition({
+const cached = await getLastKnownPositionAsync({
   maximumAge: 60_000,
   accuracy: { android: 'balanced', ios: 'hundredMeters' }
 });

--- a/docs/docs/guide/swift-package-manager.md
+++ b/docs/docs/guide/swift-package-manager.md
@@ -32,7 +32,7 @@ Install both JavaScript packages normally, then keep the CocoaPods integration
 for iOS:
 
 ```bash
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 cd ios
 bundle exec pod install
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,15 +3,15 @@ pageType: home
 
 hero:
   name: React Native Nitro Geolocation
-  text: Nitro-powered native geolocation
-  tagline: Replace community geolocation with /compat, then move to a typed Modern API.
+  text: 2.x release candidate documentation
+  tagline: Preview the breaking 2.x contracts, migration paths, and unified background APIs before the stable release.
   actions:
     - theme: brand
-      text: Introduction
-      link: /guide/
+      text: Read the 2.x guide
+      link: /v2/guide/index.html
     - theme: alt
-      text: Quick Start
-      link: /guide/quick-start/
+      text: Review migrations
+      link: /v2/guide/v2-error-migration.html
   image:
     src: /logo.png
     alt: Nitro Geolocation Logo

--- a/docs/docs/v1/_nav.json
+++ b/docs/docs/v1/_nav.json
@@ -1,0 +1,12 @@
+[
+  {
+    "text": "Guide",
+    "link": "/guide/",
+    "activeMatch": "/guide/"
+  },
+  {
+    "text": "Background",
+    "link": "/background/overview",
+    "activeMatch": "/background/"
+  }
+]

--- a/docs/docs/v1/background/_meta.json
+++ b/docs/docs/v1/background/_meta.json
@@ -1,0 +1,14 @@
+[
+  "overview",
+  "setup-android",
+  "setup-ios",
+  "permissions",
+  "start-stop",
+  "geofencing",
+  "activity-recognition",
+  "headless-js",
+  "http-sync",
+  "storage",
+  "long-run-e2e",
+  "troubleshooting"
+]

--- a/docs/docs/v1/background/activity-recognition.md
+++ b/docs/docs/v1/background/activity-recognition.md
@@ -1,0 +1,31 @@
+# Activity Recognition
+
+```ts
+import {
+  startActivityRecognition,
+  onActivityChange,
+} from 'react-native-nitro-geolocation/background';
+
+await startActivityRecognition({
+  enabled: true,
+  interval: 10_000,
+  stopOnStill: true,
+  minimumConfidence: 70,
+});
+
+const sub = onActivityChange((activity) => {
+  console.log(activity.type, activity.confidence);
+});
+```
+
+Activity events are delivered through the same native event pipeline as location
+and geofence events. Android uses Activity Recognition APIs. iOS uses Core
+Motion when available.
+
+On Android 10+, request `android.permission.ACTIVITY_RECOGNITION` at runtime
+before calling `startActivityRecognition()` or using `trackingMode:
+'activityAware'`.
+
+`trackingMode: 'activityAware'` enables activity collection alongside background
+tracking. Apps can use `onActivityChange` events to pause, resume, or tune
+tracking policy for their own product rules.

--- a/docs/docs/v1/background/geofencing.md
+++ b/docs/docs/v1/background/geofencing.md
@@ -1,0 +1,23 @@
+# Geofencing
+
+```ts
+import { addGeofences, onGeofence } from 'react-native-nitro-geolocation/background';
+
+await addGeofences([
+  {
+    identifier: 'office',
+    latitude: 37.5665,
+    longitude: 126.978,
+    radius: 150,
+    notifyOnEntry: true,
+    notifyOnExit: true,
+    metadata: { kind: 'workplace' },
+  },
+]);
+
+const sub = onGeofence((event) => {
+  console.log(event.transition, event.region.identifier);
+});
+```
+
+`notifyOnDwell` is Android-only. iOS region monitoring supports enter and exit.

--- a/docs/docs/v1/background/headless-js.md
+++ b/docs/docs/v1/background/headless-js.md
@@ -1,0 +1,18 @@
+# Android Headless JS
+
+Register task at app root, outside React components:
+
+```ts
+import {
+  registerBackgroundTask,
+  type BackgroundEvent,
+} from 'react-native-nitro-geolocation/background';
+
+registerBackgroundTask(async (event: BackgroundEvent) => {
+  if (event.type === 'location') {
+    console.log('Headless location', event.location);
+  }
+});
+```
+
+Headless JS is Android-only. On iOS, read stored events after app initialization.

--- a/docs/docs/v1/background/http-sync.md
+++ b/docs/docs/v1/background/http-sync.md
@@ -1,0 +1,30 @@
+# Native HTTP Sync
+
+```ts
+await startBackgroundLocation({
+  interval: 10_000,
+  distanceFilter: 25,
+  android: {
+    foregroundService: {
+      notificationTitle: 'Tracking active',
+      notificationText: 'Uploading location updates',
+    },
+  },
+  sync: {
+    url: 'https://api.example.com/locations',
+    method: 'POST',
+    headers: { Authorization: 'Bearer token' },
+    batch: true,
+    batchSize: 50,
+    syncThreshold: 5,
+    retry: true,
+    maxRetries: 5,
+    autoClear: false,
+  },
+});
+```
+
+When `sync` is configured, native code attempts a flush after stored locations
+reach `syncThreshold`, respecting `syncInterval`. Failed flushes can retry up to
+`maxRetries` when `retry` is enabled. Call `syncStoredLocations()` to manually
+flush the native queue.

--- a/docs/docs/v1/background/long-run-e2e.md
+++ b/docs/docs/v1/background/long-run-e2e.md
@@ -1,0 +1,99 @@
+# Long-Run Background E2E
+
+The example app has two background E2E pages:
+
+- `background-e2e` is a short smoke page for API contracts.
+- `background-long-run` is a device-level page for long-running checks.
+
+The long-run page reads native storage and status. It does not pass from React
+state alone, so app restarts do not hide missing native delivery.
+
+## Android
+
+Run the Android emulator flow:
+
+```sh
+yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android
+```
+
+This flow:
+
+1. starts background tracking with `stopOnTerminate: false` and `startOnBoot: true`,
+2. registers a geofence,
+3. sends the app home,
+4. injects outside, inside, and outside locations,
+5. reopens the page,
+6. verifies stored background location events recorded after the run marker,
+7. verifies Headless JS delivery by checking delivered native event flags,
+8. verifies geofence enter and exit events.
+
+To include reboot restore on an emulator:
+
+```sh
+RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android
+```
+
+The reboot pass is emulator-only. The wrapper refuses `RUN_REBOOT=1` on a
+physical Android device before issuing `adb reboot`, then arms a post-reboot
+proof window, injects outside/inside/outside locations after boot, and requires
+post-reboot location plus geofence events. Physical Android devices need real
+movement or another trusted location injection setup.
+
+## iOS
+
+Run the iOS simulator flow:
+
+```sh
+yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:ios
+```
+
+This flow:
+
+1. starts iOS background/significant-change tracking,
+2. sends the app home,
+3. injects location changes,
+4. reopens the page,
+5. verifies native storage drain from events recorded after the run marker.
+
+iOS does not have Android Headless JS or an Android-style boot receiver. The E2E
+page reports those as platform limits instead of pretending they are supported.
+
+## Manual Coordinates
+
+The geofence is centered at:
+
+```txt
+37.5665,126.978
+```
+
+The deterministic transition path is:
+
+```txt
+outside: 37.563,126.97
+inside:  37.5665,126.978
+outside: 37.563,126.97
+```
+
+On iOS Simulator, use the Maestro flow for the Home/background step. For a
+manual run, press Home in Simulator and inject the same path with:
+
+```sh
+xcrun simctl location booted set 37.563,126.97
+xcrun simctl location booted start --interval=2 37.563,126.97 37.5665,126.978 37.563,126.97
+```
+
+On Android Emulator:
+
+```sh
+adb shell input keyevent HOME
+adb emu geo fix 126.970 37.563
+adb emu geo fix 126.978 37.5665
+adb emu geo fix 126.970 37.563
+```
+
+## Expected Gaps
+
+Long-run background behavior is platform and device-policy dependent. If the
+screen reports a failed result, keep it failed and inspect the device state,
+permissions, battery policy, and native logs. Do not change the E2E page to pass
+without a stored native event.

--- a/docs/docs/v1/background/overview.md
+++ b/docs/docs/v1/background/overview.md
@@ -1,0 +1,50 @@
+# Background Location
+
+React Native Nitro Geolocation includes a dedicated Background Location API for background updates, geofencing, Android foreground-service tracking, native event persistence, Android Headless JS delivery, activity recognition events, start-on-boot, native HTTP sync, and stored event recovery.
+
+Background tracking is separate from `watchPosition`. `watchPosition` is for active foreground sessions. Background Location uses native services, receivers, and storage so events can be recorded even when JavaScript is not currently running.
+
+```ts
+import {
+  startBackgroundLocation,
+  diagnoseBackgroundLocation,
+  addGeofences,
+  registerBackgroundTask,
+} from 'react-native-nitro-geolocation/background';
+```
+
+Prefer `react-native-nitro-geolocation/background` so foreground and background
+imports stay explicit and tree-shakable.
+
+## Where to go next
+
+- [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.
+- [Permissions](/background/permissions) - request foreground/background access and handle settings round-trips.
+- [Start And Stop](/background/start-stop) - start continuous tracking and subscribe to native updates.
+- [Troubleshooting](/background/troubleshooting) - use `diagnoseBackgroundLocation()` to interpret the native background status when delivery is silent.
+- [Storage Recovery](/background/storage) - drain events recorded while JavaScript was not running.
+- [Geofencing](/background/geofencing), [Activity Recognition](/background/activity-recognition), and [Native HTTP Sync](/background/http-sync) - add advanced background behavior.
+
+## Diagnose Silent Background Delivery
+
+Use `diagnoseBackgroundLocation()` when background tracking is configured but
+the app is not receiving locations. It reads `getBackgroundLocationStatus()`
+and returns actionable issues instead of forcing app code to interpret every
+status field.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const diagnosis = await diagnoseBackgroundLocation();
+
+if (!diagnosis.healthy) {
+  console.warn(diagnosis.issues.join('\n'));
+}
+```
+
+The result is `{ healthy, status, issues }`. `healthy` is `true` when no issues
+were found, `status` is the raw background status, and `issues` contains
+human-readable reasons delivery may be blocked, such as a native `lastError`,
+missing foreground or background permission, disabled device location services,
+tracking configured but not started, or Android foreground-service and
+notification-permission problems.

--- a/docs/docs/v1/background/permissions.md
+++ b/docs/docs/v1/background/permissions.md
@@ -1,0 +1,35 @@
+# Permissions
+
+```ts
+import {
+  checkBackgroundPermission,
+  openAppLocationSettings,
+  requestBackgroundPermission,
+} from 'react-native-nitro-geolocation/background';
+
+export async function requestBackgroundAccess() {
+  const requested = await requestBackgroundPermission();
+
+  if (requested.needsSettingsRedirect) {
+    // Android 11+ may already have opened app settings. On iOS, show your own
+    // explanation before sending denied/restricted users to settings.
+    // await openAppLocationSettings();
+    return requested;
+  }
+
+  return requested;
+}
+
+export async function refreshBackgroundAccessAfterResume() {
+  return checkBackgroundPermission();
+}
+```
+
+`foreground` and `background` are separate because Android and iOS gate
+background access differently. `needsSettingsRedirect` means the app still needs
+a settings or app-resume round-trip before background tracking can start. On
+Android 11+, `requestBackgroundPermission()` can open the app settings screen
+because the platform no longer allows inline background-location prompts. On
+iOS, it can also remain true until Always authorization is granted; use
+`openAppLocationSettings()` after explaining why Always access is required.
+Call `checkBackgroundPermission()` again from your app-resume path.

--- a/docs/docs/v1/background/setup-android.md
+++ b/docs/docs/v1/background/setup-android.md
@@ -1,0 +1,15 @@
+# Android Setup
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+<uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+<uses-permission android:name="android.permission.WAKE_LOCK" />
+```
+
+Continuous Android background tracking runs as a foreground service and requires a visible notification. `android.foregroundService` is required.

--- a/docs/docs/v1/background/setup-ios.md
+++ b/docs/docs/v1/background/setup-ios.md
@@ -1,0 +1,23 @@
+# iOS Setup
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Allow this app to use your location.</string>
+
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>Allow this app to use your location in the background.</string>
+
+<key>UIBackgroundModes</key>
+<array>
+  <string>location</string>
+</array>
+```
+
+For activity-aware tracking:
+
+```xml
+<key>NSMotionUsageDescription</key>
+<string>Allow this app to detect your movement activity.</string>
+```
+
+iOS does not provide Android-style Headless JS. Events are stored natively and can be drained after app initialization.

--- a/docs/docs/v1/background/start-stop.md
+++ b/docs/docs/v1/background/start-stop.md
@@ -1,0 +1,61 @@
+# Start And Stop
+
+```ts
+import {
+  checkBackgroundPermission,
+  requestBackgroundPermission,
+  startBackgroundLocation,
+  stopBackgroundLocation,
+  onBackgroundLocation,
+} from 'react-native-nitro-geolocation/background';
+
+let subscription;
+
+export async function requestAndMaybeStartTracking() {
+  const permission = await requestBackgroundPermission();
+
+  if (permission.needsSettingsRedirect) {
+    // Register an AppState "active" handler and call resumeBackgroundTracking()
+    // after the user returns from settings or the authorization prompt settles.
+    return;
+  }
+
+  await startIfAllowed(permission);
+}
+
+export async function resumeBackgroundTracking() {
+  const permission = await checkBackgroundPermission();
+  await startIfAllowed(permission);
+}
+
+async function startIfAllowed(permission) {
+  if (permission.foreground === 'granted' && permission.background === 'granted') {
+    await startBackgroundLocation({
+      trackingMode: 'continuous',
+      interval: 10_000,
+      fastestInterval: 5_000,
+      distanceFilter: 25,
+      persist: true,
+      android: {
+        foregroundService: {
+          notificationTitle: 'Location tracking active',
+          notificationText: 'Your location is being recorded',
+        },
+      },
+    });
+
+    subscription?.remove();
+    subscription = onBackgroundLocation(console.log);
+  }
+}
+
+export async function stopTracking() {
+  await stopBackgroundLocation();
+  subscription?.remove();
+  subscription = undefined;
+}
+```
+
+Use [Activity Recognition](/background/activity-recognition) before switching to
+`trackingMode: 'activityAware'`. Use [Android Setup](/background/setup-android)
+before enabling boot restart or changing foreground-service behavior.

--- a/docs/docs/v1/background/storage.md
+++ b/docs/docs/v1/background/storage.md
@@ -1,0 +1,23 @@
+# Storage Recovery
+
+JavaScript listeners are delivery. Native storage is the source of truth.
+
+```ts
+import {
+  getStoredBackgroundLocations,
+  markStoredBackgroundLocationsDelivered,
+} from 'react-native-nitro-geolocation/background';
+
+const locations = await getStoredBackgroundLocations({
+  includeDelivered: false,
+  limit: 100,
+});
+
+await uploadToYourServer(locations);
+
+await markStoredBackgroundLocationsDelivered(
+  locations.map((location) => location.id)
+);
+```
+
+Use `getStoredBackgroundEvents()` for mixed event recovery.

--- a/docs/docs/v1/background/troubleshooting.md
+++ b/docs/docs/v1/background/troubleshooting.md
@@ -1,0 +1,41 @@
+# Troubleshooting
+
+## Diagnose background delivery
+
+Call `diagnoseBackgroundLocation()` when the background pipeline is silent. It
+returns `{ healthy, status, issues }`, where `issues` lists the common blockers
+derived from the native background status.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const { healthy, issues } = await diagnoseBackgroundLocation();
+
+if (!healthy) {
+  console.warn(issues.join('\n'));
+}
+```
+
+The helper checks the last native error, foreground and background permission,
+device location services, configured/running state, stored location count, and
+Android foreground-service or notification-permission state.
+
+## Android tracking does not start
+
+Check foreground location, background location, Android 13+ notification permission, and device location services. Continuous background tracking requires `android.foregroundService`.
+
+If those values look correct but no locations arrive, inspect
+`status.lastError` from `diagnoseBackgroundLocation()` or
+`getBackgroundLocationStatus()`.
+
+## Android starts but stops after swipe-away
+
+Set `stopOnTerminate: false`. Vendor battery restrictions can still stop services.
+
+## iOS killed-app behavior differs
+
+iOS and Android have different background execution models. Authorization level, Low Power Mode, and termination state affect delivery.
+
+## JS callback missed events
+
+Read native storage with `getStoredBackgroundLocations()` or `getStoredBackgroundEvents()`.

--- a/docs/docs/v1/guide/_meta.json
+++ b/docs/docs/v1/guide/_meta.json
@@ -1,0 +1,15 @@
+[
+  "index",
+  "quick-start",
+  "migration-assistance",
+  "community-migration",
+  "service-migration",
+  "expo-development-build",
+  "react-native-directory",
+  "modern-api",
+  "compat-api",
+  "agent-context-map",
+  "devtools",
+  "why-nitro-module",
+  "benchmark"
+]

--- a/docs/docs/v1/guide/agent-context-map.md
+++ b/docs/docs/v1/guide/agent-context-map.md
@@ -1,0 +1,151 @@
+# Agent Context Map
+
+Use this map when you need code context for geolocation behavior but do not
+need to read generated Nitro files, full app bundles, or every scenario screen.
+
+## Start Here for This Task
+
+Pick the smallest entry point that matches your change:
+
+| Task | Read first | Then read |
+| --- | --- | --- |
+| Public foreground API behavior | `packages/react-native-nitro-geolocation/src/api/` | `packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts`, then platform files below |
+| Community compatibility behavior | `packages/react-native-nitro-geolocation/src/compat/` | `packages/react-native-nitro-geolocation/src/NitroGeolocationCompat.nitro.ts` |
+| Background API shape | `packages/react-native-nitro-geolocation/src/background/index.ts` | `packages/react-native-nitro-geolocation/src/background/NitroBackgroundLocation.nitro.ts` |
+| Android foreground native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt` | Nearby Android helper for the specific feature |
+| Android background native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/` |
+| iOS foreground native bug | `packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift` | Nearby iOS helper for the specific feature |
+| iOS background native bug | `packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift` | `IOSBackgroundLocationDelegate.swift`, `IOSBackgroundMotion.swift`, `IOSBackgroundHttpSync.swift` |
+| E2E failure | Matching `examples/v0.81.1/.maestro/*.yaml` file | Matching `examples/v0.81.1/src/screens/*Screen.tsx` file |
+| E2E shared UI or selectors | `examples/v0.81.1/src/screens/scenario/` | `examples/v0.81.1/src/App.tsx` for route names |
+
+Avoid these until needed:
+
+- `packages/react-native-nitro-geolocation/nitrogen/generated/**`: generated
+  bindings. Read only to debug codegen output.
+- `docs/doc_build/**`: generated documentation output.
+- `examples/*/node_modules/**`: installed dependencies.
+- Full scenario screen sweeps. Use the E2E map below to open only the failing
+  flow and its screen.
+
+## Native Responsibility Map
+
+### Shared TypeScript Layer
+
+| Area | Responsibility | Main files |
+| --- | --- | --- |
+| Modern foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
+| Community compatibility API | `@react-native-community/geolocation`-style callbacks and configuration. | `src/compat/`, `src/NitroGeolocationCompat.nitro.ts` |
+| Background API | Public background exports, listener narrowing, storage methods, geofence helpers, activity recognition helpers, HTTP sync helper, and task registration. | `src/background/index.ts`, `src/background/task.ts`, `src/background/types.ts`, `src/background/NitroBackgroundLocation.nitro.ts` |
+| Web fallback | Browser geolocation behavior and web E2E support. | `src/web/`, `src/index.web.tsx`, `src/background/index.web.ts` |
+
+### Android Foreground
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro foreground module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt` |
+| Compatibility module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocationCompat.kt` |
+| One-shot current position | `GetCurrentPosition.kt`, `AndroidFusedRequestFactory.kt` |
+| Position watch | `WatchPosition.kt`, `AndroidFusedRequestFactory.kt` |
+| Permissions | `RequestAuthorization.kt` |
+| Options and conversion | `AndroidGeolocationOptions.kt`, `AndroidGeolocationConversions.kt`, `LocationValues.kt` |
+| Provider/settings/status | `AndroidLocationSettings.kt`, `AndroidGeolocationErrors.kt` |
+| Heading | `AndroidHeadingManager.kt` |
+
+### Android Background
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro background module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` |
+| Background orchestration | `android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt` |
+| Foreground service tracking | `NitroBackgroundLocationService.kt`, `NitroBackgroundNotificationFactory.kt` |
+| Location delivery from system callbacks | `NitroLocationUpdateReceiver.kt` |
+| Event fan-out to JS listeners | `NitroBackgroundEventHub.kt` |
+| Native persistence | `NitroBackgroundStore.kt`, `AndroidBackgroundSerialization.kt` |
+| Background permission contract | `AndroidBackgroundPermissions.kt` |
+| Geofencing | `NitroGeofenceReceiver.kt` |
+| Android Headless JS | `NitroBackgroundHeadlessTaskService.kt` |
+| Start on boot | `NitroBootReceiver.kt` |
+| Activity recognition | `NitroActivityRecognitionReceiver.kt` |
+| HTTP sync | `AndroidBackgroundHttpSync.kt` |
+
+### iOS Foreground
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro foreground module entry point | `ios/NitroGeolocation.swift` |
+| Compatibility module entry point | `ios/NitroGeolocationCompat.swift` |
+| Core Location manager and delegate | `ios/LocationManager.swift`, `ios/IOSGeolocationDelegate.swift` |
+| Options and conversion | `ios/IOSGeolocationOptions.swift`, `ios/IOSGeolocationConversions.swift` |
+| Error mapping | `ios/IOSGeolocationErrors.swift` |
+| Mock/provider metadata | `ios/CLLocation+GeolocationMetadata.swift` |
+
+### iOS Background
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro background module, storage, status, geofences, and Core Location start/stop | `ios/NitroBackgroundLocation.swift` |
+| Background Core Location delegate | `ios/IOSBackgroundLocationDelegate.swift` |
+| Activity recognition conversion | `ios/IOSBackgroundMotion.swift` |
+| Native HTTP sync | `ios/IOSBackgroundHttpSync.swift` |
+| Persistence serialization | `ios/IOSBackgroundSerialization.swift` |
+
+## E2E Scenario File Map
+
+All native E2E flows live in `examples/v0.81.1/.maestro/`. Route names and deep
+links live in `examples/v0.81.1/src/App.tsx`. Shared selectors, result blocks,
+permission helpers, and location assertions live in
+`examples/v0.81.1/src/screens/scenario/`.
+
+| Flow | Maestro file | App screen |
+| --- | --- | --- |
+| Master native smoke suite | `all-tests.yaml` | Multiple screens |
+| Permission check/request | `permission-check.yaml` | `PermissionCheckScreen.tsx` |
+| Current position | `current-position.yaml` | `CurrentPositionScreen.tsx` |
+| Watch position | `watch-position.yaml` | `WatchPositionScreen.tsx` |
+| Location simulation | `location-simulation.yaml` | `LocationSimulationScreen.tsx` |
+| Accuracy presets | `accuracy-presets.yaml` | `AccuracyPresetsScreen.tsx` |
+| Last known position | `last-known-position.yaml` | `LastKnownPositionScreen.tsx` |
+| Geocoding and reverse geocoding | `geocoding.yaml` | `GeocodingScreen.tsx` |
+| Location availability | `location-availability.yaml` | `LocationAvailabilityScreen.tsx` |
+| Heading dispatcher | `heading.yaml` | `HeadingScreen.tsx` |
+| Android heading | `heading-android.yaml` | `HeadingScreen.tsx` |
+| iOS heading | `heading-ios.yaml` | `HeadingScreen.tsx` |
+| Android request options | `android-request-options.yaml` | `AndroidRequestOptionsScreen.tsx` |
+| Android provider selection | `android-provider-selection.yaml` | `AndroidRequestOptionsScreen.tsx` |
+| Android provider settings | `provider-settings.yaml`, `provider-settings-not-ready.yaml` | `ProviderSettingsScreen.tsx` |
+| iOS location tuning | `ios-location-tuning.yaml` | `IOSLocationTuningScreen.tsx` |
+| iOS accuracy authorization | `ios-accuracy-authorization.yaml` | `IOSAccuracyAuthorizationScreen.tsx` |
+| iOS release bridge options | `ios-release-options-bridge.yaml` | `IOSReleaseOptionsBridgeScreen.tsx` |
+| Issue 67 coarse Android location | `issue-67-android-coarse-location.yaml` | `Issue67Screen.tsx` |
+| Background API smoke | `background-e2e.yaml` | `BackgroundE2EScreen.tsx` |
+| Android long-run background | `background-long-run-android.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
+| Android long-run reboot arming | `background-long-run-android-arm-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| Android long-run reboot proof | `background-long-run-android-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
+| iOS long-run background | `background-long-run-ios.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| Mocked metadata Android true | `mocked-metadata-android-true.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata Android false | `mocked-metadata-android-false.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata iOS true | `mocked-metadata-ios-true.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata iOS false | `mocked-metadata-ios-false.yaml` | `MockedMetadataScreen.tsx` |
+| API errors | `api-errors.yaml` | `ApiErrorsScreen.tsx` |
+| Community compatibility API | `compat-api.yaml` | `CompatScreen.tsx` |
+| Web E2E available path | `web-e2e.yaml` | `WebE2EScreen.tsx`, `examples/web-e2e/` |
+| Web E2E unavailable path | `web-e2e-unavailable.yaml` | `WebE2EScreen.tsx`, `examples/web-e2e/` |
+
+## E2E Command Map
+
+Run from repo root with the matching workspace script:
+
+| Target | Command |
+| --- | --- |
+| Android native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:android` |
+| iOS native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:ios` |
+| Android long-run background | `yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |
+| Android long-run background with reboot | `RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |
+| iOS long-run background | `yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:ios` |
+| Android web E2E | `yarn workspace react-native-nitro-geolocation-example test:e2e:web:android` |
+| iOS web E2E | `yarn workspace react-native-nitro-geolocation-example test:e2e:web:ios` |
+
+Android `all-tests.yaml` can include live provider-selection checks through
+`android-provider-selection.yaml` when `RUN_ANDROID_PROVIDER_SELECTION=1` is
+set.

--- a/docs/docs/v1/guide/benchmark.md
+++ b/docs/docs/v1/guide/benchmark.md
@@ -1,0 +1,39 @@
+# Benchmark
+
+This app benchmarks cached location read overhead between
+`react-native-nitro-geolocation` and `@react-native-community/geolocation`.
+
+![react-native-nitro-geolocation](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/benchmark.gif)
+
+## 📊 Benchmark Results
+
+**Test Environment:**
+- Device: iPhone 14 Pro
+- React Native: 0.81.4
+- Test: 1000 iterations × 5 runs of `getCurrentPosition` with cached location (measuring pure bridge/JSI latency)
+
+:::warning Benchmark scope
+This benchmark measures cached location reads and the JS-to-native call path. It
+does not measure cold GPS acquisition, permission dialogs, provider
+availability, or OS throttling. Nitro does not make GPS acquisition itself 22x
+faster; it makes cached reads and the JS-to-native path cheaper.
+:::
+
+### Results
+
+| Metric | Nitro | Community | Improvement |
+|--------|-------|-----------|-------------|
+| **Average** | 0.019ms | 0.436ms | **22.95x faster** |
+| **Median** | 0.017ms | 0.045ms | 62.2% faster |
+| **Min** | 0.014ms | 0.034ms | 58.8% faster |
+| **Max** | 1.007ms | 10.577ms | 90.5% faster |
+| **P95** | 0.025ms | 6.434ms | **257.4x faster** |
+| **P99** | 0.031ms | 7.271ms | **234.5x faster** |
+| **Std Dev** | 0.032ms | 1.545ms | 98.0% more stable |
+| **Samples** | 1000 | 1000 | - |
+
+### Why is Nitro faster for cached reads?
+
+1. **Zero Queue Overhead**: Cached location responses return immediately without any dispatch queue overhead
+2. **Direct JSI Calls**: No JSON serialization or async bridge crossing
+3. **Optimized Architecture**: Fast path for cached responses, queue-free delegate callbacks

--- a/docs/docs/v1/guide/community-migration.md
+++ b/docs/docs/v1/guide/community-migration.md
@@ -1,0 +1,152 @@
+---
+title: Community Migration
+---
+
+# Community Migration
+
+Use this path for apps that import `@react-native-community/geolocation`,
+`navigator.geolocation`, or `react-native-nitro-geolocation/compat`.
+
+The safest migration is two-step: switch community imports to `/compat` first,
+verify the app still behaves the same, then move call sites to the Modern API
+where it improves ownership, permission timing, cache behavior, or Android
+settings handling.
+
+## Agent Skill
+
+This repository ships an Agent Skills-compatible migration playbook for this
+path:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
+```
+
+The skill source is
+[`skills/community-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
+
+The bundled bootstrap script performs the first safe mechanical pass:
+
+```bash
+node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
+```
+
+After the compat bootstrap, use the skill to refactor selected call sites to the
+Modern API.
+
+## Migration Path
+
+### Step 1: Community Package
+
+```tsx
+import Geolocation from '@react-native-community/geolocation';
+
+Geolocation.getCurrentPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  {
+    enableHighAccuracy: true,
+    timeout: 15000,
+    maximumAge: 0
+  }
+);
+```
+
+### Step 2: Drop-In `/compat`
+
+First install the Nitro packages:
+
+```bash
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+```
+
+Then change only the import path:
+
+```diff
+- import Geolocation from '@react-native-community/geolocation';
++ import Geolocation from 'react-native-nitro-geolocation/compat';
+```
+
+Keep the callback call site unchanged while you verify the app:
+
+```tsx
+Geolocation.getCurrentPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  {
+    enableHighAccuracy: true,
+    timeout: 15000,
+    maximumAge: 0
+  }
+);
+```
+
+### Step 3: Modern API
+
+After the `/compat` migration is stable, move individual call sites to the
+Modern API:
+
+```tsx
+import {
+  getCurrentPosition,
+  requestLocationSettings,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'playServices'
+});
+
+const status = await requestPermission();
+
+if (status === 'granted') {
+  await requestLocationSettings({
+    accuracy: { android: 'high' },
+    interval: 5000,
+    fastestInterval: 1000
+  });
+
+  const position = await getCurrentPosition({
+    accuracy: { android: 'high', ios: 'best' },
+    granularity: 'permission',
+    waitForAccurateLocation: true,
+    timeout: 15000,
+    maximumAge: 0
+  });
+
+  console.log(position.coords.latitude, position.coords.longitude);
+}
+```
+
+For React component watches, prefer `useWatchPosition` so subscription cleanup
+is owned by the component lifecycle:
+
+```tsx
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LocationTracker() {
+  const { position, error, isWatching } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'balanced', ios: 'nearestTenMeters' },
+    distanceFilter: 10
+  });
+
+  if (error) return <Text>{error.message}</Text>;
+  if (!position) return <Text>{isWatching ? 'Waiting...' : 'Stopped'}</Text>;
+
+  return (
+    <Text>
+      {position.coords.latitude}, {position.coords.longitude}
+    </Text>
+  );
+}
+```

--- a/docs/docs/v1/guide/compat-api.md
+++ b/docs/docs/v1/guide/compat-api.md
@@ -1,0 +1,214 @@
+---
+title: Compat API (Compatibility)
+---
+
+> ⚠️ **This is the compat callback-based API for compatibility with @react-native-community/geolocation.**
+> For new projects, we recommend using the [Modern API](./modern-api.md) with functions and the `useWatchPosition` hook.
+
+## Import Path
+
+```tsx
+// Import from /compat subpath
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+// Or named imports
+import {
+  getCurrentPosition,
+  watchPosition,
+  clearWatch,
+} from 'react-native-nitro-geolocation/compat';
+```
+
+## Compatibility Scope
+
+This API is drop-in compatible with the core native
+`@react-native-community/geolocation` surface. It preserves the callback-based
+shape for existing iOS and Android apps while the Modern API gives new code a
+Promise/function API.
+
+| Community API | Nitro `/compat` | Notes |
+| --- | ---: | --- |
+| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
+| `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
+| `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
+| `watchPosition` | Supported | Returns a numeric watch id. |
+| `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
+| `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
+| `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
+| Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
+
+The root Modern API and `/compat` subpath both support web by delegating to the
+browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
+shape and legacy error constants, while `setRNConfiguration()` is a no-op and
+`requestAuthorization()` calls the success callback immediately because browsers
+do not expose a standalone geolocation authorization prompt.
+
+## Summary
+
+- [`setRNConfiguration`](#setrnconfiguration)
+- [`requestAuthorization`](#requestauthorization)
+- [`getCurrentPosition`](#getcurrentposition)
+- [`watchPosition`](#watchposition)
+- [`clearWatch`](#clearwatch)
+- [`stopObserving`](#stopobserving)
+
+## Details
+
+### `setRNConfiguration()`
+
+Preserves the legacy configuration API. Use it for iOS authorization/background
+settings. Android provider selection and request behavior should be configured
+per call or through the Modern API root import.
+
+```ts
+Geolocation.setRNConfiguration(config: {
+  skipPermissionRequests: boolean;
+  authorizationLevel?: 'always' | 'whenInUse' | 'auto';
+  enableBackgroundLocationUpdates?: boolean;
+  locationProvider?: 'playServices' | 'android' | 'auto';
+});
+```
+
+Supported options:
+
+- `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
+- `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
+- `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
+
+### `requestAuthorization()`
+
+Request suitable Location permission.
+
+```ts
+Geolocation.requestAuthorization(
+  success?: () => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void
+);
+```
+
+On iOS if NSLocationAlwaysUsageDescription is set, it will request Always authorization, although if NSLocationWhenInUseUsageDescription is set, it will request InUse authorization.
+
+### `getCurrentPosition()`
+
+Invokes the success callback once with the latest location info.
+
+```ts
+Geolocation.getCurrentPosition(
+  success: (position: {
+    coords: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      accuracy: number;
+      altitudeAccuracy: number | null;
+      heading: number | null;
+      speed: number | null;
+    };
+    timestamp: number;
+  }) => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void,
+  options?: {
+    timeout?: number;
+    maximumAge?: number;
+    enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
+  }
+);
+```
+
+Supported options:
+
+- `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Native compat defaults to 10 minutes. Web omits the field when you do not pass it, so browser defaults apply.
+- `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. Native compat defaults to INFINITY. Web omits the field when you do not pass it, so browser defaults apply.
+- `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
+
+### `watchPosition()`
+
+Invokes the success callback whenever the location changes. Returns a `watchId` (number).
+
+```ts
+Geolocation.watchPosition(
+  success: (position: {
+    coords: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      accuracy: number;
+      altitudeAccuracy: number | null;
+      heading: number | null;
+      speed: number | null;
+    };
+    timestamp: number;
+  }) => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void,
+  options?: {
+    interval?: number;
+    fastestInterval?: number;
+    timeout?: number;
+    maximumAge?: number;
+    enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
+    distanceFilter?: number;
+    useSignificantChanges?: boolean;
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
+  }
+) => number;
+```
+
+Supported options:
+
+- `interval` (ms) -- (Android only) The rate in milliseconds at which your app prefers to receive location updates. Note that the location updates may be somewhat faster or slower than this rate to optimize for battery usage, or there may be no updates at all (if the device has no connectivity, for example).
+- `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `distanceFilter` (m) - The minimum distance from the previous location to exceed before returning a new location. Set to 0 to not filter locations. Defaults to 100m on Android and no distance filter on iOS.
+- `useSignificantChanges` (bool) - Uses the battery-efficient native significant changes APIs to return locations. Locations will only be returned when the device detects a significant distance has been breached. Defaults to FALSE.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
+
+`timeout`, `maximumAge`, and `fastestInterval` are part of the legacy option
+type for compatibility, but native `/compat` watches do not use them. On web,
+`watchPosition()` forwards `timeout`, `maximumAge`, and `enableHighAccuracy` to
+`navigator.geolocation`.
+
+### `clearWatch()`
+
+Clears watch observer by id returned by `watchPosition()`
+
+```ts
+Geolocation.clearWatch(watchID: number);
+```

--- a/docs/docs/v1/guide/devtools.md
+++ b/docs/docs/v1/guide/devtools.md
@@ -1,0 +1,228 @@
+# DevTools Plugin (Rozenite)
+
+Mock geolocation data in development with an interactive map interface using the Rozenite DevTools plugin.
+
+## Prerequisites
+
+This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) before proceeding.
+
+:::warning API Compatibility
+This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
+:::
+
+## Installation
+
+```bash
+npm install @react-native-nitro-geolocation/rozenite-plugin
+# or
+yarn add @react-native-nitro-geolocation/rozenite-plugin
+```
+
+## Setup
+
+Add the devtools hook to your app entry point:
+
+```tsx
+import { useGeolocationDevTools } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+function App() {
+  // Enable devtools with default position (Seoul)
+  useGeolocationDevTools();
+
+  return <YourApp />;
+}
+```
+
+### With Initial Position
+
+#### Using City Presets
+
+Choose from 20 pre-configured city locations:
+
+```tsx
+import { useGeolocationDevTools, createPosition } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: createPosition('Dubai, UAE')
+  });
+
+  return <YourApp />;
+}
+```
+
+#### Using Custom Coordinates
+
+Manually define a position with specific coordinates:
+
+```tsx
+import { useGeolocationDevTools, type Position } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+const customPosition: Position = {
+  coords: {
+    latitude: 37.7749,
+    longitude: -122.4194,
+    altitude: 0,
+    accuracy: 100,
+    altitudeAccuracy: 100,
+    heading: 0,
+    speed: 0,
+  },
+  timestamp: Date.now()
+};
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: customPosition
+  });
+
+  return <YourApp />;
+}
+```
+
+## Opening DevTools
+
+1. Start your React Native app with Metro bundler
+2. Press `j` in the Metro terminal to open DevTools
+3. Enable the **Geolocation** plugin from the Rozenite DevTools panel
+4. Start mocking locations!
+
+## Features
+
+### Interactive Map Control
+- **Click to set location**: Click anywhere on the map to instantly update device position
+- **Visual feedback**: Real-time marker updates as you change location
+- **Zoom and pan**: Full map navigation support
+
+### Keyboard Navigation
+Use arrow keys for precise position adjustments:
+- `↑` Move north
+- `↓` Move south
+- `←` Move west
+- `→` Move east
+
+### Manual Input
+Enter exact coordinates via input fields:
+- **Latitude**: Direct decimal degree input
+- **Longitude**: Direct decimal degree input
+- Auto-updates map and position when changed
+
+### Location Presets
+Quick access to 20 major cities worldwide:
+
+**Asia-Pacific**: Seoul, Tokyo, Beijing, Shanghai, Hong Kong, Singapore, Mumbai, Bangkok, Sydney
+
+**Europe**: London, Paris, Berlin, Moscow
+
+**Americas**: New York, Los Angeles, San Francisco, São Paulo, Mexico City, Toronto
+
+**Middle East**: Dubai
+
+### Real-time Position Data
+
+The plugin automatically calculates and updates:
+- **Heading**: Direction of movement (0-360°)
+- **Speed**: Velocity based on distance over time (m/s)
+- **Accuracy**: Position accuracy in meters
+- **Altitude**: Optional altitude data
+- **Timestamp**: Precise update timing
+
+## Demo
+
+![DevTools Plugin in Action](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
+
+## How It Works
+
+The DevTools plugin uses an event-driven architecture:
+
+1. **Ready Signal**: DevTools UI sends a "ready" signal when mounted
+2. **Initial Position**: App responds with the configured initial position
+3. **Position Updates**: UI sends position changes to the app in real-time
+4. **Global State**: Position data is stored globally and accessible to all geolocation APIs
+
+```tsx
+// Behind the scenes
+useGeolocationDevTools() → Sets up message bridge
+↓
+DevTools UI opens → Sends "ready" signal
+↓
+App responds → Sends initial position
+↓
+User changes location → DevTools sends position update
+↓
+getCurrentPosition() / useWatchPosition() → Returns mocked position
+```
+
+## Development Workflow
+
+### Typical Usage
+
+```tsx
+import { useGeolocationDevTools, createPosition } from '@react-native-nitro-geolocation/rozenite-plugin';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function App() {
+  // 1. Enable devtools with initial position
+  useGeolocationDevTools({
+    initialPosition: createPosition('Tokyo, Japan')
+  });
+
+  // 2. Use geolocation as normal
+  const { position } = useWatchPosition({ enabled: true });
+
+  return (
+    <Map
+      latitude={position?.coords.latitude}
+      longitude={position?.coords.longitude}
+    />
+  );
+}
+```
+
+### Testing Scenarios
+
+**Test navigation**:
+1. Select a start location from presets
+2. Click a destination on the map
+3. Observe your app update in real-time
+
+**Test accuracy handling**:
+1. Monitor the accuracy value in DevTools
+2. Test how your app handles low accuracy readings
+
+**Test movement**:
+1. Use arrow keys for smooth movement
+2. Verify heading and speed calculations
+3. Test distance-based triggers
+
+## Important Notes
+
+:::warning Production Builds
+The DevTools plugin should only be enabled in development builds. Rozenite DevTools is automatically disabled in production, so no additional configuration is needed.
+:::
+
+:::tip
+The plugin only intercepts Modern API calls. Compat API calls keep the drop-in replacement behavior.
+:::
+
+## Troubleshooting
+
+**DevTools not connecting**:
+- Ensure Rozenite DevTools is properly installed
+- Check that you've enabled the Geolocation plugin in the DevTools panel
+- Try closing and reopening DevTools (press `j` again)
+
+**Position not updating**:
+- Verify `useGeolocationDevTools()` is called before any geolocation APIs
+- Check Metro bundler logs for errors
+- Ensure DevTools panel is open and plugin is enabled
+
+**Initial position not applied**:
+- Make sure DevTools is open when the app starts
+- The ready signal may be delayed - try reloading the app
+
+## Source Code
+
+View the full source code on GitHub:
+- [Plugin Repository](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/packages/rozenite-devtools-plugin)
+- [Report Issues](https://github.com/jingjing2222/react-native-nitro-geolocation/issues)

--- a/docs/docs/v1/guide/expo-development-build.md
+++ b/docs/docs/v1/guide/expo-development-build.md
@@ -1,0 +1,81 @@
+---
+title: Expo Development Builds
+---
+
+# Expo Development Builds
+
+`react-native-nitro-geolocation` requires native Nitro bindings. It does not run
+inside Expo Go because Expo Go cannot load arbitrary native modules that are not
+already bundled into the client.
+
+Use this package in Expo apps only when the app has a custom native build:
+
+- Expo prebuild
+- Expo development build
+- EAS build with native project generation
+- Any custom native iOS/Android build that can install pods and Gradle modules
+
+Managed Expo apps that cannot rebuild native code should use `expo-location`.
+
+## Installation
+
+Install the native dependencies:
+
+```bash
+npx expo install react-native-nitro-modules react-native-nitro-geolocation
+```
+
+Then generate or update the native projects:
+
+```bash
+npx expo prebuild
+```
+
+Install iOS pods after native project generation:
+
+```bash
+cd ios && pod install
+```
+
+## Native Permissions
+
+Add the same native permission declarations as a bare React Native app.
+
+iOS `Info.plist`:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>This app requires access to your location while it's in use.</string>
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>This app requires access to your location at all times.</string>
+```
+
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
+Android `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+Optional background permission:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
+
+## Supported Positioning
+
+Use this package when you want Nitro/New Architecture native geolocation in an
+Expo development build or custom native build.
+
+Use `expo-location` when you need Expo Go, managed workflow setup without native
+rebuilds, Expo background tasks, Expo geofencing, or Expo config-plugin-driven
+permission setup.

--- a/docs/docs/v1/guide/index.md
+++ b/docs/docs/v1/guide/index.md
@@ -1,0 +1,249 @@
+# Introduction
+
+The [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation) package has been the standard way to access device location in React Native apps.
+
+With the React Native ecosystem moving toward **TurboModules**, **Fabric**, and **JSI-based architecture**, we saw an opportunity to bring geolocation to the new architecture while improving the developer experience.
+
+This project — **React Native Nitro Geolocation** — is a native iOS/Android
+module designed for the **Nitro Module** system. It is best positioned as a
+React Native 0.75+ / New Architecture path for replacing the core native
+`@react-native-community/geolocation` API with `/compat`, then gradually moving
+to a typed Modern API.
+
+The current release line adds a clearer three-surface story: Modern and
+`/compat` foreground geolocation on web, plus a native Background Location API
+for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
+## When should I use this?
+
+| Use case | Recommendation |
+| --- | --- |
+| Bare React Native 0.75+ app with New Architecture/Nitro enabled | Use Nitro Geolocation |
+| Migrating from `@react-native-community/geolocation` | Start with `/compat` |
+| New Architecture / Nitro-based app | Recommended |
+| Expo development build or custom native build | Supported with native setup |
+| Expo managed app without native rebuild | Use `expo-location` |
+| Web support required | Use the Modern API root import or `/compat` callback API |
+| Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
+
+Web support is available for the Modern API root import and the `/compat`
+subpath. Browser builds resolve both entries to implementations backed by
+`navigator.geolocation` and do not load Nitro native bindings. Background
+location remains native-only.
+
+React Native Nitro Geolocation provides **three public API surfaces** to fit
+your needs:
+
+## 1. Modern API (Recommended)
+
+**Simple functional API** with direct calls and minimal abstractions.
+
+```tsx
+import {
+  setConfiguration,
+  requestPermission,
+  getCurrentPosition,
+  geocode,
+  reverseGeocode,
+  useWatchPosition
+} from 'react-native-nitro-geolocation';
+
+// Configure once at app startup
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'auto'
+});
+
+// Request permission
+const status = await requestPermission();
+if (status !== 'granted') {
+  throw new Error('Location permission was not granted');
+}
+
+// Get current location
+const position = await getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  timeout: 15000
+});
+
+// Convert between addresses and coordinates
+const locations = await geocode('City Hall, Seoul, South Korea');
+const addresses = await reverseGeocode({
+  latitude: 37.5665,
+  longitude: 126.978
+});
+
+// Continuous tracking with hook
+function LocationTracker() {
+  const { position, error, isWatching } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'high', ios: 'bestForNavigation' },
+    distanceFilter: 10
+  });
+
+  if (error) return <Text>Error: {error.message}</Text>;
+  if (!position) return <Text>Waiting...</Text>;
+
+  return (
+    <Text>
+      {position.coords.latitude}, {position.coords.longitude}
+    </Text>
+  );
+}
+```
+
+**Key Features**:
+- 🎯 Simple and direct — No complex abstractions
+- 🪝 Single hook for continuous tracking
+- 🧹 Auto-cleanup when component unmounts
+- 📘 Full TypeScript support
+
+## 2. Compat API (Compatibility)
+
+Drop-in compatible with the core native `@react-native-community/geolocation`
+API via the `/compat` subpath.
+
+```tsx
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+Geolocation.getCurrentPosition(
+  (position) => console.log(position),
+  (error) => console.error(error),
+  { enableHighAccuracy: true }
+);
+```
+
+**Use cases**:
+- Drop-in replacement for existing apps
+- Minimal migration effort
+- Callback-based API preference
+
+## 3. Background API
+
+Native background tracking, geofencing, activity events, Android Headless JS,
+HTTP sync, and stored event recovery should use the explicit background subpath
+`react-native-nitro-geolocation/background`.
+
+Background location is native-only. Browser builds expose unsupported stubs so
+web bundles can still import shared code safely. Start with the
+[Background Location guide](/background/overview) when you need full background
+tracking, geofencing, storage recovery, or native sync.
+
+## Why Modern API?
+
+The Modern API brings simplicity and React hook patterns to geolocation:
+
+### Declarative vs Imperative
+
+**Before (Imperative)**:
+```tsx
+const [position, setPosition] = useState(null);
+const watchIdRef = useRef(null);
+
+useEffect(() => {
+  watchIdRef.current = Geolocation.watchPosition(
+    (pos) => setPosition(pos),
+    (err) => console.error(err)
+  );
+
+  return () => {
+    if (watchIdRef.current !== null) {
+      Geolocation.clearWatch(watchIdRef.current);
+    }
+  };
+}, []);
+```
+
+**After (Declarative)**:
+```tsx
+const { position } = useWatchPosition({ enabled: true });
+// Auto cleanup, no watch ID management needed!
+```
+
+### Key Benefits
+
+- **🎯 Simple and Direct**: Just functions and one hook
+- **🧹 Auto-cleanup**: No need to remember `clearWatch()` in `useEffect` cleanup
+- **🪝 Single Hook**: Only `useWatchPosition` for continuous tracking
+- **📘 Type-safe**: Full TypeScript support with inference
+- **⚡ High Performance**: JSI-powered for native speed
+
+
+## Motivation
+
+The motivation behind React Native Nitro Geolocation is twofold:
+
+### 1. Update the Architecture
+
+React Native has evolved with new architectural capabilities, and we wanted to bring these benefits to the Geolocation API.
+
+`@react-native-community/geolocation` was built on the **bridge-based architecture**, which was the standard at the time. The new JSI-based architecture offers different characteristics:
+
+- Direct communication between JS and native layers
+- Support for synchronous APIs when needed
+- Better integration with concurrent React and Fabric
+- Enhanced TypeScript support and platform consistency
+
+### 2. Improve Developer Experience
+
+We created a geolocation API that:
+
+- **Simple configuration**: Call `setConfiguration()` once
+- **Direct function calls**: No classes or complex abstractions
+- **Handles lifecycle automatically**: No manual cleanup required
+- **Provides declarative control**: `{ enabled }` prop instead of start/stop
+- **Ensures type safety**: Full TypeScript inference
+
+
+## Design Philosophy
+
+### Simple and Functional
+
+Instead of complex provider patterns or class-based APIs, we provide:
+
+| Concept | Modern API |
+|---------|------------|
+| **Configuration** | `setConfiguration()` |
+| **Permission** | `checkPermission()`, `requestPermission()` |
+| **Location** | `getCurrentPosition()`, `useWatchPosition()` |
+| **Geocoding** | `geocode()`, `reverseGeocode()` |
+| **Cleanup** | Automatic (in hook) |
+
+### Core Principles
+
+1. **Configuration at startup**: Set up once with `setConfiguration()`
+2. **Direct function calls**: Use Promise-based functions directly
+3. **Single hook for tracking**: `useWatchPosition` handles continuous updates
+4. **Automatic lifecycle**: No manual cleanup code
+5. **Type-safe by default**: Full TypeScript inference
+6. **Performance first**: JSI-powered for native speed
+
+
+## What You Get
+
+The package has three clear surfaces:
+
+- **Modern API** - typed foreground geolocation, geocoding, watching, cached reads, and Android settings helpers.
+- **Compat API** - a `/compat` path for migrating the core `@react-native-community/geolocation` surface.
+- **Background API** - native tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
+Modern and `/compat` foreground APIs also support web through the browser
+`navigator.geolocation` API.
+
+The benchmark measures cached location reads and the JS-to-native call path. It
+does not make cold GPS acquisition itself 22x faster.
+
+Whether you're upgrading an existing app or building a new one using the latest React Native architecture, **React Native Nitro Geolocation** gives you the Modern API with a migration-friendly compat path.
+
+
+## Next Steps
+
+- [Quick Start Guide](/guide/quick-start) — Get up and running in minutes
+- [Migration Skills](/guide/migration-assistance) — Choose the right agent skill for community or service migrations
+- [Community Migration](/guide/community-migration) — Move from community imports to `/compat` and the Modern API
+- [Service Migration](/guide/service-migration) — Move from `react-native-geolocation-service` directly to the Modern API
+- [Expo Development Build Guide](/guide/expo-development-build) — Use the package in Expo custom native builds
+- [Modern API Reference](/guide/modern-api) — Explore functions and hooks
+- [Compat API Reference](/guide/compat-api) — Compatibility documentation
+- [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
+- [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/v1/guide/migration-assistance.md
+++ b/docs/docs/v1/guide/migration-assistance.md
@@ -1,0 +1,106 @@
+---
+title: Migration Skills
+---
+
+# Migration Skills
+
+Use this guide when migrating an existing app from
+`@react-native-community/geolocation`, `navigator.geolocation`,
+`react-native-geolocation-service`, or `react-native-nitro-geolocation/compat`
+toward the Modern API.
+
+## Agent Skill
+
+This repository publishes Agent Skills-compatible migration playbooks for
+coding agents.
+
+For `@react-native-community/geolocation`, `navigator.geolocation`, or existing
+`/compat` code, use:
+
+[`community-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
+
+Install it with the Vercel Labs `skills` CLI:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
+```
+
+For `react-native-geolocation-service`, migrate directly to the Modern API with:
+
+[`service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
+```
+
+Both skills are migration assistance, not fully automatic migrations.
+
+The community migration skill uses a two-phase workflow:
+
+1. Run a package-manager-aware compat bootstrap script that installs
+   `react-native-nitro-modules` and `react-native-nitro-geolocation`, rewrites
+   `@react-native-community/geolocation` import sources to
+   `react-native-nitro-geolocation/compat`, removes the legacy package, and
+   prints validation commands for scripts that exist in the target app.
+2. Refactor `/compat` call sites to Modern API best practices using explicit
+   criteria for permission timing, React lifecycle ownership, watch cleanup,
+   cache-vs-fresh reads, accuracy, and Android provider/settings handling.
+
+The service migration skill skips `/compat` and targets the Modern API directly.
+It preserves service-specific behavior such as `accuracy`, fused-provider
+intent, Android settings-dialog handling, `mocked`/`provider` metadata, and
+provider-related error codes.
+
+## Choose a Path
+
+For `@react-native-community/geolocation`, first make the mechanical
+dependency/import change and verify the app still builds. Then refactor the
+callback-based compat code to Modern API calls. See
+[Community Migration](/guide/community-migration).
+
+For `react-native-geolocation-service`, migrate directly to named Modern API
+imports. That package's Android fused-provider and settings-dialog options map
+more naturally to Modern APIs such as
+`setConfiguration({ locationProvider: 'playServices' })` and
+`requestLocationSettings()`. See [Service Migration](/guide/service-migration).
+
+The final target state should avoid runtime imports from
+`@react-native-community/geolocation`, `navigator.geolocation`, and
+`react-native-nitro-geolocation/compat` unless the app deliberately keeps a
+compatibility fallback.
+
+## Modern API Targets
+
+| Legacy or compat usage | Modern API target |
+| --- | --- |
+| `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
+| cache-first startup location reads | `await getLastKnownPosition(options)` |
+| `requestAuthorization(success, error)` | `await requestPermission()` |
+| `setRNConfiguration(config)` | `setConfiguration(config)` |
+| `watchPosition` in function components | `useWatchPosition({ enabled, ...options })` |
+| `watchPosition` in services, classes, or tasks | `watchPosition(...)` + `unwatch(token)` |
+| `clearWatch(id)` | `unwatch(token)` |
+| `enableHighAccuracy: true` | `accuracy: { android: 'high', ios: 'best' }` |
+
+Use `checkPermission()` when you only need to read permission status. Use
+`requestPermission()` only when the app is ready to show the native permission
+prompt.
+
+For Android flows that require precise location, consider
+`getLocationAvailability()` or `requestLocationSettings()` before requesting a
+fresh position. Avoid interrupting approximate, passive, or low-power flows
+with settings prompts unless the feature requires it.
+
+## Agent-Readable Docs
+
+The public docs are also available in agent-readable form:
+
+```bash
+curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms.txt
+curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms-full.txt
+```
+
+Use `llms.txt` as the docs index. Use `llms-full.txt` when an agent needs exact
+API names, option semantics, or examples. If the target app pins an older
+`react-native-nitro-geolocation` version, confirm API availability in the
+installed package types before using docs-only APIs.

--- a/docs/docs/v1/guide/modern-api.md
+++ b/docs/docs/v1/guide/modern-api.md
@@ -1,0 +1,922 @@
+---
+title: Modern API (Recommended)
+---
+
+> Simple functional API with direct calls and minimal abstractions
+
+The Modern API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
+
+## Design Philosophy
+
+**Simple and Direct**:
+
+- **Direct function calls**: No complex abstractions or classes
+- **Single hook**: Only `useWatchPosition` for continuous tracking
+- **No Provider required**: Just call functions directly
+- **Automatic cleanup**: Hook handles subscription lifecycle
+
+**Core Principles**:
+
+- **Simple configuration**: Call `setConfiguration()` once at app startup
+- **Direct function calls**: Use `getCurrentPosition()`, `requestPermission()` etc.
+- **One hook for tracking**: `useWatchPosition` for continuous updates
+- **Type-safe**: Full TypeScript support
+- **Battery efficient**: Native subscriptions stop immediately when disabled
+
+## Configuration
+
+Set global configuration once at app startup.
+
+### setConfiguration()
+
+```tsx
+import { setConfiguration } from 'react-native-nitro-geolocation';
+
+// In App.tsx or index.js
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  enableBackgroundLocationUpdates: false,
+  locationProvider: 'auto'
+});
+```
+
+**Options**:
+
+- `autoRequestPermission?: boolean` - Deprecated compatibility option. `setConfiguration()` does not request permission; call `requestPermission()` explicitly when the app is ready to show the native prompt.
+- `authorizationLevel?: 'whenInUse' | 'always' | 'auto'` - iOS: Authorization level
+- `enableBackgroundLocationUpdates?: boolean` - iOS: Enable background location
+- `locationProvider?: 'playServices' | 'android' | 'auto'` - Android: `auto` and `playServices` prefer Google Play Services fused location when available and fall back to Android's platform provider. `android` forces the platform `LocationManager` path.
+
+**Type**:
+
+```typescript
+export type GeolocationConfiguration = {
+  /** @deprecated Call `requestPermission()` explicitly. */
+  autoRequestPermission?: boolean;
+  authorizationLevel?: 'always' | 'whenInUse' | 'auto';
+  enableBackgroundLocationUpdates?: boolean;
+  /** `auto` and `playServices` prefer fused, then platform fallback. */
+  locationProvider?: 'playServices' | 'android' | 'auto';
+};
+
+/**
+ * @deprecated Use `GeolocationConfiguration` instead.
+ * This alias is kept only for backward compatibility.
+ */
+export type ModernGeolocationConfiguration = GeolocationConfiguration;
+```
+
+**When to call**:
+
+- Once at app startup (e.g., in `App.tsx` or `index.js`)
+- Before making any location requests
+
+**Web behavior**:
+
+- Browser builds resolve the root import to a web entry that uses
+  `navigator.geolocation`.
+- `setConfiguration()` is a no-op on web. Browser permission prompts are driven
+  by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
+  request API.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, and
+  `locationProvider` are ignored on web.
+
+## Permission Functions
+
+### checkPermission()
+
+Check current location permission status without requesting it.
+
+```tsx
+import { checkPermission } from 'react-native-nitro-geolocation';
+
+async function checkLocationPermission() {
+  const status = await checkPermission();
+  console.log('Permission status:', status);
+  // status: 'granted' | 'denied' | 'restricted' | 'undetermined'
+}
+```
+
+**Returns**: `Promise<PermissionStatus>`
+
+**Permission Status**:
+
+- `'granted'` - User granted location permission
+- `'denied'` - User denied permission
+- `'restricted'` - Permission restricted (iOS parental controls)
+- `'undetermined'` - Permission not yet requested
+
+
+### requestPermission()
+
+Request location permission from the user.
+
+```tsx
+import { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { requestPermission } from 'react-native-nitro-geolocation';
+
+function PermissionButton() {
+  const [status, setStatus] = useState<string>('unknown');
+  const [loading, setLoading] = useState(false);
+
+  const handlePress = async () => {
+    setLoading(true);
+    try {
+      const result = await requestPermission();
+      setStatus(result);
+      if (result === 'granted') {
+        console.log('Permission granted!');
+      }
+    } catch (err) {
+      console.error('Permission error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View>
+      <Button
+        onPress={handlePress}
+        disabled={loading}
+        title={loading ? 'Requesting...' : 'Enable Location'}
+      />
+      <Text>Status: {status}</Text>
+    </View>
+  );
+}
+```
+
+**Returns**: `Promise<PermissionStatus>`
+
+**Behavior**:
+
+- Shows system permission dialog if `undetermined`
+- Returns immediately if already `granted` or `denied`
+- On iOS, uses `authorizationLevel` from configuration
+- On web, triggers the browser prompt by making a one-shot
+  `navigator.geolocation.getCurrentPosition()` call, then returns the mapped
+  browser permission state.
+
+
+## Location Functions
+
+### Android Provider and Settings
+
+Available since `v1.2`.
+
+Use these helpers before user-facing precise-location flows where the app needs
+to know whether Android device settings can satisfy the request.
+
+```tsx
+import {
+  getCurrentPosition,
+  getLocationAvailability,
+  getProviderStatus,
+  hasServicesEnabled,
+  requestLocationSettings
+} from 'react-native-nitro-geolocation';
+
+async function prepareAccurateLocation() {
+  const availability = await getLocationAvailability();
+  const servicesEnabled = await hasServicesEnabled();
+  const providerStatus = await getProviderStatus();
+
+  if (!availability.available || !servicesEnabled || providerStatus.googleLocationAccuracyEnabled === false) {
+    await requestLocationSettings({
+      accuracy: { android: 'high' },
+      interval: 5000,
+      fastestInterval: 1000
+    });
+  }
+
+  return getCurrentPosition({
+    accuracy: { android: 'high', ios: 'best' },
+    timeout: 15000
+  });
+}
+```
+
+**Functions**:
+
+- `hasServicesEnabled(): Promise<boolean>` - Checks whether device-level
+  location services are enabled.
+- `getProviderStatus(): Promise<LocationProviderStatus>` - Returns provider
+  state such as `locationServicesEnabled`, `gpsAvailable`,
+  `networkAvailable`, `passiveAvailable`, Android Google Play Services
+  availability, and Google Location Accuracy when Google Play Services exposes
+  it.
+- `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
+  Available since `v1.2`. Android reads Fused Location availability when
+  `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
+  configured, then falls back to platform provider/service checks. iOS maps Core
+  Location service and authorization state.
+- `requestLocationSettings(options?): Promise<LocationProviderStatus>` -
+  Checks the requested Android location settings and shows Android's native
+  resolution dialog when available. It resolves with the updated provider
+  status after the settings satisfy the request.
+
+`requestLocationSettings()` is Android-focused. On iOS it resolves with the
+current Core Location service status and does not show a settings dialog.
+
+### Android Reliability Notes
+
+- `locationProvider: 'auto'` and `locationProvider: 'playServices'` prefer
+  Google Play Services fused location when available and fall back to Android's
+  platform provider.
+- `locationProvider: 'android'` forces Android's platform `LocationManager`
+  path.
+- Approximate/coarse location flows are supported through permissions and
+  Android `granularity`.
+- Use `getLastKnownPosition()` when you want an explicit cached read without
+  starting a fresh native request.
+- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
+  `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
+
+### Web Notes
+
+Modern API web support uses the browser standard `navigator.geolocation` API.
+It requires a secure context (`https://`, `localhost`, or another browser-trusted
+origin). Unsupported browsers or unavailable providers reject location requests
+with `POSITION_UNAVAILABLE`.
+
+Supported on web:
+
+- `checkPermission()` maps `navigator.permissions.query({ name:
+  'geolocation' })` to `granted`, `denied`, or `undetermined` when the
+  Permissions API is available.
+- `requestPermission()` performs a one-shot browser geolocation request because
+  browsers do not expose a standalone geolocation permission request API.
+- `getCurrentPosition()` wraps `navigator.geolocation.getCurrentPosition()`.
+- `watchPosition()` wraps `navigator.geolocation.watchPosition()` and returns a
+  string token.
+- `unwatch()` and `stopObserving()` clear browser watch IDs.
+
+Web option behavior:
+
+- `enableHighAccuracy`, `timeout`, and `maximumAge` are forwarded to the
+  browser.
+- `distanceFilter` is applied in JavaScript for watch updates after the first
+  emitted position.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`,
+  `interval`, `fastestInterval`, `useSignificantChanges`, Android granularity
+  options, and iOS tuning options are ignored because browsers do not provide
+  matching controls.
+- Geocoding, heading, Android settings, and temporary full-accuracy APIs are
+  native-focused. On web, provider/status helpers return browser availability
+  where possible; unsupported sensor/geocoder calls reject with
+  `POSITION_UNAVAILABLE`.
+
+### getCurrentPosition()
+
+Get current location (one-time request).
+
+```tsx
+import { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import {
+  getCurrentPosition,
+  type GeolocationResponse
+} from 'react-native-nitro-geolocation';
+
+function LocationButton() {
+  const [position, setPosition] = useState<GeolocationResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePress = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const pos = await getCurrentPosition({
+        accuracy: { android: 'high', ios: 'best' },
+        timeout: 15000
+      });
+      setPosition(pos);
+    } catch (err: any) {
+      setError(err?.message || 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View>
+      <Button
+        onPress={handlePress}
+        disabled={loading}
+        title={loading ? 'Loading...' : 'Get Location'}
+      />
+      {error && <Text style={{ color: 'red' }}>Error: {error}</Text>}
+      {position && (
+        <View>
+          <Text>Lat: {position.coords.latitude}</Text>
+          <Text>Lng: {position.coords.longitude}</Text>
+          <Text>Accuracy: {position.coords.accuracy}m</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+```
+
+**Parameters**: `options?: LocationRequestOptions`
+
+**Options**:
+
+- `timeout?: number` - Request timeout in ms (default: 600000 / 10 min)
+- `maximumAge?: number` - Max age of cached location in ms (default: 0)
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
+- `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
+- `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
+- `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
+- `maxUpdateDelay?: number` - Android-only maximum batching delay in ms, available since `v1.2`.
+- `maxUpdates?: number` - Android-only maximum watch updates before native cleanup, available since `v1.2`.
+- `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`.
+- `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`.
+- `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`. This only has a visible effect when the app has background location capability and permission.
+
+Use `accuracy` when you need explicit platform-native behavior:
+
+```tsx
+await getCurrentPosition({
+  accuracy: {
+    android: 'high',
+    ios: 'bestForNavigation'
+  },
+  granularity: 'permission',
+  waitForAccurateLocation: true,
+  timeout: 15000
+});
+```
+
+Android maps the presets to native accuracy/priority intent. With `auto` or
+`playServices`, requests prefer Google Play Services fused location and use the
+matching fused priority before platform fallback. With `android`, requests stay
+on `LocationManager`: `high` prefers GPS with a network fallback, `balanced`
+uses the network provider, `low` uses network/passive providers, and `passive`
+only listens through the passive provider. iOS maps the presets to Core
+Location `desiredAccuracy` constants.
+
+iOS tuning options are applied to both one-time requests and watches through
+the shared Core Location manager configuration:
+
+```tsx
+await getCurrentPosition({
+  accuracy: { ios: 'kilometer' },
+  activityType: 'fitness',
+  pausesLocationUpdatesAutomatically: false,
+  showsBackgroundLocationIndicator: false,
+  timeout: 15000
+});
+```
+
+Use `showsBackgroundLocationIndicator` only after configuring background
+location in the app target, including the `location` background mode and the
+required Info.plist location usage descriptions.
+
+**Returns**: `Promise<GeolocationResponse>`
+
+**Response**:
+
+```typescript
+export type LocationProviderUsed =
+  | 'fused'
+  | 'gps'
+  | 'network'
+  | 'passive'
+  | 'unknown';
+
+interface GeolocationResponse {
+  coords: {
+    latitude: number;
+    longitude: number;
+    altitude: number | null;
+    accuracy: number;
+    altitudeAccuracy: number | null;
+    heading: number | null;
+    speed: number | null;
+  };
+  timestamp: number;
+  mocked?: boolean;
+  provider?: LocationProviderUsed;
+}
+```
+
+`mocked` and `provider` are optional metadata fields added to the Modern API response in v1.2. The `/compat` API keeps the `@react-native-community/geolocation` response shape and does not include these fields.
+
+**Error Handling**:
+
+```tsx
+import {
+  LocationErrorCode,
+  watchPosition,
+  unwatch,
+} from 'react-native-nitro-geolocation';
+
+const token = watchPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    if (error.code === LocationErrorCode.SETTINGS_NOT_SATISFIED) {
+      // Device/provider settings do not satisfy the request.
+    }
+    // error.message: Human-readable error
+  }
+);
+
+unwatch(token);
+```
+
+Modern API errors use the following codes. The expanded modern-only native
+setup/provider codes (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
+`SETTINGS_NOT_SATISFIED`) were added in v1.2; codes 1-3 remain aligned with the
+legacy browser-style contract.
+
+The code is committed by the native layer before a `LocationError` is sent to
+JS. Both `watchPosition` error callbacks and public Promise rejections from
+`getCurrentPosition`/`requestPermission` receive the same `{ code, message }`
+shape; JS only relays that object and does not parse or reclassify native
+messages.
+
+| Code | Name                         | Meaning                                      |
+| ---- | ---------------------------- | -------------------------------------------- |
+| -1   | `INTERNAL_ERROR`             | Unexpected module/native failure             |
+| 1    | `PERMISSION_DENIED`          | Location permission was denied               |
+| 2    | `POSITION_UNAVAILABLE`       | A position fix is unavailable                |
+| 3    | `TIMEOUT`                    | The request timed out                        |
+| 4    | `PLAY_SERVICE_NOT_AVAILABLE` | Android Google Play Services is unavailable  |
+| 5    | `SETTINGS_NOT_SATISFIED`     | Device/provider settings do not satisfy the request |
+
+The `/compat` API keeps the legacy browser-style error contract with only `PERMISSION_DENIED`, `POSITION_UNAVAILABLE`, and `TIMEOUT`.
+
+### getLastKnownPosition()
+
+Available since `v1.2`.
+
+Read the best cached native location explicitly without starting a fresh
+location request. This is useful for fast app startup, stale-while-refresh UI,
+and cache-only flows where a fresh GPS/network request would be too expensive.
+
+```tsx
+import { getLastKnownPosition } from 'react-native-nitro-geolocation';
+
+const cached = await getLastKnownPosition({
+  maximumAge: 60_000,
+  accuracy: { android: 'balanced', ios: 'hundredMeters' }
+});
+```
+
+`getLastKnownPosition(options?)` uses the same provider and cache-filtering
+options as `getCurrentPosition()`, but it never falls through to a fresh native
+request. If no cached location satisfies `maximumAge` or permission is denied,
+it rejects with the native `LocationError` contract, usually
+`POSITION_UNAVAILABLE` or `PERMISSION_DENIED`.
+
+### Geocoding APIs
+
+Available since `v1.2`.
+
+Use `geocode()` to convert a human-readable address into candidate coordinates,
+and `reverseGeocode()` to convert coordinates into candidate address fields.
+Both APIs use the platform geocoder, so result quality, language, network
+behavior, and availability can differ between Android `Geocoder` and iOS
+`CLGeocoder`.
+
+```tsx
+import {
+  geocode,
+  reverseGeocode
+} from 'react-native-nitro-geolocation';
+
+const locations = await geocode('City Hall, Seoul, South Korea');
+// locations: Array<{ latitude: number; longitude: number; accuracy?: number }>
+
+const addresses = await reverseGeocode({
+  latitude: 37.5665,
+  longitude: 126.978
+});
+// addresses: Array<{
+//   country?: string;
+//   region?: string;
+//   city?: string;
+//   district?: string;
+//   street?: string;
+//   postalCode?: string;
+//   formattedAddress?: string;
+// }>
+```
+
+`geocode(address)` rejects with `INTERNAL_ERROR` when `address` is blank.
+`reverseGeocode(coords)` rejects with `INTERNAL_ERROR` when latitude or
+longitude is non-finite or outside the valid coordinate range. Platform
+geocoder service failures reject with the same `{ code, message }`
+`LocationError` shape as the rest of the Modern API.
+
+### Heading APIs
+
+Available since `v1.2`.
+
+Use `getHeading()` for a single compass heading and `watchHeading()` for
+continuous heading updates. Stop heading watches with the same `unwatch(token)`
+API used by `watchPosition()`.
+
+```tsx
+import { getHeading, watchHeading, unwatch } from 'react-native-nitro-geolocation';
+
+const heading = await getHeading();
+
+const token = watchHeading(
+  (nextHeading) => {
+    console.log(nextHeading.magneticHeading);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  { headingFilter: 5 }
+);
+
+unwatch(token);
+```
+
+```typescript
+type Heading = {
+  magneticHeading: number;
+  trueHeading?: number;
+  accuracy?: number;
+  timestamp: number;
+};
+```
+
+Heading APIs require location permission and reject with the same
+`LocationError` contract when permission is denied or heading sensors are not
+available.
+
+### iOS Accuracy Authorization
+
+Available since `v1.2`.
+
+Use `getAccuracyAuthorization()` to read whether iOS currently grants full or
+reduced location accuracy. Android maps fine permission to `full`, coarse-only
+permission to `reduced`, and no location permission to `unknown`.
+
+```tsx
+import {
+  getAccuracyAuthorization,
+  requestTemporaryFullAccuracy
+} from 'react-native-nitro-geolocation';
+
+const authorization = await getAccuracyAuthorization();
+
+if (authorization === 'reduced') {
+  await requestTemporaryFullAccuracy('TurnByTurnNavigation');
+}
+```
+
+For iOS, `requestTemporaryFullAccuracy(purposeKey)` calls Core Location's
+temporary full accuracy API. The `purposeKey` must exist in
+`NSLocationTemporaryUsageDescriptionDictionary` in Info.plist, for example:
+
+```xml
+<key>NSLocationTemporaryUsageDescriptionDictionary</key>
+<dict>
+  <key>TurnByTurnNavigation</key>
+  <string>Precise location improves turn-by-turn navigation.</string>
+</dict>
+```
+
+Passing an empty `purposeKey` rejects with `INTERNAL_ERROR`. Android does not
+show a temporary accuracy prompt and resolves with the current mapped accuracy
+authorization.
+
+
+## React Hook
+
+### useWatchPosition()
+
+Watch for continuous location updates with automatic lifecycle management.
+
+```tsx
+import { useState } from 'react';
+import { Switch, Text, View } from 'react-native';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LiveTracker() {
+  const [enabled, setEnabled] = useState(false);
+
+  const { position, error, isWatching } = useWatchPosition({
+    enabled,
+    accuracy: { android: 'high', ios: 'best' },
+    distanceFilter: 10, // Update every 10 meters
+    interval: 5000, // Update every 5 seconds (Android)
+  });
+
+  return (
+    <View>
+      <Switch
+        value={enabled}
+        onValueChange={setEnabled}
+        label="Track location"
+      />
+
+      <Text>Status: {isWatching ? 'Watching 🟢' : 'Stopped 🔴'}</Text>
+
+      {error && (
+        <Text style={{ color: 'red' }}>Error: {error.message}</Text>
+      )}
+
+      {position && (
+        <View>
+          <Text>Lat: {position.coords.latitude}</Text>
+          <Text>Lng: {position.coords.longitude}</Text>
+          <Text>Accuracy: {position.coords.accuracy}m</Text>
+          {position.coords.speed !== null && (
+            <Text>Speed: {position.coords.speed}m/s</Text>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+```
+
+**Options**:
+
+- `enabled?: boolean` - Start/stop watching (default: `false`)
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`.
+- `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
+- `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
+- `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
+- `maxUpdateDelay?: number` - Android-only batching delay, available since `v1.2`
+- `maxUpdates?: number` - Android-only watch update limit, available since `v1.2`
+- `distanceFilter?: number` - Minimum distance change in meters
+- `interval?: number` - Update interval in ms (Android)
+- `fastestInterval?: number` - Fastest interval in ms (Android)
+- `timeout?: number` - Request timeout
+- `maximumAge?: number` - Max cached location age
+- `useSignificantChanges?: boolean` - Use significant changes mode (iOS)
+- `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`
+- `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`
+- `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`
+
+**Returns**:
+
+- `position: GeolocationResponse | null` - Latest position (null if no update yet)
+- `error: LocationError | null` - Error details if location watching failed
+- `isWatching: boolean` - Whether currently watching
+
+**Key Features**:
+
+- ✅ **Auto cleanup**: Unsubscribes when component unmounts or `enabled` becomes `false`
+- ✅ **Declarative**: Toggle with `enabled` prop
+- ✅ **No watch ID management**: Handled internally
+- ✅ **Battery efficient**: Native subscription stops immediately when disabled
+- ✅ **Reactive**: Changes to options restart the watch
+
+**Common Patterns**:
+
+1.  **Toggle tracking**:
+    ```tsx
+    const [tracking, setTracking] = useState(false);
+    const { position } = useWatchPosition({ enabled: tracking });
+    ```
+2.  **Conditional tracking** (track only when screen is focused):
+    ```tsx
+    const isFocused = useIsFocused(); // React Navigation
+    const { position } = useWatchPosition({ enabled: isFocused });
+    ```
+3.  **Track only when permission granted**:
+    ```tsx
+    const [hasPermission, setHasPermission] = useState(false);
+    const { position, error } = useWatchPosition({
+      enabled: hasPermission,
+      accuracy: { android: 'high', ios: 'best' },
+    });
+    ```
+
+
+## Low-level Functions (Advanced)
+
+For non-React code or advanced use cases, you can use the low-level watch API.
+
+### watchPosition()
+
+```tsx
+import { watchPosition, unwatch } from 'react-native-nitro-geolocation';
+
+const token = watchPosition(
+  (position) => {
+    console.log('Position updated:', position.coords);
+  },
+  (error) => {
+    console.error('Location error:', error.message);
+  },
+  {
+    accuracy: { android: 'high', ios: 'best' },
+    distanceFilter: 10
+  }
+);
+
+// Later: cleanup
+unwatch(token);
+```
+
+**Parameters**:
+- `onUpdate: (position: GeolocationResponse) => void` - Success callback
+- `onError?: (error: LocationError) => void` - Error callback
+- `options?: LocationRequestOptions` - Location options
+
+**Returns**: `string` - Subscription token
+
+### unwatch()
+
+Stop a specific watch subscription.
+
+```tsx
+import { unwatch } from 'react-native-nitro-geolocation';
+
+unwatch(token);
+```
+
+### stopObserving()
+
+Stop ALL watch subscriptions immediately.
+
+```tsx
+import { stopObserving } from 'react-native-nitro-geolocation';
+
+// Emergency cleanup - stops all location tracking
+stopObserving();
+```
+
+
+## Advanced Patterns
+
+### Permission Check Before Location Request
+
+```tsx
+import {
+  checkPermission,
+  requestPermission,
+  getCurrentPosition
+} from 'react-native-nitro-geolocation';
+
+async function getLocationWithPermission() {
+  // Check permission first
+  let status = await checkPermission();
+
+  // Request if needed
+  if (status !== 'granted') {
+    status = await requestPermission();
+  }
+
+  // Get location if granted
+  if (status === 'granted') {
+    const position = await getCurrentPosition({
+      accuracy: { android: 'high', ios: 'best' }
+    });
+    return position;
+  } else {
+    throw new Error('Permission denied');
+  }
+}
+```
+
+### Conditional Tracking Based on App State
+
+```tsx
+import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function BackgroundTracker() {
+  const [isActive, setIsActive] = useState(AppState.currentState === 'active');
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      setIsActive(state === 'active');
+    });
+    return () => subscription.remove();
+  }, []);
+
+  const { position, error } = useWatchPosition({
+    enabled: isActive,
+    distanceFilter: 50,
+  });
+
+  return (
+    <>
+      {error && <ErrorBanner message={error.message} />}
+      <Map position={position?.coords} />
+    </>
+  );
+}
+```
+
+
+## TypeScript Support
+
+All Modern API exports are fully typed:
+
+```typescript
+import type {
+  PermissionStatus,
+  LocationRequestOptions,
+  LocationErrorCode,
+  LocationError,
+  GeolocationResponse,
+  GeolocationCoordinates,
+  LocationProviderUsed,
+  GeolocationConfiguration
+} from 'react-native-nitro-geolocation';
+```
+
+`ModernGeolocationConfiguration` is still exported as a deprecated compatibility alias.
+
+### Type Inference
+
+Functions and hooks provide full type inference:
+
+```tsx
+const { position } = useWatchPosition({ enabled: true });
+// position: GeolocationResponse | null (inferred)
+
+const pos = await getCurrentPosition();
+// pos: GeolocationResponse (inferred)
+
+const status = await requestPermission();
+// status: PermissionStatus (inferred)
+```
+
+
+## Comparison with Compat API
+
+| Feature          | Modern API                               | Compat API                               |
+| ---------------- | ---------------------------------------- | ---------------------------------------- |
+| **Import**       | `react-native-nitro-geolocation`         | `react-native-nitro-geolocation/compat`  |
+| **Pattern**      | Functions + Hook                         | Callbacks                                |
+| **Configuration**| `setConfiguration()`                     | `setRNConfiguration()`                   |
+| **Permission**   | `requestPermission()`                    | `requestAuthorization()`                 |
+| **Get Location** | `getCurrentPosition()` (Promise)         | `getCurrentPosition()` (callbacks)       |
+| **Watch**        | `useWatchPosition({ enabled })`          | `watchPosition()` / `clearWatch()`       |
+| **Cleanup**      | Automatic (hook)                         | Manual (`clearWatch`)                    |
+| **Watch ID**     | Hidden (internal)                        | User-managed                             |
+| **TypeScript**   | Full inference                           | Basic types                              |
+| **React Friendly** | ✅ Yes                                  | ⚠️ Requires useEffect boilerplate       |
+
+
+## Migration from Compat
+
+**Before (Compat API)**:
+
+```tsx
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+function LocationTracker() {
+  const [position, setPosition] = useState(null);
+  const watchIdRef = useRef(null);
+
+  useEffect(() => {
+    watchIdRef.current = Geolocation.watchPosition(
+      (pos) => setPosition(pos),
+      (err) => console.error(err),
+      { enableHighAccuracy: true }
+    );
+
+    return () => {
+      if (watchIdRef.current !== null) {
+        Geolocation.clearWatch(watchIdRef.current);
+      }
+    };
+  }, []);
+
+  return <Map position={position} />;
+}
+```
+
+**After (Modern API)**:
+
+```tsx
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LocationTracker() {
+  const { position } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'high', ios: 'best' },
+  });
+
+  return <Map position={position} />;
+}
+```
+
+**Benefits**:
+
+- 70% less code
+- No watch ID management
+- Automatic cleanup
+- Declarative enable/disable
+- Better TypeScript support

--- a/docs/docs/v1/guide/quick-start.md
+++ b/docs/docs/v1/guide/quick-start.md
@@ -1,0 +1,138 @@
+# Quick Start
+
+This guide walks you through installing and setting up **React Native Nitro Geolocation** in your React Native project.
+
+## 1. Installation
+
+Before installing the module, make sure your app uses React Native 0.75+ with
+the New Architecture and Nitro Modules enabled.
+
+```bash
+# Install Nitro core and Geolocation module
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+
+# or using npm
+npm install react-native-nitro-modules react-native-nitro-geolocation
+```
+
+After installation, rebuild your native app to ensure the new module is linked.
+
+```bash
+cd ios && pod install
+```
+
+Released npm builds try to use the matching GitHub Release prebuilts first:
+Android downloads the release AAR and reuses its native `.so` files, while iOS
+downloads the release XCFramework. If the prebuilt asset is unavailable, the
+native source build is used automatically. Android prebuilts are used only when
+the app's React Native and Nitro Modules major/minor versions match the release
+asset build. To force source builds, set:
+
+```bash
+NITRO_GEOLOCATION_USE_PREBUILT=0
+```
+
+This package requires native Nitro bindings. Expo Go is not supported. For Expo
+apps, use prebuild, a development build, or another custom native build flow;
+see the [Expo development build guide](/guide/expo-development-build).
+
+
+## 2. iOS Setup
+
+### Permissions
+
+Add the following keys to your **Info.plist**:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>This app requires access to your location while it's in use.</string>
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>This app requires access to your location at all times.</string>
+```
+
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
+
+## 3. Android Setup
+
+Add the following permissions to your **android/app/src/main/AndroidManifest.xml**:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+Optional (for background access):
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
+
+## 4. Get Your First Location
+
+Configure once at app startup. Ask for permission from a user action, then read
+one position.
+
+```tsx
+import {
+  getCurrentPosition,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'auto'
+});
+
+async function handleUseMyLocation() {
+  const status = await requestPermission();
+
+  if (status === 'granted') {
+    const position = await getCurrentPosition({
+      accuracy: { android: 'high', ios: 'best' },
+      timeout: 15000
+    });
+  }
+}
+```
+
+## 5. Android Accuracy Helpers (Optional)
+
+If Android needs a settings prompt or an explicit cached read, configure the
+provider in your startup `setConfiguration()` call and add the settings helpers
+from the [Modern API reference](/guide/modern-api).
+
+```tsx
+import {
+  getLastKnownPosition,
+  requestLocationSettings
+} from 'react-native-nitro-geolocation';
+
+await requestLocationSettings({
+  accuracy: { android: 'high' }
+});
+
+const cached = await getLastKnownPosition({
+  maximumAge: 60_000,
+  accuracy: { android: 'balanced', ios: 'hundredMeters' }
+});
+```
+
+
+## Next Steps
+
+- [Modern API Reference](/guide/modern-api) — Complete documentation
+- [Compat API Reference](/guide/compat-api) — Compatibility methods
+- [Background Location](/background/overview) — Native background tracking, geofencing, and storage recovery
+- [Migration Guides](/guide/migration-assistance) — Move from community/service geolocation packages
+- [Expo Development Builds](/guide/expo-development-build) — Use the package in Expo custom native builds
+- [DevTools Plugin Guide](/guide/devtools) — Mock locations in development
+- [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
+- [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/v1/guide/react-native-directory.md
+++ b/docs/docs/v1/guide/react-native-directory.md
@@ -1,0 +1,45 @@
+---
+title: React Native Directory
+---
+
+# React Native Directory Submission
+
+Use this checklist before submitting `react-native-nitro-geolocation` to React
+Native Directory.
+
+## Support Matrix
+
+| Capability | Status |
+| --- | --- |
+| iOS | Supported |
+| Android | Supported |
+| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
+| New Architecture | Required target; implemented through Nitro Modules |
+| Expo Go | Not supported |
+| Expo development builds | Supported with native setup |
+| Full background tracking/geofencing | Supported through `react-native-nitro-geolocation/background` |
+
+## Directory Positioning
+
+Recommended short description:
+
+```txt
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
+```
+
+Recommended caveat:
+
+```txt
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
+```
+
+## Pre-Submission Checklist
+
+- README explains when to use the package and when not to use it.
+- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
+- npm package has discoverability keywords.
+- Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
+- Docs include Expo development build guidance.
+- Docs include community and service migration paths.
+- Benchmark docs clearly state cached-read and JS-native latency scope.
+- Roadmap issue tracks compatibility matrix, extra benchmarks, and real migration examples.

--- a/docs/docs/v1/guide/service-migration.md
+++ b/docs/docs/v1/guide/service-migration.md
@@ -1,0 +1,207 @@
+---
+title: Service Migration
+---
+
+# Service Migration
+
+Apps that use `react-native-geolocation-service` should migrate directly to the
+Modern API:
+
+```ts
+import {
+  getCurrentPosition,
+  getLastKnownPosition,
+  hasServicesEnabled,
+  LocationErrorCode,
+  requestPermission,
+  requestLocationSettings,
+  setConfiguration,
+  stopObserving,
+  unwatch,
+  watchPosition
+} from 'react-native-nitro-geolocation';
+```
+
+Do not migrate through `react-native-nitro-geolocation/compat`. The service
+package exposes Android fused-provider and settings-dialog behavior that maps
+more closely to Nitro Geolocation's Modern Android provider/settings API.
+
+## Agent Skill
+
+This repository ships an Agent Skills-compatible migration playbook for this
+path:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
+```
+
+The skill source is
+[`skills/service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
+
+The bundled helper script can inventory and safely transform the first pass:
+
+```bash
+node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inventory-only
+node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
+```
+
+If the app startup file is obvious, the script can also add the Modern startup
+configuration:
+
+```bash
+node <skill-dir>/scripts/migrate-geolocation-service.mjs \
+  --root <app-root> \
+  --startup-file <app-root>/src/App.tsx
+```
+
+## Startup Configuration
+
+Configure Nitro Geolocation once near app startup.
+
+Normal `react-native-geolocation-service` migrations should explicitly use
+Google Play Services fused location on Android:
+
+```ts
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  enableBackgroundLocationUpdates: false,
+  locationProvider: 'playServices'
+});
+```
+
+Use `locationProvider: 'android'` only when the legacy app intentionally used
+`forceLocationManager: true` or the product requires Android `LocationManager`.
+
+## API Mapping
+
+| `react-native-geolocation-service` | Nitro Modern API |
+| --- | --- |
+| `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` |
+| `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` |
+| `Geolocation.clearWatch(id)` | `unwatch(token)` |
+| `Geolocation.stopObserving()` | `stopObserving()` |
+| `requestAuthorization('whenInUse' \| 'always')` | `setConfiguration({ authorizationLevel })` plus `requestPermission()` |
+| `accuracy: { android, ios }` | `accuracy: { android, ios }` |
+| `enableHighAccuracy: true` | `accuracy: { android: 'high', ios: 'best' }` |
+| `showLocationDialog: true` | `requestLocationSettings()` before the request |
+| `forceLocationManager: true` | `setConfiguration({ locationProvider: 'android' })` |
+| default fused provider intent | `setConfiguration({ locationProvider: 'playServices' })` |
+| `position.mocked` | `GeolocationResponse.mocked` |
+| `position.provider` | `GeolocationResponse.provider` |
+| error code `-1`, `1`, `2`, `3`, `4`, `5` | `LocationErrorCode` |
+
+`forceRequestLocation` has no direct Modern option. Preserve that fallback
+behavior manually only after reviewing the intended UX.
+
+## One-Shot Location
+
+Prefer a Promise chain for mechanical migrations so the containing function does
+not need to become `async` immediately.
+
+```diff
+- import Geolocation from 'react-native-geolocation-service';
++ import {
++   getCurrentPosition,
++   requestLocationSettings
++ } from 'react-native-nitro-geolocation';
+
+  export function loadLocation(onSuccess, onError) {
+-   Geolocation.getCurrentPosition(onSuccess, onError, {
+-     enableHighAccuracy: true,
+-     timeout: 15000,
+-     maximumAge: 10000,
+-     showLocationDialog: true
+-   });
++   requestLocationSettings({
++     accuracy: { android: 'high', ios: 'best' }
++   })
++     .then(() =>
++       getCurrentPosition({
++         accuracy: { android: 'high', ios: 'best' },
++         timeout: 15000,
++         maximumAge: 10000
++       })
++     )
++     .then(onSuccess)
++     .catch(onError);
+  }
+```
+
+Do not add `requestLocationSettings()` when the legacy call explicitly used
+`showLocationDialog: false`.
+
+When `showLocationDialog` was omitted, review the flow manually. The service
+package default was `true`; Nitro Modern API requires an explicit settings flow.
+
+## Watches
+
+Use the low-level Modern watch API as the first safe target:
+
+```diff
+- const watchId = Geolocation.watchPosition(onPosition, onError, {
+-   enableHighAccuracy: true,
+-   distanceFilter: 10,
+-   interval: 5000,
+-   fastestInterval: 2000
+- });
++ const watchToken = watchPosition(onPosition, onError, {
++   accuracy: { android: 'high', ios: 'best' },
++   distanceFilter: 10,
++   interval: 5000,
++   fastestInterval: 2000
++ });
+
+- Geolocation.clearWatch(watchId);
++ unwatch(watchToken);
+```
+
+Upgrade to `useWatchPosition()` only when the watch is owned by a React function
+component or custom hook and the existing callbacks do not contain
+ordering-sensitive side effects such as analytics, navigation, mutation, or
+debouncing.
+
+## Permission Differences
+
+Legacy `requestAuthorization()` can return `disabled`. Modern
+`requestPermission()` returns permission status only:
+
+```ts
+const status = await requestPermission();
+```
+
+If the old code handled `disabled`, check device-level service state separately:
+
+```ts
+const servicesEnabled = await hasServicesEnabled();
+
+if (!servicesEnabled) {
+  showLocationServicesDisabledMessage();
+  return;
+}
+
+const status = await requestPermission();
+```
+
+## Default Differences
+
+Review call sites that omit options:
+
+| Option | Service default | Nitro Modern default |
+| --- | --- | --- |
+| `getCurrentPosition.timeout` | `Infinity` | `600000` |
+| `getCurrentPosition.maximumAge` | `Infinity` | `0` |
+| `distanceFilter` | `100` | Review per API flow |
+| `showLocationDialog` | `true` | No implicit dialog; call `requestLocationSettings()` |
+
+For fresh user-facing location, choose explicit options such as:
+
+```ts
+await getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  maximumAge: 0,
+  timeout: 15000
+});
+```
+
+For cached UI, read cached state explicitly with `getLastKnownPosition()` and
+then refresh if the product flow needs it.

--- a/docs/docs/v1/guide/why-nitro-module.md
+++ b/docs/docs/v1/guide/why-nitro-module.md
@@ -1,0 +1,129 @@
+# Why Nitro Module?
+
+The **Nitro Module** system provides the next generation of native modules for React Native.
+Instead of using the bridge-based approach (JSON serialization between JS and native), Nitro Modules communicate directly through **JSI (JavaScript Interface)**.
+
+This enables:
+
+- ⚡ **Direct native calls** — reduced overhead
+- 🧠 **Synchronous APIs** for critical paths
+- 🔧 **Better integration** with the new Fabric renderer
+- 🧩 **Cross-platform consistency** and simpler maintenance
+
+In short, Nitro Geolocation builds on the proven API design of
+`@react-native-community/geolocation` while leveraging the new React Native
+architecture, providing a **forward-compatible foundation** with a
+migration-friendly `/compat` API.
+
+## Architecture Comparison
+
+### Origin: Event-based Architecture (`@react-native-community/geolocation`)
+
+```
+JavaScript Layer
+  ↓ EventEmitter.addListener('geolocationDidChange', callback)
+  ↓ (Callback stored in JS only)
+React Native Bridge (JSON serialization)
+  ↓
+Native Layer (Android/iOS)
+  ↓ LocationListener receives updates
+  ↓ emit('geolocationDidChange', data) → Bridge
+  ↓
+EventEmitter dispatches to all listeners
+  ↓
+User callback executed
+```
+
+**Key characteristics:**
+- Callbacks **not passed** to native — stored in JS EventEmitter
+- Native emits generic events through Bridge
+- Multiple listeners share one event stream
+- Requires JSON serialization on every update
+
+### Modern API: Direct Callback Architecture (`React Native Nitro Geolocation`)
+
+```
+JavaScript Layer
+  ↓ nitroGeolocation.watchPosition(success, error, options)
+  ↓ (Callbacks passed directly to native via JSI)
+JSI Layer (No Bridge!)
+  ↓
+Native Layer (Kotlin/Swift)
+  ↓ LocationListener receives updates
+  ↓ callback.success(position) → JSI direct call
+  ↓
+User callback executed immediately
+```
+
+**Key characteristics:**
+- Callbacks **passed directly** to native as JSI function references
+- Native calls JS functions directly (no Bridge)
+- Each watch has its own callback (no shared event stream)
+- Minimal serialization (C++ structs → JS objects)
+
+## Hook Layer
+
+React Native Nitro Geolocation now provides a React-friendly layer on top of the JSI architecture:
+
+```
+User Code (React Components)
+  ↓ useWatchPosition({ enabled: true })
+  ↓ Declarative, auto-cleanup
+Modern API Layer (direct functions + hooks)
+  ↓ watchPosition(callback)
+JSI Layer (Nitro Modules)
+  ↓ Direct callbacks, no Bridge
+Native Layer (Kotlin/Swift)
+  ↓ CLLocationManager / FusedLocationProvider
+Device GPS/Network
+```
+
+**Benefits of Hook Layer**:
+- **TanStack Query-inspired**: Familiar patterns for React developers
+- **Declarative**: `{ enabled }` prop instead of imperative start/stop
+- **Auto-cleanup**: No manual `clearWatch()` required
+- **Type-safe**: Full TypeScript inference
+- **Best practices**: Encourages proper React patterns
+
+**Architecture Layers**:
+1. **Presentation** (Hooks): `useWatchPosition`
+2. **Modern API** (Functions): `getCurrentPosition`, `watchPosition`, `unwatch`
+3. **JSI Bridge** (Nitro): Direct native communication
+4. **Native** (Platform): iOS/Android location APIs
+
+## How JSI Enables Direct Callbacks
+
+Nitro Modules use **Nitrogen** code generation to create JSI bindings:
+
+1. **TypeScript spec** (`NitroGeolocation.nitro.ts`) defines the interface
+2. **Nitrogen generates C++ code** that bridges Kotlin/Swift ↔ JSI
+3. **HybridObject** in native code implements the spec
+4. **JSI** holds references to JS functions and calls them directly
+
+**Result:** When `watchPosition(callback)` is called, the `callback` function becomes a JSI function reference in native code, callable without the Bridge.
+
+## When to Use Each Approach
+
+### Use Event-based if:
+- Supporting React Native < 0.68
+- Team unfamiliar with JSI/New Architecture
+- Stability over performance
+
+### Use Nitro (Direct Callback) if:
+- Performance-critical (real-time tracking, animations)
+- Using React Native New Architecture
+- Need type safety at compile-time
+- Building for the future
+
+## Summary
+
+`React Native Nitro Geolocation` transforms the geolocation API at multiple levels:
+
+1. **Low-level**: Bridge-based events → JSI direct callbacks (Nitro Modules)
+2. **High-level**: Imperative callbacks → Declarative hooks (Modern API)
+
+This provides:
+- **Performance**: Native-level speed via JSI
+- **Developer Experience**: React-friendly hooks with TanStack Query patterns
+- **Flexibility**: Choose Modern API (hooks) or Compat API (callbacks)
+- **Compatibility**: Drop-in compatible with the core native community API via `/compat`

--- a/docs/docs/v1/index.md
+++ b/docs/docs/v1/index.md
@@ -1,0 +1,47 @@
+---
+pageType: home
+
+hero:
+  name: React Native Nitro Geolocation
+  text: Nitro-powered native geolocation
+  tagline: Replace community geolocation with /compat, then move to a typed Modern API.
+  actions:
+    - theme: brand
+      text: Introduction
+      link: /guide/
+    - theme: alt
+      text: Quick Start
+      link: /guide/quick-start/
+  image:
+    src: /logo.png
+    alt: Nitro Geolocation Logo
+
+features:
+  - title: Simple Functional API
+    details: Direct function calls and a single hook for tracking. No complex abstractions, just simple and effective.
+    icon: 🎯
+  - title: Fully native implementation
+    details: Access device geolocation data through JSI and Nitro Modules for maximum performance.
+    icon: 📡
+  - title: Drop-in replacement (via /compat)
+    details: Compat API is drop-in compatible with the core native @react-native-community/geolocation API for easy migration.
+    icon: 🔁
+  - title: Consistent Android & iOS behavior
+    details: Unified permission handling, background location consistency, and improved accuracy tuning.
+    icon: 📱
+  - title: Direct JSI communication
+    details: Built with Nitro Modules, enabling direct JS-to-native calls without bridge serialization overhead.
+    icon: ⚙️
+  - title: Automatic cleanup
+    details: useWatchPosition automatically manages subscriptions with component lifecycle—no manual cleanup needed.
+    icon: 🧹
+  - title: DevTools Plugin for Rozenite
+    details: Mock locations in development with an interactive map interface, city presets, and keyboard controls.
+    icon: 🛠️
+  - title: TypeScript ready
+    details: Full type definitions for all APIs with complete type inference for functions and hooks.
+    icon: 📘
+  - title: Easy integration
+    details: Works in bare React Native, RN CLI, Expo development builds, and other custom native builds.
+    icon: 🧩
+---

--- a/docs/docs/v2/_nav.json
+++ b/docs/docs/v2/_nav.json
@@ -1,0 +1,12 @@
+[
+  {
+    "text": "Guide",
+    "link": "/guide/",
+    "activeMatch": "/guide/"
+  },
+  {
+    "text": "Background",
+    "link": "/background/overview",
+    "activeMatch": "/background/"
+  }
+]

--- a/docs/docs/v2/background/_meta.json
+++ b/docs/docs/v2/background/_meta.json
@@ -1,0 +1,16 @@
+[
+  "overview",
+  "setup-android",
+  "setup-ios",
+  "permissions",
+  "start-stop",
+  "location-lifecycle",
+  "geofencing",
+  "activity-recognition",
+  "headless-js",
+  "http-sync",
+  "storage",
+  "reliability-contract",
+  "long-run-e2e",
+  "troubleshooting"
+]

--- a/docs/docs/v2/background/activity-recognition.md
+++ b/docs/docs/v2/background/activity-recognition.md
@@ -1,0 +1,36 @@
+# Activity Recognition
+
+```ts
+import {
+  startActivityRecognition,
+  onActivityChange,
+} from 'react-native-nitro-geolocation/background';
+
+await startActivityRecognition({
+  enabled: true,
+  interval: 10_000,
+  stopOnStill: true,
+  minimumConfidence: 70,
+});
+
+const sub = onActivityChange((activity) => {
+  console.log(activity.type, activity.confidence);
+});
+```
+
+Activity events are delivered through the same native event pipeline as location
+and geofence events. Android uses Activity Recognition APIs. iOS uses Core
+Motion when available.
+
+On iOS, starting standalone or activity-aware tracking waits for the Core Motion
+authorization decision. It rejects when activity recognition is unavailable,
+denied, restricted, or still undetermined after the permission timeout; it does
+not report a silently inactive motion provider as running.
+
+On Android 10+, request `android.permission.ACTIVITY_RECOGNITION` at runtime
+before calling `startActivityRecognition()` or using `trackingMode:
+'activityAware'`.
+
+`trackingMode: 'activityAware'` enables activity collection alongside background
+tracking. Apps can use `onActivityChange` events to pause, resume, or tune
+tracking policy for their own product rules.

--- a/docs/docs/v2/background/geofencing.md
+++ b/docs/docs/v2/background/geofencing.md
@@ -1,0 +1,23 @@
+# Geofencing
+
+```ts
+import { addGeofences, onGeofence } from 'react-native-nitro-geolocation/background';
+
+await addGeofences([
+  {
+    identifier: 'office',
+    latitude: 37.5665,
+    longitude: 126.978,
+    radius: 150,
+    notifyOnEntry: true,
+    notifyOnExit: true,
+    metadata: { kind: 'workplace' },
+  },
+]);
+
+const sub = onGeofence((event) => {
+  console.log(event.transition, event.region.identifier);
+});
+```
+
+`notifyOnDwell` is Android-only. iOS region monitoring supports enter and exit.

--- a/docs/docs/v2/background/headless-js.md
+++ b/docs/docs/v2/background/headless-js.md
@@ -1,0 +1,18 @@
+# Android Headless JS
+
+Register task at app root, outside React components:
+
+```ts
+import {
+  registerBackgroundTask,
+  type BackgroundEvent,
+} from 'react-native-nitro-geolocation/background';
+
+registerBackgroundTask(async (event: BackgroundEvent) => {
+  if (event.type === 'location') {
+    console.log('Headless location', event.location);
+  }
+});
+```
+
+Headless JS is Android-only. On iOS, read stored events after app initialization.

--- a/docs/docs/v2/background/http-sync.md
+++ b/docs/docs/v2/background/http-sync.md
@@ -1,0 +1,42 @@
+# Native HTTP Sync
+
+```ts
+await startBackgroundLocation({
+  interval: 10_000,
+  distanceFilter: 25,
+  android: {
+    foregroundService: {
+      notificationTitle: 'Tracking active',
+      notificationText: 'Uploading location updates',
+    },
+  },
+  sync: {
+    url: 'https://api.example.com/locations',
+    method: 'POST',
+    headers: { Authorization: 'Bearer token' },
+    batch: true,
+    batchSize: 50,
+    syncThreshold: 5,
+    retry: true,
+    maxRetries: 5,
+    autoClear: false,
+  },
+});
+```
+
+When `sync` is configured, native code attempts a flush after stored locations
+reach `syncThreshold`, respecting `syncInterval`. Failed flushes can retry up to
+`maxRetries` when `retry` is enabled. Call `syncStoredLocations()` to manually
+flush the native queue. Manual and automatic flushes share one serial native
+queue. Automatic work rechecks the active run, current sync options, threshold,
+batch, and interval when its turn begins, so queued work cannot reuse a stale
+batch or upload the same stored locations alongside a manual flush.
+While an automatic upload is running, further location callbacks coalesce into
+one latest pending check instead of growing an unbounded upload backlog.
+Pending work from an older run cannot replace a newer run's check. After a
+successful upload, native code continues one batch at a time until the unsynced
+count falls below `syncThreshold`; each batch returns to the serial queue first,
+so manual sync and a newer run can take precedence.
+Calling `configureBackgroundLocation()` starts a new sync-config revision. An
+older upload may finish, but its continuation must reapply the replacement
+config's `syncInterval` before starting another batch.

--- a/docs/docs/v2/background/location-lifecycle.md
+++ b/docs/docs/v2/background/location-lifecycle.md
@@ -1,0 +1,72 @@
+# iOS Location Lifecycle
+
+Observe the moments when Core Location pauses or resumes background location
+updates:
+
+```ts
+import {
+  onLocationLifecycleChange,
+  startBackgroundLocation,
+} from 'react-native-nitro-geolocation/background';
+
+const lifecycleSubscription = onLocationLifecycleChange((event) => {
+  if (event.state === 'paused') {
+    console.log('Core Location paused updates', event.timestamp);
+  } else {
+    console.log('Core Location resumed updates', event.timestamp);
+  }
+});
+
+await startBackgroundLocation({
+  trackingMode: 'continuous',
+  persist: true,
+  ios: {
+    activityType: 'fitness',
+    pausesLocationUpdatesAutomatically: true,
+  },
+});
+
+// Later, when the observer is no longer needed:
+lifecycleSubscription.remove();
+```
+
+In 2.x, this convenience listener filters lifecycle events from the same native
+subscription used by `onBackgroundEvent`. It reports the native
+`locationManagerDidPauseLocationUpdates` and
+`locationManagerDidResumeLocationUpdates` delegate callbacks. iOS decides
+whether to pause based on the configured activity and device movement. After an
+automatic pause, Core Location does not restart updates just because the device
+moves: your app must call `startBackgroundLocation()` before iOS can report the
+`resumed` callback. Starting or stopping tracking does not synthesize a
+lifecycle event.
+
+The listener is observational: it does not restart tracking or change the
+background state. The event also arrives through `onBackgroundEvent` with
+`type: 'lifecycle'` and is retained by `getStoredBackgroundEvents()` when
+background persistence is enabled. Choose an app-specific restart policy after
+a pause if your use case needs one.
+
+Android and web return a removable subscription but do not emit these iOS Core
+Location events. Keep platform-independent cleanup code, but do not wait for a
+pause or resume event outside iOS.
+
+## Test on a real device
+
+Automatic pausing is controlled by iOS and is not deterministic in a simulator
+or short automated test. For an end-to-end check:
+
+1. Install the example app on an iPhone and grant Always location access.
+2. Open **iOS Location Lifecycle** and register the listener.
+3. Start pause-eligible tracking, leave the device stationary, and wait for iOS
+   to report `paused`.
+4. Move to an appropriate place, then use **Restart Tracking After Pause**. This
+   calls `startBackgroundLocation()` again; confirm that `resumed` appears.
+5. Stop tracking, then remove the listener twice to confirm cleanup remains
+   safe and idempotent.
+
+The automated E2E scenario covers the deterministic boundary instead: it uses
+the public unified subscription through the real native bridge and verifies
+provider delivery and removal. A separate native delegate contract invokes the
+real Core Location delegate methods and verifies that `paused` and `resumed`
+retain the active location-session generation and reach the unified event path
+in order.

--- a/docs/docs/v2/background/long-run-e2e.md
+++ b/docs/docs/v2/background/long-run-e2e.md
@@ -1,0 +1,127 @@
+# Long-Run Background E2E
+
+The example app has two background E2E pages:
+
+- `background-e2e` is a short smoke page for API contracts.
+- `background-long-run` is a device-level page for long-running checks.
+
+The long-run page reads native storage and status. It does not pass from React
+state alone, so app restarts do not hide missing native delivery.
+
+## Android
+
+Run the Android emulator flow:
+
+```sh
+yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android
+```
+
+This flow:
+
+1. clears native storage and verifies both last native-record timestamps are absent,
+2. starts background tracking with `stopOnTerminate: false` and `startOnBoot: true`,
+3. registers a geofence,
+4. establishes an outside foreground baseline, then arms a new proof marker,
+5. sends the app home and injects inside, then outside locations,
+6. reopens the page,
+7. requires the injected inside coordinate followed by the outside coordinate, for both stored locations and location events, after the proof marker,
+8. verifies `lastLocationAt` and `lastEventAt` are at or after that marker,
+9. verifies the registered Headless task marked an inside event whose native measurement timestamp is after the marker,
+10. verifies geofence enter and exit events after the marker,
+11. stops tracking, removes geofences, and polls the native lifecycle briefly
+    before failing cleanup if desired tracking, the actual foreground service,
+    or a geofence remains active.
+
+The prepare and arm registrations omit Android initial triggers, so the required
+exit cannot be satisfied by the already-outside foreground baseline. Both
+location payloads are matched to the exact injected coordinates, and the
+outside row/event must have been stored after the matching inside row/event.
+
+The Headless assertion proves handler delivery without an in-process background
+listener. It does not terminate the React runtime or claim cold-start delivery.
+
+To include reboot restore on an emulator:
+
+```sh
+RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android
+```
+
+The reboot pass is emulator-only. The wrapper refuses `RUN_REBOOT=1` on a
+physical Android device before issuing `adb reboot`, then arms a post-reboot
+proof window, waits for `sys.boot_completed=1`, injects
+outside/inside/outside locations after boot, and requires
+the same ordered coordinates in both location rows and events using their
+native measurement timestamps, plus ordered geofence events. Physical Android
+devices need real movement or another trusted location injection setup.
+
+## iOS
+
+Run the iOS simulator flow:
+
+```sh
+yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:ios
+```
+
+This flow:
+
+1. clears native storage and verifies both last native-record timestamps are absent,
+2. starts iOS background/significant-change tracking and records an initial native location timestamp,
+3. establishes an outside foreground baseline, then arms a new proof marker,
+4. sends the app home and injects inside, then outside locations,
+5. reopens the page,
+6. requires stored geofence enter and exit events after the proof marker,
+7. proves target-region enter-to-exit callback order with native transition timestamps,
+8. verifies `lastEventAt` is at or after that marker,
+9. stops tracking, removes geofences, and verifies cleanup from native status.
+
+The Simulator does not reliably emit standard or significant-change location
+rows after the app goes home. The iOS gate therefore uses region transitions,
+which are native background callbacks, and does not claim that the injected
+coordinates were retained as location rows. Real-device location delivery
+remains a manual matrix item.
+
+iOS does not have Android Headless JS or an Android-style boot receiver. The E2E
+page reports those as platform limits instead of pretending they are supported.
+
+## Manual Coordinates
+
+The geofence is centered at:
+
+```txt
+37.5665,126.978
+```
+
+The deterministic transition path is:
+
+```txt
+outside: 37.563,126.97
+inside:  37.5665,126.978
+outside: 37.563,126.97
+```
+
+On iOS Simulator, use the Maestro flow for the Home/background step. For a
+manual run, press Home in Simulator and inject the same path with:
+
+```sh
+xcrun simctl location booted set 37.563,126.97
+xcrun simctl location booted start --interval=2 37.563,126.97 37.5665,126.978 37.563,126.97
+```
+
+On Android Emulator:
+
+```sh
+adb shell input keyevent HOME
+adb emu geo fix 126.970 37.563
+adb emu geo fix 126.978 37.5665
+adb emu geo fix 126.970 37.563
+```
+
+## Expected Gaps
+
+Long-run background behavior is platform and device-policy dependent. If the
+screen reports a failed result, keep it failed and inspect the device state,
+permissions, battery policy, and native logs. Do not change the E2E page to pass
+without a stored native event.
+
+The supported guarantees and the full automated/manual matrix are documented
+in [Background Reliability Contract](/background/reliability-contract).

--- a/docs/docs/v2/background/overview.md
+++ b/docs/docs/v2/background/overview.md
@@ -1,0 +1,53 @@
+# Background Location
+
+React Native Nitro Geolocation includes a dedicated Background Location API for background updates, geofencing, Android foreground-service tracking, native event persistence, Android Headless JS delivery, activity recognition events, start-on-boot, native HTTP sync, and stored event recovery.
+
+Background tracking is separate from `watchPosition`. `watchPosition` is for active foreground sessions. Background Location uses native services, receivers, and storage so events can be recorded even when JavaScript is not currently running.
+
+```ts
+import {
+  startBackgroundLocation,
+  diagnoseBackgroundLocation,
+  addGeofences,
+  registerBackgroundTask,
+} from 'react-native-nitro-geolocation/background';
+```
+
+Prefer `react-native-nitro-geolocation/background` so foreground and background
+imports stay explicit and tree-shakable.
+
+## Where to go next
+
+- [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.
+- [Permissions](/background/permissions) - request foreground/background access and handle settings round-trips.
+- [Start And Stop](/background/start-stop) - start continuous tracking and subscribe to native updates.
+- [iOS Location Lifecycle](/background/location-lifecycle) - observe Core Location automatic pause and app-triggered resume callbacks without synthetic events.
+- [2.0 Unified Background Events](/guide/v2-unified-background-events) - migrate provider and iOS lifecycle observation to the single background event stream.
+- [Troubleshooting](/background/troubleshooting) - use `diagnoseBackgroundLocation()` to interpret the native background status when delivery is silent.
+- [Storage Recovery](/background/storage) - drain events recorded while JavaScript was not running.
+- [Reliability Contract](/background/reliability-contract) - understand foreground, background, termination, reboot, iOS suspension, status timestamps, and the E2E matrix.
+- [Geofencing](/background/geofencing), [Activity Recognition](/background/activity-recognition), and [Native HTTP Sync](/background/http-sync) - add advanced background behavior.
+
+## Diagnose Silent Background Delivery
+
+Use `diagnoseBackgroundLocation()` when background tracking is configured but
+the app is not receiving locations. It reads `getBackgroundLocationStatus()`
+and returns actionable issues instead of forcing app code to interpret every
+status field.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const diagnosis = await diagnoseBackgroundLocation();
+
+if (!diagnosis.healthy) {
+  console.warn(diagnosis.issues.join('\n'));
+}
+```
+
+The result is `{ healthy, status, issues }`. `healthy` is `true` when no issues
+were found, `status` is the raw background status, and `issues` contains
+human-readable reasons delivery may be blocked, such as a native `lastError`,
+missing foreground or background permission, disabled device location services,
+tracking configured but not started, or Android foreground-service and
+notification-permission problems.

--- a/docs/docs/v2/background/permissions.md
+++ b/docs/docs/v2/background/permissions.md
@@ -1,0 +1,38 @@
+# Permissions
+
+```ts
+import {
+  checkBackgroundPermission,
+  openAppLocationSettings,
+  requestBackgroundPermission,
+} from 'react-native-nitro-geolocation/background';
+
+export async function requestBackgroundAccess() {
+  const requested = await requestBackgroundPermission();
+
+  if (requested.needsSettingsRedirect) {
+    // Android 11+ may already have opened app settings. On iOS, show your own
+    // explanation before sending denied/restricted users to settings.
+    // await openAppLocationSettings();
+    return requested;
+  }
+
+  return requested;
+}
+
+export async function refreshBackgroundAccessAfterResume() {
+  return checkBackgroundPermission();
+}
+```
+
+`foreground` and `background` are separate because Android and iOS gate
+background access differently. `needsSettingsRedirect` means the app still needs
+a settings or app-resume round-trip before background tracking can start. On
+Android 11+, `requestBackgroundPermission()` can open the app settings screen
+because the platform no longer allows inline background-location prompts. On
+iOS, it can also remain true until Always authorization is granted; use
+`openAppLocationSettings()` after explaining why Always access is required.
+When the current iOS status is When In Use, the OS may keep that status without
+delivering another authorization callback. The request therefore returns the
+current result instead of waiting for a callback that may never arrive.
+Call `checkBackgroundPermission()` again from your app-resume path.

--- a/docs/docs/v2/background/reliability-contract.md
+++ b/docs/docs/v2/background/reliability-contract.md
@@ -1,0 +1,65 @@
+# Background Reliability Contract
+
+Background location is a native, best-effort pipeline. Starting it means the
+library has registered the platform mechanisms described below; it does not
+promise a fixed delivery interval while the app is backgrounded, suspended,
+terminated, force-stopped, or constrained by battery policy.
+
+## Runtime states
+
+| App/device state | Android contract | iOS contract |
+| --- | --- | --- |
+| Foreground | The foreground service owns continuous updates. Live JS listeners receive events while the React runtime exists; retained events remain available through the storage APIs. | Core Location runs with the selected mode. Live JS listeners receive events while the React runtime exists; retained events remain available through the storage APIs. |
+| Background or screen off | A visible location foreground service continues when permissions and OS policy allow it. Native storage records retained events, and Headless JS is attempted when no in-process listener is available. | `allowsBackgroundLocationUpdates` and the Location background mode allow Core Location delivery, but iOS controls timing and may suspend the process. Significant-change and region monitoring are more restart-friendly than continuous standard updates. |
+| Task removed / process killed | `stopOnTerminate: true` stops tracking. With `false`, the service requests sticky restart, but OEM policy, Android background-start limits, permission changes, or resource pressure can still prevent or delay it. | System termination is not a continuous-delivery guarantee. Significant-change or region monitoring may allow a later system relaunch; standard updates and arbitrary JS execution are not promised. |
+| User force-stop / force-quit | Android stops the service and suppresses receivers until the user launches the app again. No library option overrides force-stop. | Treat user force-quit as stopped. Do not depend on background relaunch until the user opens the app again. |
+| Device reboot | With `startOnBoot: true`, persisted configuration, `RECEIVE_BOOT_COMPLETED`, and valid permissions, the boot receiver attempts to restore geofences and tracking. OS/OEM policy can delay or reject the start. | There is no `startOnBoot` contract or boot receiver. Re-establish the desired tracking session after the app is launched. |
+
+The new status fields do not change existing behavior or defaults. Native
+storage remains enabled unless `persist: false`; Android
+`stopOnTerminate` defaults to `true` and `startOnBoot` defaults to `false`.
+Starting Android tracking continues to use the existing foreground service and
+Headless fallback.
+
+On Android, a successful `startBackgroundLocation()` resolves only after the
+foreground service and location provider are active. Activity-aware sessions
+also wait for Activity Recognition registration. A failed replacement leaves a
+previously confirmed standalone Activity Recognition registration intact.
+`android.isForegroundServiceRunning` observes the actual process-local service
+lifecycle; it is not an alias for the desired `isRunning` state.
+
+## Status timestamps
+
+`getBackgroundLocationStatus()` includes two optional native-storage fields:
+
+```ts
+const status = await getBackgroundLocationStatus();
+
+console.log(status.lastLocationAt); // newest retained native location record
+console.log(status.lastEventAt);    // newest retained native event
+```
+
+Both values are Unix timestamps in milliseconds. They are absent when no
+matching record is retained, such as in a fresh or reset store. With
+`persist: false`, new records do not advance these fields, but previously
+retained records remain visible until they are removed. The fields describe
+native recording, not a promise that a live JS listener, Headless task, server
+sync, or application UI consumed the record.
+Compare them with your own run marker and inspect stored rows instead of using
+the counters alone.
+
+## Verification matrix
+
+| Scenario | Android automation | iOS automation | Physical-device/manual proof |
+| --- | --- | --- | --- |
+| Foreground start/stop and invalid configuration | `background-e2e.yaml` | `background-e2e.yaml` | Confirm permission and notification UX on the target OS versions. |
+| Background delivery with React UI inactive | After a foreground baseline, `background-long-run-android.yaml` arms a new marker, presses Home, injects inside/outside coordinates, and requires both retained coordinates plus fresh status timestamps. | After a foreground baseline, the iOS flow arms a new marker, presses Home, and requires post-marker region enter/exit records plus a fresh event timestamp. Simulator location rows are not claimed. | Lock the screen and walk/drive long enough to exceed the configured distance and interval filters. |
+| No in-process background listener | Android long-run requires the registered Headless task to mark the post-marker inside event delivered. | iOS has no Headless JS contract; the flow verifies storage drain after reopening. | Inspect task receipts and native logs for the exact test run. |
+| React runtime unavailable | Not automated by the Home-key flow. | Not automated by the Home-key flow. | Terminate the React runtime without force-stopping/force-quitting the app, then inspect native storage and logs after relaunch. |
+| Geofence enter/exit | Android long-run injects outside → inside → outside and requires both transitions. | The iOS simulator gate requires both post-marker transitions from the same path. | Cross the boundary on real hardware; account for OS batching and region limits. |
+| Reboot restore | `RUN_REBOOT=1` waits for Android's boot-complete signal, then verifies post-marker outside → inside → outside native measurement order for both retained locations and events, plus ordered geofence transitions. The receiver requests `startOnBoot` tracking immediately and delegates persisted geofence restoration to an OS-owned `JobService`, including when tracking itself is not restarted. | Not supported. | Test reboot on each Android OEM targeted by the app; keep failures visible. |
+| User force-stop / force-quit | Not asserted as recoverable. Relaunch is required. | Not asserted as recoverable. Relaunch is required. | Verify the app reports stopped/stale state after the user reopens it. |
+
+See [Long-Run Background E2E](/background/long-run-e2e) for commands and
+coordinates. A failed device-policy case is evidence to diagnose, not a reason
+to weaken the assertion.

--- a/docs/docs/v2/background/setup-android.md
+++ b/docs/docs/v2/background/setup-android.md
@@ -1,0 +1,15 @@
+# Android Setup
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+<uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+<uses-permission android:name="android.permission.WAKE_LOCK" />
+```
+
+Continuous Android background tracking runs as a foreground service and requires a visible notification. `android.foregroundService` is required.

--- a/docs/docs/v2/background/setup-ios.md
+++ b/docs/docs/v2/background/setup-ios.md
@@ -1,0 +1,23 @@
+# iOS Setup
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Allow this app to use your location.</string>
+
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>Allow this app to use your location in the background.</string>
+
+<key>UIBackgroundModes</key>
+<array>
+  <string>location</string>
+</array>
+```
+
+For activity-aware tracking:
+
+```xml
+<key>NSMotionUsageDescription</key>
+<string>Allow this app to detect your movement activity.</string>
+```
+
+iOS does not provide Android-style Headless JS. Events are stored natively and can be drained after app initialization.

--- a/docs/docs/v2/background/start-stop.md
+++ b/docs/docs/v2/background/start-stop.md
@@ -1,0 +1,61 @@
+# Start And Stop
+
+```ts
+import {
+  checkBackgroundPermission,
+  requestBackgroundPermission,
+  startBackgroundLocation,
+  stopBackgroundLocation,
+  onBackgroundLocation,
+} from 'react-native-nitro-geolocation/background';
+
+let subscription;
+
+export async function requestAndMaybeStartTracking() {
+  const permission = await requestBackgroundPermission();
+
+  if (permission.needsSettingsRedirect) {
+    // Register an AppState "active" handler and call resumeBackgroundTracking()
+    // after the user returns from settings or the authorization prompt settles.
+    return;
+  }
+
+  await startIfAllowed(permission);
+}
+
+export async function resumeBackgroundTracking() {
+  const permission = await checkBackgroundPermission();
+  await startIfAllowed(permission);
+}
+
+async function startIfAllowed(permission) {
+  if (permission.foreground === 'granted' && permission.background === 'granted') {
+    await startBackgroundLocation({
+      trackingMode: 'continuous',
+      interval: 10_000,
+      fastestInterval: 5_000,
+      distanceFilter: 25,
+      persist: true,
+      android: {
+        foregroundService: {
+          notificationTitle: 'Location tracking active',
+          notificationText: 'Your location is being recorded',
+        },
+      },
+    });
+
+    subscription?.remove();
+    subscription = onBackgroundLocation(console.log);
+  }
+}
+
+export async function stopTracking() {
+  await stopBackgroundLocation();
+  subscription?.remove();
+  subscription = undefined;
+}
+```
+
+Use [Activity Recognition](/background/activity-recognition) before switching to
+`trackingMode: 'activityAware'`. Use [Android Setup](/background/setup-android)
+before enabling boot restart or changing foreground-service behavior.

--- a/docs/docs/v2/background/storage.md
+++ b/docs/docs/v2/background/storage.md
@@ -1,0 +1,26 @@
+# Storage Recovery
+
+JavaScript listeners are delivery. Native storage is the source of truth.
+
+```ts
+import {
+  getStoredBackgroundLocations,
+  markStoredBackgroundLocationsDelivered,
+} from 'react-native-nitro-geolocation/background';
+
+const locations = await getStoredBackgroundLocations({
+  includeDelivered: false,
+  limit: 100,
+});
+
+await uploadToYourServer(locations);
+
+await markStoredBackgroundLocationsDelivered(
+  locations.map((location) => location.id)
+);
+```
+
+Use `getStoredBackgroundEvents()` for mixed event recovery. In 2.x this includes
+iOS `lifecycle` events when persistence is enabled. `providerChange` events are
+live snapshots for active JavaScript subscriptions and are not written to the
+background store.

--- a/docs/docs/v2/background/troubleshooting.md
+++ b/docs/docs/v2/background/troubleshooting.md
@@ -1,0 +1,41 @@
+# Troubleshooting
+
+## Diagnose background delivery
+
+Call `diagnoseBackgroundLocation()` when the background pipeline is silent. It
+returns `{ healthy, status, issues }`, where `issues` lists the common blockers
+derived from the native background status.
+
+```ts
+import { diagnoseBackgroundLocation } from 'react-native-nitro-geolocation/background';
+
+const { healthy, issues } = await diagnoseBackgroundLocation();
+
+if (!healthy) {
+  console.warn(issues.join('\n'));
+}
+```
+
+The helper checks the last native error, foreground and background permission,
+device location services, configured/running state, stored location count, and
+Android foreground-service or notification-permission state.
+
+## Android tracking does not start
+
+Check foreground location, background location, Android 13+ notification permission, and device location services. Continuous background tracking requires `android.foregroundService`.
+
+If those values look correct but no locations arrive, inspect
+`status.lastError` from `diagnoseBackgroundLocation()` or
+`getBackgroundLocationStatus()`.
+
+## Android starts but stops after swipe-away
+
+Set `stopOnTerminate: false`. Vendor battery restrictions can still stop services.
+
+## iOS killed-app behavior differs
+
+iOS and Android have different background execution models. Authorization level, Low Power Mode, and termination state affect delivery.
+
+## JS callback missed events
+
+Read native storage with `getStoredBackgroundLocations()` or `getStoredBackgroundEvents()`.

--- a/docs/docs/v2/guide/_meta.json
+++ b/docs/docs/v2/guide/_meta.json
@@ -1,0 +1,23 @@
+[
+  "index",
+  "quick-start",
+  "install-doctor",
+  "swift-package-manager",
+  "migration-assistance",
+  "v2-error-migration",
+  "v2-unified-background-events",
+  "community-migration",
+  "service-migration",
+  "gps-offline-recipe",
+  "consumer-e2e-contract-kit",
+  "expo-development-build",
+  "privacy-compliance",
+  "react-native-directory",
+  "modern-api",
+  "watch-observability",
+  "compat-api",
+  "agent-context-map",
+  "devtools",
+  "why-nitro-module",
+  "benchmark"
+]

--- a/docs/docs/v2/guide/agent-context-map.md
+++ b/docs/docs/v2/guide/agent-context-map.md
@@ -1,0 +1,160 @@
+# Agent Context Map
+
+Use this map when you need code context for geolocation behavior but do not
+need to read generated Nitro files, full app bundles, or every scenario screen.
+
+## Start Here for This Task
+
+Pick the smallest entry point that matches your change:
+
+| Task | Read first | Then read |
+| --- | --- | --- |
+| Public foreground API behavior | `packages/react-native-nitro-geolocation/src/api/` | `packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts`, then platform files below |
+| Active watch snapshots and cleanup semantics | `packages/react-native-nitro-geolocation/src/api/getActiveWatches.ts` | `docs/docs/guide/watch-observability.md`, then platform watch registries |
+| Community compatibility behavior | `packages/react-native-nitro-geolocation/src/compat/` | `packages/react-native-nitro-geolocation/src/NitroGeolocationCompat.nitro.ts` |
+| Background API shape | `packages/react-native-nitro-geolocation/src/background/index.ts` | `packages/react-native-nitro-geolocation/src/background/NitroBackgroundLocation.nitro.ts` |
+| Android foreground native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt` | Nearby Android helper for the specific feature |
+| Android background native bug | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` | `packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/` |
+| iOS foreground native bug | `packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift` | Nearby iOS helper for the specific feature |
+| iOS background native bug | `packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift` | `IOSBackgroundLocationDelegate.swift`, `IOSBackgroundMotion.swift`, `IOSBackgroundHttpSync.swift` |
+| iOS lifecycle delegate regression | `tests/ios/IOSBackgroundLocationDelegateContract.swift` | `scripts/test-ios-location-lifecycle.sh`, then `IOSBackgroundLocationDelegate.swift` |
+| E2E failure | Matching `examples/v0.81.1/.maestro/*.yaml` file | Matching `examples/v0.81.1/src/screens/*Screen.tsx` file |
+| E2E shared UI or selectors | `examples/v0.81.1/src/screens/scenario/` | `examples/v0.81.1/src/App.tsx` for route names |
+
+Avoid these until needed:
+
+- `packages/react-native-nitro-geolocation/nitrogen/generated/**`: generated
+  bindings. Read only to debug codegen output.
+- `docs/doc_build/**`: generated documentation output.
+- `examples/*/node_modules/**`: installed dependencies.
+- Full scenario screen sweeps. Use the E2E map below to open only the failing
+  flow and its screen.
+
+## Native Responsibility Map
+
+### Shared TypeScript Layer
+
+| Area | Responsibility | Main files |
+| --- | --- | --- |
+| Modern foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
+| Community compatibility API | `@react-native-community/geolocation`-style callbacks and configuration. | `src/compat/`, `src/NitroGeolocationCompat.nitro.ts` |
+| Background API | Public background exports, listener narrowing, iOS lifecycle subscriptions, storage methods, geofence helpers, activity recognition helpers, HTTP sync helper, and task registration. | `src/background/index.ts`, `src/background/locationLifecycle.ts`, `src/background/task.ts`, `src/background/types.ts`, `src/background/NitroBackgroundLocation.nitro.ts` |
+| Web fallback | Browser geolocation behavior and web E2E support. | `src/web/`, `src/index.web.tsx`, `src/background/index.web.ts` |
+
+### Android Foreground
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro foreground module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt` |
+| Compatibility module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocationCompat.kt` |
+| One-shot current position | `GetCurrentPosition.kt`, `AndroidFusedRequestFactory.kt` |
+| Position watch | `WatchPosition.kt`, `AndroidFusedRequestFactory.kt` |
+| Permissions | `RequestAuthorization.kt` |
+| Options and conversion | `AndroidGeolocationOptions.kt`, `AndroidGeolocationConversions.kt`, `LocationValues.kt` |
+| Provider/settings/status | `AndroidLocationSettings.kt`, `AndroidGeolocationErrors.kt` |
+| Heading | `AndroidHeadingManager.kt` |
+
+### Android Background
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro background module entry point | `android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroBackgroundLocation.kt` |
+| Background orchestration | `android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt` |
+| Foreground service tracking | `NitroBackgroundLocationService.kt`, `NitroBackgroundNotificationFactory.kt` |
+| Location delivery and run-scoped PendingIntents | `NitroLocationUpdateReceiver.kt`, `NitroBackgroundPendingIntents.kt` |
+| Event fan-out to JS listeners | `NitroBackgroundEventHub.kt` |
+| Native persistence | `NitroBackgroundStore.kt`, `AndroidBackgroundSerialization.kt` |
+| Background permission contract | `AndroidBackgroundPermissions.kt` |
+| Geofencing | `NitroGeofenceReceiver.kt` |
+| Android Headless JS | `NitroBackgroundHeadlessTaskService.kt` |
+| Start on boot | `NitroBootReceiver.kt` |
+| Activity recognition | `NitroActivityRecognitionReceiver.kt` |
+| HTTP sync scheduling, serial admission, and batch ownership | `NitroBackgroundSyncCoordinator.kt`, `NitroBackgroundSyncQueue.kt`, `NitroBackgroundSyncGate.kt` |
+| HTTP transport and retry | `AndroidBackgroundHttpSync.kt` |
+
+### iOS Foreground
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro foreground module entry point | `ios/NitroGeolocation.swift` |
+| Compatibility module entry point | `ios/NitroGeolocationCompat.swift` |
+| Core Location manager and delegate | `ios/LocationManager.swift`, `ios/IOSGeolocationDelegate.swift` |
+| Options and conversion | `ios/IOSGeolocationOptions.swift`, `ios/IOSGeolocationConversions.swift` |
+| Error mapping | `ios/IOSGeolocationErrors.swift` |
+| Mock/provider metadata | `ios/CLLocation+GeolocationMetadata.swift` |
+
+### iOS Background
+
+| Responsibility | Main files |
+| --- | --- |
+| Nitro background module, storage, status, geofences, and Core Location start/stop | `ios/NitroBackgroundLocation.swift` |
+| Background Core Location pause and app-triggered resume lifecycle delegate | `ios/IOSBackgroundLocationDelegate.swift` |
+| Activity recognition conversion | `ios/IOSBackgroundMotion.swift` |
+| HTTP sync scheduling, batch ownership, and store marking | `ios/IOSBackgroundSync.swift`, `ios/IOSBackgroundSyncScheduler.swift` |
+| HTTP transport and retry | `ios/IOSBackgroundHttpSync.swift` |
+| Persistence serialization | `ios/IOSBackgroundSerialization.swift` |
+
+## E2E Scenario File Map
+
+All native E2E flows live in `examples/v0.81.1/.maestro/`. Route names and deep
+links live in `examples/v0.81.1/src/App.tsx`. Shared selectors, result blocks,
+permission helpers, and location assertions live in
+`examples/v0.81.1/src/screens/scenario/`.
+
+| Flow | Maestro file | App screen |
+| --- | --- | --- |
+| Master native smoke suite | `all-tests.yaml` | Multiple screens |
+| Permission check/request | `permission-check.yaml` | `PermissionCheckScreen.tsx` |
+| Current position | `current-position.yaml` | `CurrentPositionScreen.tsx` |
+| Watch position | `watch-position.yaml` | `WatchPositionScreen.tsx` |
+| Location simulation | `location-simulation.yaml` | `LocationSimulationScreen.tsx` |
+| Accuracy presets | `accuracy-presets.yaml` | `AccuracyPresetsScreen.tsx` |
+| Last known position | `last-known-position.yaml` | `LastKnownPositionScreen.tsx` |
+| Geocoding and reverse geocoding | `geocoding.yaml` | `GeocodingScreen.tsx` |
+| Location availability | `location-availability.yaml` | `LocationAvailabilityScreen.tsx` |
+| Heading dispatcher | `heading.yaml` | `HeadingScreen.tsx` |
+| Android heading | `heading-android.yaml` | `HeadingScreen.tsx` |
+| iOS heading | `heading-ios.yaml` | `HeadingScreen.tsx` |
+| Android request options | `android-request-options.yaml` | `AndroidRequestOptionsScreen.tsx` |
+| Android provider selection | `android-provider-selection.yaml` | `AndroidRequestOptionsScreen.tsx` |
+| Android provider settings | `provider-settings.yaml`, `provider-settings-not-ready.yaml` | `ProviderSettingsScreen.tsx` |
+| GPS-only / offline recipe | `gps-only-recipe.yaml`, `gps-only-recipe-coarse.yaml`, runner-orchestrated `gps-only-recipe-stale-readiness-prepare.yaml` + `gps-only-recipe-stale-readiness-verify.yaml`, `gps-only-recipe-not-ready.yaml`, `gps-offline-emulator.yaml`, `gps-offline-physical.yaml` | `GpsOfflineRecipeScreen.tsx` |
+| iOS location tuning | `ios-location-tuning.yaml` | `IOSLocationTuningScreen.tsx` |
+| iOS accuracy authorization | `ios-accuracy-authorization.yaml` | `IOSAccuracyAuthorizationScreen.tsx` |
+| iOS release bridge options | `ios-release-options-bridge.yaml` | `IOSReleaseOptionsBridgeScreen.tsx` |
+| iOS Core Location lifecycle listener | `location-lifecycle.yaml` | `IOSLocationLifecycleScreen.tsx` |
+| Issue 67 coarse Android location | `issue-67-android-coarse-location.yaml` | `Issue67Screen.tsx` |
+| Background API smoke | `background-e2e.yaml` | `BackgroundE2EScreen.tsx` |
+| Android long-run background | `background-long-run-android.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
+| Android long-run reboot arming | `background-long-run-android-arm-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| Android long-run reboot route drive | `background-long-run-android-reboot-drive.yaml` | Native store proof only; the app remains backgrounded |
+| Android long-run reboot proof | `background-long-run-android-reboot.yaml` | `LongRunBackgroundE2EScreen.tsx`, `backgroundLongRunTask.ts` |
+| Long-run cleanup | `background-long-run-cleanup.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| iOS long-run background | `background-long-run-ios.yaml` | `LongRunBackgroundE2EScreen.tsx` |
+| Mocked metadata Android true | `mocked-metadata-android-true.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata Android false | `mocked-metadata-android-false.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata iOS true | `mocked-metadata-ios-true.yaml` | `MockedMetadataScreen.tsx` |
+| Mocked metadata iOS false | `mocked-metadata-ios-false.yaml` | `MockedMetadataScreen.tsx` |
+| API errors | `api-errors.yaml` | `ApiErrorsScreen.tsx` |
+| Community compatibility API | `compat-api.yaml` | `CompatScreen.tsx` |
+| Web E2E available path | `web-e2e.yaml` | `WebE2EScreen.tsx`, `examples/web-e2e/` |
+| Web E2E unavailable path | `web-e2e-unavailable.yaml` | `WebE2EScreen.tsx`, `examples/web-e2e/` |
+
+## E2E Command Map
+
+Run from repo root with the matching workspace script:
+
+| Target | Command |
+| --- | --- |
+| Android native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:android` |
+| Android GPS/offline verification | `yarn workspace react-native-nitro-geolocation-example test:e2e:gps-offline:android` |
+| iOS native smoke suite | `yarn workspace react-native-nitro-geolocation-example test:e2e:ios` |
+| Android long-run background | `yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |
+| Android long-run background with reboot | `RUN_REBOOT=1 yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:android` |
+| iOS long-run background | `yarn workspace react-native-nitro-geolocation-example test:e2e:background-long-run:ios` |
+| Android web E2E | `yarn workspace react-native-nitro-geolocation-example test:e2e:web:android` |
+| iOS web E2E | `yarn workspace react-native-nitro-geolocation-example test:e2e:web:ios` |
+
+Android `all-tests.yaml` can include live provider-selection checks through
+`android-provider-selection.yaml` when `RUN_ANDROID_PROVIDER_SELECTION=1` is
+set.

--- a/docs/docs/v2/guide/benchmark.md
+++ b/docs/docs/v2/guide/benchmark.md
@@ -1,0 +1,39 @@
+# Benchmark
+
+This app benchmarks cached location read overhead between
+`react-native-nitro-geolocation` and `@react-native-community/geolocation`.
+
+![react-native-nitro-geolocation](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/benchmark.gif)
+
+## 📊 Benchmark Results
+
+**Test Environment:**
+- Device: iPhone 14 Pro
+- React Native: 0.81.4
+- Test: 1000 iterations × 5 runs of `getCurrentPosition` with cached location (measuring pure bridge/JSI latency)
+
+:::warning Benchmark scope
+This benchmark measures cached location reads and the JS-to-native call path. It
+does not measure cold GPS acquisition, permission dialogs, provider
+availability, or OS throttling. Nitro does not make GPS acquisition itself 22x
+faster; it makes cached reads and the JS-to-native path cheaper.
+:::
+
+### Results
+
+| Metric | Nitro | Community | Improvement |
+|--------|-------|-----------|-------------|
+| **Average** | 0.019ms | 0.436ms | **22.95x faster** |
+| **Median** | 0.017ms | 0.045ms | 62.2% faster |
+| **Min** | 0.014ms | 0.034ms | 58.8% faster |
+| **Max** | 1.007ms | 10.577ms | 90.5% faster |
+| **P95** | 0.025ms | 6.434ms | **257.4x faster** |
+| **P99** | 0.031ms | 7.271ms | **234.5x faster** |
+| **Std Dev** | 0.032ms | 1.545ms | 98.0% more stable |
+| **Samples** | 1000 | 1000 | - |
+
+### Why is Nitro faster for cached reads?
+
+1. **Zero Queue Overhead**: Cached location responses return immediately without any dispatch queue overhead
+2. **Direct JSI Calls**: No JSON serialization or async bridge crossing
+3. **Optimized Architecture**: Fast path for cached responses, queue-free delegate callbacks

--- a/docs/docs/v2/guide/community-migration.md
+++ b/docs/docs/v2/guide/community-migration.md
@@ -1,0 +1,152 @@
+---
+title: Community Migration
+---
+
+# Community Migration
+
+Use this path for apps that import `@react-native-community/geolocation`,
+`navigator.geolocation`, or `react-native-nitro-geolocation/compat`.
+
+The safest migration is two-step: switch community imports to `/compat` first,
+verify the app still behaves the same, then move call sites to the Modern API
+where it improves ownership, permission timing, cache behavior, or Android
+settings handling.
+
+## Agent Skill
+
+This repository ships an Agent Skills-compatible migration playbook for this
+path:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
+```
+
+The skill source is
+[`skills/community-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
+
+The bundled bootstrap script performs the first safe mechanical pass:
+
+```bash
+node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
+```
+
+After the compat bootstrap, use the skill to refactor selected call sites to the
+Modern API.
+
+## Migration Path
+
+### Step 1: Community Package
+
+```tsx
+import Geolocation from '@react-native-community/geolocation';
+
+Geolocation.getCurrentPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  {
+    enableHighAccuracy: true,
+    timeout: 15000,
+    maximumAge: 0
+  }
+);
+```
+
+### Step 2: Drop-In `/compat`
+
+First install the Nitro packages:
+
+```bash
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+```
+
+Then change only the import path:
+
+```diff
+- import Geolocation from '@react-native-community/geolocation';
++ import Geolocation from 'react-native-nitro-geolocation/compat';
+```
+
+Keep the callback call site unchanged while you verify the app:
+
+```tsx
+Geolocation.getCurrentPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  {
+    enableHighAccuracy: true,
+    timeout: 15000,
+    maximumAge: 0
+  }
+);
+```
+
+### Step 3: Modern API
+
+After the `/compat` migration is stable, move individual call sites to the
+Modern API:
+
+```tsx
+import {
+  getCurrentPosition,
+  requestLocationSettings,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'playServices'
+});
+
+const status = await requestPermission();
+
+if (status === 'granted') {
+  await requestLocationSettings({
+    accuracy: { android: 'high' },
+    interval: 5000,
+    fastestInterval: 1000
+  });
+
+  const position = await getCurrentPosition({
+    accuracy: { android: 'high', ios: 'best' },
+    granularity: 'permission',
+    waitForAccurateLocation: true,
+    timeout: 15000,
+    maximumAge: 0
+  });
+
+  console.log(position.coords.latitude, position.coords.longitude);
+}
+```
+
+For React component watches, prefer `useWatchPosition` so subscription cleanup
+is owned by the component lifecycle:
+
+```tsx
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LocationTracker() {
+  const { position, error, isWatching } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'balanced', ios: 'nearestTenMeters' },
+    distanceFilter: 10
+  });
+
+  if (error) return <Text>{error.message}</Text>;
+  if (!position) return <Text>{isWatching ? 'Waiting...' : 'Stopped'}</Text>;
+
+  return (
+    <Text>
+      {position.coords.latitude}, {position.coords.longitude}
+    </Text>
+  );
+}
+```

--- a/docs/docs/v2/guide/community-migration.md
+++ b/docs/docs/v2/guide/community-migration.md
@@ -60,7 +60,7 @@ Geolocation.getCurrentPosition(
 First install the Nitro packages:
 
 ```bash
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 Then change only the import path:

--- a/docs/docs/v2/guide/compat-api.md
+++ b/docs/docs/v2/guide/compat-api.md
@@ -1,0 +1,272 @@
+---
+title: Compat API (Compatibility)
+---
+
+> ⚠️ **This is the compat callback-based API for compatibility with @react-native-community/geolocation.**
+> For new projects, we recommend using the [Modern API](./modern-api.md) with functions and the `useWatchPosition` hook.
+
+## Import Path
+
+```tsx
+// Import from /compat subpath
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+// Or named imports
+import {
+  getCurrentPosition,
+  watchPosition,
+  clearWatch,
+} from 'react-native-nitro-geolocation/compat';
+```
+
+## Compatibility Scope
+
+This API is drop-in compatible with the core native
+`@react-native-community/geolocation` surface. It preserves the callback-based
+shape for existing iOS and Android apps while the Modern API gives new code a
+Promise/function API.
+
+| Community API | Nitro `/compat` | Notes |
+| --- | ---: | --- |
+| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
+| `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
+| `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
+| `watchPosition` | Supported | Returns a numeric watch id. |
+| `clearWatch` | Supported | Clears a watch id from `watchPosition`. |
+| `stopObserving` | Supported | Preserved for legacy cleanup compatibility. |
+| `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
+| Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
+
+The root Modern API and `/compat` subpath both support web by delegating to the
+browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
+shape and legacy error constants, while `setRNConfiguration()` is a no-op and
+`requestAuthorization()` calls the success callback immediately because browsers
+do not expose a standalone geolocation authorization prompt.
+
+## Summary
+
+- [`setRNConfiguration`](#setrnconfiguration)
+- [`requestAuthorization`](#requestauthorization)
+- [`getCurrentPosition`](#getcurrentposition)
+- [`watchPosition`](#watchposition)
+- [Opt-in integrity metadata](#opt-in-integrity-metadata)
+- [`clearWatch`](#clearwatch)
+- [`stopObserving`](#stopobserving)
+
+## Details
+
+### `setRNConfiguration()`
+
+Preserves the legacy configuration API. Use it for iOS authorization/background
+settings. Android provider selection and request behavior should be configured
+per call or through the Modern API root import.
+
+```ts
+Geolocation.setRNConfiguration(config: {
+  skipPermissionRequests: boolean;
+  authorizationLevel?: 'always' | 'whenInUse' | 'auto';
+  enableBackgroundLocationUpdates?: boolean;
+  locationProvider?: 'playServices' | 'android' | 'auto';
+});
+```
+
+Supported options:
+
+- `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
+- `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
+- `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
+
+### `requestAuthorization()`
+
+Request suitable Location permission.
+
+```ts
+Geolocation.requestAuthorization(
+  success?: () => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void
+);
+```
+
+On iOS if NSLocationAlwaysUsageDescription is set, it will request Always authorization, although if NSLocationWhenInUseUsageDescription is set, it will request InUse authorization.
+
+### `getCurrentPosition()`
+
+Invokes the success callback once with the latest location info.
+
+```ts
+Geolocation.getCurrentPosition(
+  success: (position: {
+    coords: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      accuracy: number;
+      altitudeAccuracy: number | null;
+      heading: number | null;
+      speed: number | null;
+    };
+    timestamp: number;
+  }) => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void,
+  options?: {
+    timeout?: number;
+    maximumAge?: number;
+    enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
+    includeExtraMetadata?: boolean;
+  }
+);
+```
+
+Supported options:
+
+- `timeout` (ms) - Is a positive value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. Native compat defaults to 10 minutes. Web omits the field when you do not pass it, so browser defaults apply.
+- `maximumAge` (ms) - Is a positive value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. Native compat defaults to INFINITY. Web omits the field when you do not pass it, so browser defaults apply.
+- `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
+- `includeExtraMetadata` - Set to `true` to opt this call into the metadata response described in [Opt-in integrity metadata](#opt-in-integrity-metadata). Omit it or pass `false` to keep the exact community response shape. This JS-only flag is not forwarded to the native location request.
+
+### `watchPosition()`
+
+Invokes the success callback whenever the location changes. Returns a `watchId` (number).
+
+```ts
+Geolocation.watchPosition(
+  success: (position: {
+    coords: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      accuracy: number;
+      altitudeAccuracy: number | null;
+      heading: number | null;
+      speed: number | null;
+    };
+    timestamp: number;
+  }) => void,
+  error?: (error: {
+    code: number;
+    message: string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+  }) => void,
+  options?: {
+    interval?: number;
+    fastestInterval?: number;
+    timeout?: number;
+    maximumAge?: number;
+    enableHighAccuracy?: boolean;
+    accuracy?: {
+      android?: 'high' | 'balanced' | 'low' | 'passive';
+      ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced';
+    };
+    distanceFilter?: number;
+    useSignificantChanges?: boolean;
+    activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne';
+    pausesLocationUpdatesAutomatically?: boolean;
+    showsBackgroundLocationIndicator?: boolean;
+    includeExtraMetadata?: boolean;
+  }
+) => number;
+```
+
+Supported options:
+
+- `interval` (ms) -- (Android only) The rate in milliseconds at which your app prefers to receive location updates. Note that the location updates may be somewhat faster or slower than this rate to optimize for battery usage, or there may be no updates at all (if the device has no connectivity, for example).
+- `enableHighAccuracy` (bool) - Is a boolean representing if to use GPS or not. If set to true, a GPS position will be requested. If set to false, a WIFI location will be requested.
+- `accuracy` - Native-only platform-specific accuracy preset. On iOS and Android, it takes precedence over `enableHighAccuracy` when supplied for the current platform. On web, `/compat` forwards only `enableHighAccuracy`, `timeout`, and `maximumAge` to `navigator.geolocation`.
+- `distanceFilter` (m) - The minimum distance from the previous location to exceed before returning a new location. Set to 0 to not filter locations. Defaults to 100m on Android and no distance filter on iOS.
+- `useSignificantChanges` (bool) - Uses the battery-efficient native significant changes APIs to return locations. Locations will only be returned when the device detects a significant distance has been breached. Defaults to FALSE.
+- `activityType` (iOS only) - Core Location activity type.
+- `pausesLocationUpdatesAutomatically` (iOS only) - Core Location automatic pause behavior.
+- `showsBackgroundLocationIndicator` (iOS only) - Shows the iOS background location indicator when the app has background location capability and permission.
+- `includeExtraMetadata` - Set to `true` to opt this watch subscription into the metadata response described below. Other watches, including concurrent default watches, keep the exact community response shape.
+
+`timeout`, `maximumAge`, and `fastestInterval` are part of the legacy option
+type for compatibility, but native `/compat` watches do not use them. On web,
+`watchPosition()` forwards `timeout`, `maximumAge`, and `enableHighAccuracy` to
+`navigator.geolocation`.
+
+### Opt-in integrity metadata
+
+The default `/compat` response remains exactly `{ coords, timestamp }` in both
+TypeScript and at runtime. Existing callers do not receive extra own-properties,
+including properties whose value would be `undefined`.
+
+New callers can request mock/provider metadata for one current-position call or
+one watch subscription:
+
+```ts
+import Geolocation from 'react-native-nitro-geolocation/compat';
+import type {
+  GeolocationOptionsWithMetadata,
+  GeolocationResponseWithMetadata,
+} from 'react-native-nitro-geolocation/compat';
+
+const options: GeolocationOptionsWithMetadata = {
+  includeExtraMetadata: true,
+  enableHighAccuracy: true,
+};
+
+Geolocation.getCurrentPosition(
+  (position: GeolocationResponseWithMetadata) => {
+    if (position.mocked === true) {
+      console.warn('The platform marked this sample as simulated');
+    }
+
+    console.log(position.provider);
+  },
+  undefined,
+  options,
+);
+```
+
+The opt-in response adds:
+
+- `mocked?: boolean` - `true` or `false` only when the platform reports the
+  value. Absence means unknown; it must not be treated as `false`. Android uses
+  the platform mock-location marker. iOS uses `CLLocation.sourceInformation`
+  on iOS 15 and newer when it is present.
+- `provider?: 'fused' | 'gps' | 'network' | 'passive' | 'unknown'` - The native
+  provider where it can be identified. iOS and web report `unknown`.
+
+The option is per call/subscription rather than global. A default watch and an
+opted-in watch can run concurrently without changing each other's response
+shape. Native apps must rebuild after upgrading because the opted-in path uses
+new native methods. If newer JavaScript is delivered OTA to an older native
+binary, the option safely falls back to the default `{ coords, timestamp }`
+shape. Gate any code that requires metadata on rollout of the matching native
+binary; the metadata fields remain optional for this reason. On web, `mocked`
+is omitted because browser geolocation does not expose that signal, and
+`provider` is `unknown`.
+
+### `clearWatch()`
+
+Clears watch observer by id returned by `watchPosition()`
+
+```ts
+Geolocation.clearWatch(watchID: number);
+```

--- a/docs/docs/v2/guide/consumer-e2e-contract-kit.md
+++ b/docs/docs/v2/guide/consumer-e2e-contract-kit.md
@@ -1,0 +1,137 @@
+# Consumer E2E contract kit
+
+This kit gives a consuming React Native app one small product page and two
+black-box contracts:
+
+- a granted user receives and renders a real native location;
+- a denied user does not call the public position API and receives an
+  actionable permission remedy.
+
+It deliberately uses the public API directly. There is no test-only provider,
+hidden retry, fixture branch, or library policy change.
+
+## Copy the page
+
+Complete the foreground location setup in [Quick Start](/guide/quick-start)
+before copying the kit. Android needs `ACCESS_FINE_LOCATION` and
+`ACCESS_COARSE_LOCATION`; iOS needs `NSLocationWhenInUseUsageDescription`.
+Include `authorizationLevel: 'whenInUse'` in the app's single, complete startup
+`setConfiguration()` call. The copied screen deliberately does not mutate that
+app-wide policy.
+
+Copy
+[`ConsumerLocationContractScreen.tsx`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/src/screens/ConsumerLocationContractScreen.tsx)
+into the consuming app, then register it at a deterministic test route. The
+repository example uses this React Navigation linking entry:
+
+```ts
+const linking = {
+  prefixes: ['myapp://app'],
+  config: {
+    screens: {
+      ConsumerLocationContract: 'consumer-location-contract'
+    }
+  }
+};
+```
+
+Register the same scheme with each operating system. Add an intent filter to
+the Android activity that owns the React Native route:
+
+```xml
+<intent-filter>
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="myapp" />
+</intent-filter>
+```
+
+Add the scheme to the iOS app's `Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+If the app already has a deterministic native route, adapt the flows to use it
+instead of adding another scheme.
+
+Keep these test IDs stable in the copied page:
+
+| Test ID | Contract |
+| --- | --- |
+| `consumer-location-run` | Starts the same user action exercised in production |
+| `consumer-location-status-<state>` | Exposes `passed`, `permission-required`, or `failed` without localized text |
+| `consumer-location-permission-<status>` | Exposes the permission observed before a request |
+| `consumer-location-api-attempts-<count>` | Counts this page's calls to the public position API |
+| `consumer-location-position-<latitude-e6>-<longitude-e6>` | Encodes the rendered position without presentation text |
+| `consumer-location-request-permission` | Gives a denied user an explicit next action |
+| `consumer-location-open-settings` | Leaves the app for settings when another prompt cannot recover access |
+
+The page reads `getPermissionDetails()` before `getCurrentPosition()`. It does
+not prompt on mount or change global configuration. Its remediation follows
+`settingsGuidance`: request again when possible, open app settings when
+required, or explain a managed restriction. Adapt and localize the presentation,
+but preserve the machine-readable IDs and those behavioral boundaries. The API
+attempt ID is page-owned observability, not native telemetry.
+
+## Copy the contracts
+
+Copy the two Maestro flows:
+
+- [`consumer-location-contract-happy.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-happy.yaml)
+- [`consumer-location-contract-denied.yaml`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/examples/v0.81.1/.maestro/consumer-location-contract-denied.yaml)
+
+In both flows, change `appId` and the `nitrogeolocation://app` deep-link prefix
+to the consumer app's registered values. In the denied flow, also set
+`CONSUMER_APP_DISPLAY_NAME_PATTERN`, `ANDROID_APP_SETTINGS_TITLE_PATTERN`, and
+`IOS_SETTINGS_TITLE_PATTERN`. These values are regular expressions, so escape
+metacharacters in app names such as `Foo \(Dev\)`. The flows reset unrelated
+permissions to `unset`, then select only the location boundary under test:
+Android `allow`/`deny` and iOS `inuse`/`never`. Keep the location injection,
+API-attempt count, and coordinate ID assertion in the happy flow: asserting only
+a passed status can hide a page that never rendered the native result. Keep the
+denied flow separate so CI proves this page never called the public position API
+and reports which contract failed. Its final platform-specific assertions must
+identify both the system Settings UI and the consumer app; adapt the title
+patterns for every OS locale the consumer supports.
+
+## RED to GREEN
+
+Register a minimal reachable page with the stable selectors first, but leave its
+button without location behavior. The happy flow should fail on the native
+API-attempt and coordinate assertions. Implement the granted path through the
+public API and make that flow green before committing it.
+
+Next run the denied flow against a page that calls `getCurrentPosition()`
+without a permission gate. It should fail because the API-attempt count is one
+and no actionable remediation appears. Add the read-only permission gate
+and guidance-driven remediation, then make the denied flow green:
+
+```bash
+maestro test .maestro/consumer-location-contract-happy.yaml
+maestro test .maestro/consumer-location-contract-denied.yaml
+```
+
+Run both again against the same release build before committing. Do not replace
+the denied case with a mocked JavaScript rejection: the flow controls the real
+OS permission state.
+
+## CI boundary
+
+Build and install the release variant before Maestro so the contract covers the
+artifact shipped to users. Run Android and iOS jobs separately; their permission
+stores and system dialogs are mutually exclusive environments. Use a dedicated
+emulator or simulator and inject a location only for the happy path.
+
+These two smoke contracts are intentionally small. Add product-specific edge
+cases such as provider disabled, approximate permission, timeout, or background
+delivery only when the consuming feature depends on them.

--- a/docs/docs/v2/guide/devtools.md
+++ b/docs/docs/v2/guide/devtools.md
@@ -1,0 +1,228 @@
+# DevTools Plugin (Rozenite)
+
+Mock geolocation data in development with an interactive map interface using the Rozenite DevTools plugin.
+
+## Prerequisites
+
+This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) before proceeding.
+
+:::warning API Compatibility
+This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
+:::
+
+## Installation
+
+```bash
+npm install @react-native-nitro-geolocation/rozenite-plugin
+# or
+yarn add @react-native-nitro-geolocation/rozenite-plugin
+```
+
+## Setup
+
+Add the devtools hook to your app entry point:
+
+```tsx
+import { useGeolocationDevTools } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+function App() {
+  // Enable devtools with default position (Seoul)
+  useGeolocationDevTools();
+
+  return <YourApp />;
+}
+```
+
+### With Initial Position
+
+#### Using City Presets
+
+Choose from 20 pre-configured city locations:
+
+```tsx
+import { useGeolocationDevTools, createPosition } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: createPosition('Dubai, UAE')
+  });
+
+  return <YourApp />;
+}
+```
+
+#### Using Custom Coordinates
+
+Manually define a position with specific coordinates:
+
+```tsx
+import { useGeolocationDevTools, type Position } from '@react-native-nitro-geolocation/rozenite-plugin';
+
+const customPosition: Position = {
+  coords: {
+    latitude: 37.7749,
+    longitude: -122.4194,
+    altitude: 0,
+    accuracy: 100,
+    altitudeAccuracy: 100,
+    heading: 0,
+    speed: 0,
+  },
+  timestamp: Date.now()
+};
+
+function App() {
+  useGeolocationDevTools({
+    initialPosition: customPosition
+  });
+
+  return <YourApp />;
+}
+```
+
+## Opening DevTools
+
+1. Start your React Native app with Metro bundler
+2. Press `j` in the Metro terminal to open DevTools
+3. Enable the **Geolocation** plugin from the Rozenite DevTools panel
+4. Start mocking locations!
+
+## Features
+
+### Interactive Map Control
+- **Click to set location**: Click anywhere on the map to instantly update device position
+- **Visual feedback**: Real-time marker updates as you change location
+- **Zoom and pan**: Full map navigation support
+
+### Keyboard Navigation
+Use arrow keys for precise position adjustments:
+- `↑` Move north
+- `↓` Move south
+- `←` Move west
+- `→` Move east
+
+### Manual Input
+Enter exact coordinates via input fields:
+- **Latitude**: Direct decimal degree input
+- **Longitude**: Direct decimal degree input
+- Auto-updates map and position when changed
+
+### Location Presets
+Quick access to 20 major cities worldwide:
+
+**Asia-Pacific**: Seoul, Tokyo, Beijing, Shanghai, Hong Kong, Singapore, Mumbai, Bangkok, Sydney
+
+**Europe**: London, Paris, Berlin, Moscow
+
+**Americas**: New York, Los Angeles, San Francisco, São Paulo, Mexico City, Toronto
+
+**Middle East**: Dubai
+
+### Real-time Position Data
+
+The plugin automatically calculates and updates:
+- **Heading**: Direction of movement (0-360°)
+- **Speed**: Velocity based on distance over time (m/s)
+- **Accuracy**: Position accuracy in meters
+- **Altitude**: Optional altitude data
+- **Timestamp**: Precise update timing
+
+## Demo
+
+![DevTools Plugin in Action](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
+
+## How It Works
+
+The DevTools plugin uses an event-driven architecture:
+
+1. **Ready Signal**: DevTools UI sends a "ready" signal when mounted
+2. **Initial Position**: App responds with the configured initial position
+3. **Position Updates**: UI sends position changes to the app in real-time
+4. **Global State**: Position data is stored globally and accessible to all geolocation APIs
+
+```tsx
+// Behind the scenes
+useGeolocationDevTools() → Sets up message bridge
+↓
+DevTools UI opens → Sends "ready" signal
+↓
+App responds → Sends initial position
+↓
+User changes location → DevTools sends position update
+↓
+getCurrentPosition() / useWatchPosition() → Returns mocked position
+```
+
+## Development Workflow
+
+### Typical Usage
+
+```tsx
+import { useGeolocationDevTools, createPosition } from '@react-native-nitro-geolocation/rozenite-plugin';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function App() {
+  // 1. Enable devtools with initial position
+  useGeolocationDevTools({
+    initialPosition: createPosition('Tokyo, Japan')
+  });
+
+  // 2. Use geolocation as normal
+  const { position } = useWatchPosition({ enabled: true });
+
+  return (
+    <Map
+      latitude={position?.coords.latitude}
+      longitude={position?.coords.longitude}
+    />
+  );
+}
+```
+
+### Testing Scenarios
+
+**Test navigation**:
+1. Select a start location from presets
+2. Click a destination on the map
+3. Observe your app update in real-time
+
+**Test accuracy handling**:
+1. Monitor the accuracy value in DevTools
+2. Test how your app handles low accuracy readings
+
+**Test movement**:
+1. Use arrow keys for smooth movement
+2. Verify heading and speed calculations
+3. Test distance-based triggers
+
+## Important Notes
+
+:::warning Production Builds
+The DevTools plugin should only be enabled in development builds. Rozenite DevTools is automatically disabled in production, so no additional configuration is needed.
+:::
+
+:::tip
+The plugin only intercepts Modern API calls. Compat API calls keep the drop-in replacement behavior.
+:::
+
+## Troubleshooting
+
+**DevTools not connecting**:
+- Ensure Rozenite DevTools is properly installed
+- Check that you've enabled the Geolocation plugin in the DevTools panel
+- Try closing and reopening DevTools (press `j` again)
+
+**Position not updating**:
+- Verify `useGeolocationDevTools()` is called before any geolocation APIs
+- Check Metro bundler logs for errors
+- Ensure DevTools panel is open and plugin is enabled
+
+**Initial position not applied**:
+- Make sure DevTools is open when the app starts
+- The ready signal may be delayed - try reloading the app
+
+## Source Code
+
+View the full source code on GitHub:
+- [Plugin Repository](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/packages/rozenite-devtools-plugin)
+- [Report Issues](https://github.com/jingjing2222/react-native-nitro-geolocation/issues)

--- a/docs/docs/v2/guide/expo-development-build.md
+++ b/docs/docs/v2/guide/expo-development-build.md
@@ -1,0 +1,140 @@
+---
+title: Expo Development Builds
+---
+
+# Expo Development Builds
+
+`react-native-nitro-geolocation` requires native Nitro bindings. It does not run
+inside Expo Go because Expo Go cannot load arbitrary native modules that are not
+already bundled into the client.
+
+Use this package in Expo apps only when the app has a custom native build:
+
+- Expo prebuild
+- Expo development build
+- EAS build with native project generation
+- Any custom native iOS/Android build that can install pods and Gradle modules
+
+Managed Expo apps that cannot rebuild native code should use `expo-location`.
+
+## Installation
+
+Install the native dependencies:
+
+```bash
+npx expo install react-native-nitro-modules react-native-nitro-geolocation
+```
+
+Then generate or update the native projects:
+
+```bash
+npx expo prebuild
+```
+
+Install iOS pods after native project generation:
+
+```bash
+cd ios && pod install
+```
+
+## Optional config plugin
+
+The package includes an opt-in Expo config plugin. Installing the package does
+not activate it, and there is no `postinstall` mutation. Add it explicitly to
+the app config when you want Expo prebuild or EAS Build to generate foreground
+permission entries:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-nitro-geolocation",
+        {
+          "locationWhenInUsePermission": "Allow $(PRODUCT_NAME) to show nearby deliveries."
+        }
+      ]
+    ]
+  }
+}
+```
+
+The plugin preserves an existing non-empty iOS permission message when an
+option is omitted. Otherwise it uses a generic default. It adds Android coarse
+and fine location permissions idempotently.
+
+Background configuration is a separate opt-in:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-nitro-geolocation",
+        {
+          "enableBackgroundLocation": true,
+          "locationWhenInUsePermission": "Allow $(PRODUCT_NAME) to show nearby deliveries.",
+          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to continue an active delivery."
+        }
+      ]
+    ]
+  }
+}
+```
+
+This also adds the iOS `location` background mode and the Android background,
+foreground-service, foreground-service-location, and notification permission
+declarations. Your app must still request runtime permissions from a user
+action and explain why background access is needed. Run `npx expo prebuild`
+and rebuild the native app after changing plugin options.
+
+When changing `enableBackgroundLocation` from `true` to `false`, regenerate the
+native projects with `npx expo prebuild --clean` before rebuilding. The plugin
+does not remove existing background declarations from an already-generated
+project because it cannot distinguish its previous output from app-owned native
+configuration. If a clean prebuild is not possible, remove the Android
+background/service/notification declarations, the iOS Always usage description,
+and the iOS `location` background mode manually when they are no longer needed.
+
+## Manual native permissions
+
+If you do not enable the config plugin, add the same native permission
+declarations as a bare React Native app.
+
+iOS `Info.plist`:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>This app requires access to your location while it's in use.</string>
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>This app requires access to your location at all times.</string>
+```
+
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
+Android `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+Optional background permission:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
+
+## Supported Positioning
+
+Use this package when you want Nitro/New Architecture native geolocation in an
+Expo development build or custom native build.
+
+Use `expo-location` when you need Expo Go, managed workflow setup without native
+rebuilds, Expo background tasks, or Expo geofencing.

--- a/docs/docs/v2/guide/expo-development-build.md
+++ b/docs/docs/v2/guide/expo-development-build.md
@@ -22,7 +22,7 @@ Managed Expo apps that cannot rebuild native code should use `expo-location`.
 Install the native dependencies:
 
 ```bash
-npx expo install react-native-nitro-modules react-native-nitro-geolocation
+npx expo install react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 Then generate or update the native projects:

--- a/docs/docs/v2/guide/gps-offline-recipe.md
+++ b/docs/docs/v2/guide/gps-offline-recipe.md
@@ -1,0 +1,149 @@
+# GPS-only and offline verification
+
+GPS-only routing and offline operation are related but different contracts:
+
+- **GPS-only result acceptance** means Android's platform location manager is
+  selected and the app accepts only a result whose provider is `gps`. The
+  native high-accuracy route prefers GPS but may try the network provider when
+  GPS cannot serve the request; the recipe detects and rejects that fallback.
+- **Offline** describes the device environment. The app cannot infer that
+  Wi-Fi and mobile data are truly unavailable from geolocation provider status,
+  so verify it outside the app.
+
+This recipe is intentionally explicit. It does not install a hidden provider
+policy or retry after a timeout. It makes any native fallback visible instead
+of accepting it as a GPS result.
+
+## Android recipe
+
+Request `ACCESS_FINE_LOCATION`, keep Android location services enabled, and
+configure the Android platform provider once during app startup:
+
+```ts
+import {
+  getCurrentPosition,
+  getAccuracyAuthorization,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  locationProvider: 'android'
+});
+
+export async function getFreshGpsPosition() {
+  const permission = await requestPermission();
+  const accuracyAuthorization = await getAccuracyAuthorization();
+  if (permission !== 'granted' || accuracyAuthorization !== 'full') {
+    throw new Error('Precise location permission is required');
+  }
+
+  const position = await getCurrentPosition({
+    accuracy: { android: 'high' },
+    granularity: 'fine',
+    maximumAge: 0,
+    maxUpdateAge: 0,
+    maxUpdateDelay: 0,
+    timeout: 45_000
+  });
+
+  if (position.provider !== 'gps') {
+    throw new Error(
+      `Expected the GPS provider, received ${position.provider ?? 'unknown'}`
+    );
+  }
+
+  return position;
+}
+```
+
+`maximumAge: 0` and `maxUpdateAge: 0` prevent an accepted cached fix. A long
+timeout is still normal for the first satellite fix, especially after reboot,
+travel, or a long period indoors. The Android platform route can try a network
+provider if GPS fails; the response assertion turns that into an explicit
+application error. Decide whether to show a retry action in your product, but
+do not silently accept or retry another provider when the feature requires a
+GPS result.
+
+Before calling the recipe, `getProviderStatus()` can report whether Android
+location services and the GPS provider are available. `networkAvailable` is the
+Android network *location provider*, not proof that the device has internet
+connectivity.
+
+Android reports coarse-only access as granted, so also require
+`getAccuracyAuthorization() === 'full'`. If it returns `reduced`, send the user
+to the app's system settings with React Native's `Linking.openSettings()` and
+let them opt into precise location; calling `requestPermission()` again is not
+an upgrade path after coarse access is already granted.
+
+## iOS boundary
+
+iOS Core Location does not expose a public sensor-selection API. You can test
+that an iOS feature works without connectivity, but you cannot truthfully label
+the request GPS-only or assert an iOS `provider` value of `gps`. Keep the normal
+`locationProvider: 'auto'` configuration on iOS.
+
+## Verification matrix
+
+Run the same product action in every required environment. Record the device,
+OS, permission scope, sky conditions, elapsed time, returned provider, mock
+flag, and outcome.
+
+| Case | Environment | Expected result | Automation role |
+| --- | --- | --- | --- |
+| Android route | Emulator, location services on, injected fix | Fresh accepted result with `provider=gps` and `mocked=true` | Required E2E; proves routing and response checks, not satellites |
+| Android no services | Emulator, master location switch off | Readiness reports services/GPS unavailable and request stays blocked | Required edge-case E2E |
+| Android online | Physical device outdoors, precise permission, network on | Fresh non-mocked `gps` result | Manual baseline |
+| Android offline | Same physical device, Wi-Fi and mobile data off, location services on | Fresh non-mocked `gps` result or an explicit timeout | Required manual offline proof |
+| Android approximate only | Emulator or physical device, precise permission denied | Readiness reports `accuracy=reduced`, blocks the request, and opens app settings for remediation | Required E2E and manual permission edge case |
+| Android GPS unavailable | Physical device, GPS/location services off | Readiness blocks the request | Manual provider edge case |
+| Android cold start | Physical device offline after reboot or long idle, clear sky | `gps` result within the product timeout or an explicit timeout | Manual latency boundary |
+| iOS offline | Physical iPhone, connectivity off | Core Location result or explicit error/timeout; no source assertion | Manual platform boundary |
+
+An emulator result cannot replace the physical offline row: Maestro location
+injection is mocked. A physical result is valid only when `mocked=false` and the
+device network state was checked independently.
+
+## Repository verification kit
+
+Build and install the Release example before running these commands from the
+repository root.
+
+The normal Android suite includes the injected GPS route and the
+location-services-disabled edge case:
+
+```bash
+yarn workspace react-native-nitro-geolocation-example test:e2e:android
+```
+
+Start the emulator with validated internet access. The dedicated command first
+verifies that online baseline, temporarily disables Wi-Fi and mobile data, runs
+the injected provider-routing flow, and restores both on exit. It intentionally
+rejects an emulator that starts offline or behind an unvalidated/captive route
+because it could not prove the disconnect-and-restore transition:
+
+```bash
+yarn workspace react-native-nitro-geolocation-example \
+  test:e2e:gps-offline:android
+```
+
+For a physical satellite proof, disable Wi-Fi and mobile data yourself, keep
+location services enabled, move outdoors, then acknowledge the prepared state:
+
+```bash
+GPS_OFFLINE_NETWORK_PREPARED=1 \
+ANDROID_SERIAL=<device-serial> \
+yarn workspace react-native-nitro-geolocation-example \
+  test:e2e:gps-offline:android
+```
+
+The physical flow does not mutate connectivity. It rejects a result unless the
+provider is `gps` and `mocked` is `false`.
+
+The example page is available at
+`nitrogeolocation://app/gps-offline-recipe`. Use it for Android manual matrix
+runs and capture its readiness and result cards with the environment notes
+above. The page intentionally reports iOS as unsupported because Core Location
+does not expose sensor routing; exercise the iOS offline row through the normal
+current-position screen or your product flow and record the result without a
+source assertion.

--- a/docs/docs/v2/guide/index.md
+++ b/docs/docs/v2/guide/index.md
@@ -1,0 +1,251 @@
+# Introduction
+
+The [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation) package has been the standard way to access device location in React Native apps.
+
+With the React Native ecosystem moving toward **TurboModules**, **Fabric**, and **JSI-based architecture**, we saw an opportunity to bring geolocation to the new architecture while improving the developer experience.
+
+This project — **React Native Nitro Geolocation** — is a native iOS/Android
+module designed for the **Nitro Module** system. It is best positioned as a
+React Native 0.75+ / New Architecture path for replacing the core native
+`@react-native-community/geolocation` API with `/compat`, then gradually moving
+to a typed Modern API.
+
+The current release line adds a clearer three-surface story: Modern and
+`/compat` foreground geolocation on web, plus a native Background Location API
+for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
+## When should I use this?
+
+| Use case | Recommendation |
+| --- | --- |
+| Bare React Native 0.75+ app with New Architecture/Nitro enabled | Use Nitro Geolocation |
+| Migrating from `@react-native-community/geolocation` | Start with `/compat` |
+| New Architecture / Nitro-based app | Recommended |
+| Expo development build or custom native build | Supported with native setup |
+| Expo managed app without native rebuild | Use `expo-location` |
+| React Native 0.87 app using CocoaPods | Supported |
+| React Native 0.87 SwiftPM-only app | Wait for official Nitro Modules SwiftPM support |
+| Web support required | Use the Modern API root import or `/compat` callback API |
+| Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
+
+Web support is available for the Modern API root import and the `/compat`
+subpath. Browser builds resolve both entries to implementations backed by
+`navigator.geolocation` and do not load Nitro native bindings. Background
+location remains native-only.
+
+React Native Nitro Geolocation provides **three public API surfaces** to fit
+your needs:
+
+## 1. Modern API (Recommended)
+
+**Simple functional API** with direct calls and minimal abstractions.
+
+```tsx
+import {
+  setConfiguration,
+  requestPermission,
+  getCurrentPosition,
+  geocode,
+  reverseGeocode,
+  useWatchPosition
+} from 'react-native-nitro-geolocation';
+
+// Configure once at app startup
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'auto'
+});
+
+// Request permission
+const status = await requestPermission();
+if (status !== 'granted') {
+  throw new Error('Location permission was not granted');
+}
+
+// Get current location
+const position = await getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  timeout: 15000
+});
+
+// Convert between addresses and coordinates
+const locations = await geocode('City Hall, Seoul, South Korea');
+const addresses = await reverseGeocode({
+  latitude: 37.5665,
+  longitude: 126.978
+});
+
+// Continuous tracking with hook
+function LocationTracker() {
+  const { position, error, isWatching } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'high', ios: 'bestForNavigation' },
+    distanceFilter: 10
+  });
+
+  if (error) return <Text>Error: {error.message}</Text>;
+  if (!position) return <Text>Waiting...</Text>;
+
+  return (
+    <Text>
+      {position.coords.latitude}, {position.coords.longitude}
+    </Text>
+  );
+}
+```
+
+**Key Features**:
+- 🎯 Simple and direct — No complex abstractions
+- 🪝 Single hook for continuous tracking
+- 🧹 Auto-cleanup when component unmounts
+- 📘 Full TypeScript support
+
+## 2. Compat API (Compatibility)
+
+Drop-in compatible with the core native `@react-native-community/geolocation`
+API via the `/compat` subpath.
+
+```tsx
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+Geolocation.getCurrentPosition(
+  (position) => console.log(position),
+  (error) => console.error(error),
+  { enableHighAccuracy: true }
+);
+```
+
+**Use cases**:
+- Drop-in replacement for existing apps
+- Minimal migration effort
+- Callback-based API preference
+
+## 3. Background API
+
+Native background tracking, geofencing, activity events, Android Headless JS,
+HTTP sync, and stored event recovery should use the explicit background subpath
+`react-native-nitro-geolocation/background`.
+
+Background location is native-only. Browser builds expose unsupported stubs so
+web bundles can still import shared code safely. Start with the
+[Background Location guide](/background/overview) when you need full background
+tracking, geofencing, storage recovery, or native sync.
+
+## Why Modern API?
+
+The Modern API brings simplicity and React hook patterns to geolocation:
+
+### Declarative vs Imperative
+
+**Before (Imperative)**:
+```tsx
+const [position, setPosition] = useState(null);
+const watchIdRef = useRef(null);
+
+useEffect(() => {
+  watchIdRef.current = Geolocation.watchPosition(
+    (pos) => setPosition(pos),
+    (err) => console.error(err)
+  );
+
+  return () => {
+    if (watchIdRef.current !== null) {
+      Geolocation.clearWatch(watchIdRef.current);
+    }
+  };
+}, []);
+```
+
+**After (Declarative)**:
+```tsx
+const { position } = useWatchPosition({ enabled: true });
+// Auto cleanup, no watch ID management needed!
+```
+
+### Key Benefits
+
+- **🎯 Simple and Direct**: Just functions and one hook
+- **🧹 Auto-cleanup**: No need to remember `clearWatch()` in `useEffect` cleanup
+- **🪝 Single Hook**: Only `useWatchPosition` for continuous tracking
+- **📘 Type-safe**: Full TypeScript support with inference
+- **⚡ High Performance**: JSI-powered for native speed
+
+
+## Motivation
+
+The motivation behind React Native Nitro Geolocation is twofold:
+
+### 1. Update the Architecture
+
+React Native has evolved with new architectural capabilities, and we wanted to bring these benefits to the Geolocation API.
+
+`@react-native-community/geolocation` was built on the **bridge-based architecture**, which was the standard at the time. The new JSI-based architecture offers different characteristics:
+
+- Direct communication between JS and native layers
+- Support for synchronous APIs when needed
+- Better integration with concurrent React and Fabric
+- Enhanced TypeScript support and platform consistency
+
+### 2. Improve Developer Experience
+
+We created a geolocation API that:
+
+- **Simple configuration**: Call `setConfiguration()` once
+- **Direct function calls**: No classes or complex abstractions
+- **Handles lifecycle automatically**: No manual cleanup required
+- **Provides declarative control**: `{ enabled }` prop instead of start/stop
+- **Ensures type safety**: Full TypeScript inference
+
+
+## Design Philosophy
+
+### Simple and Functional
+
+Instead of complex provider patterns or class-based APIs, we provide:
+
+| Concept | Modern API |
+|---------|------------|
+| **Configuration** | `setConfiguration()` |
+| **Permission** | `checkPermission()`, `requestPermission()` |
+| **Location** | `getCurrentPosition()`, `useWatchPosition()` |
+| **Geocoding** | `geocode()`, `reverseGeocode()` |
+| **Cleanup** | Automatic (in hook) |
+
+### Core Principles
+
+1. **Configuration at startup**: Set up once with `setConfiguration()`
+2. **Direct function calls**: Use Promise-based functions directly
+3. **Single hook for tracking**: `useWatchPosition` handles continuous updates
+4. **Automatic lifecycle**: No manual cleanup code
+5. **Type-safe by default**: Full TypeScript inference
+6. **Performance first**: JSI-powered for native speed
+
+
+## What You Get
+
+The package has three clear surfaces:
+
+- **Modern API** - typed foreground geolocation, geocoding, watching, cached reads, and Android settings helpers.
+- **Compat API** - a `/compat` path for migrating the core `@react-native-community/geolocation` surface.
+- **Background API** - native tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+
+Modern and `/compat` foreground APIs also support web through the browser
+`navigator.geolocation` API.
+
+The benchmark measures cached location reads and the JS-to-native call path. It
+does not make cold GPS acquisition itself 22x faster.
+
+Whether you're upgrading an existing app or building a new one using the latest React Native architecture, **React Native Nitro Geolocation** gives you the Modern API with a migration-friendly compat path.
+
+
+## Next Steps
+
+- [Quick Start Guide](/guide/quick-start) — Get up and running in minutes
+- [Migration Skills](/guide/migration-assistance) — Choose the right agent skill for community or service migrations
+- [Community Migration](/guide/community-migration) — Move from community imports to `/compat` and the Modern API
+- [Service Migration](/guide/service-migration) — Move from `react-native-geolocation-service` directly to the Modern API
+- [Expo Development Build Guide](/guide/expo-development-build) — Use the package in Expo custom native builds
+- [Modern API Reference](/guide/modern-api) — Explore functions and hooks
+- [Compat API Reference](/guide/compat-api) — Compatibility documentation
+- [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
+- [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/v2/guide/install-doctor.md
+++ b/docs/docs/v2/guide/install-doctor.md
@@ -1,0 +1,50 @@
+# Install Doctor
+
+`nitro-geolocation doctor` checks a consumer app's installation without
+changing any files. It has no `postinstall` hook and never applies native
+configuration automatically.
+
+Run it from the React Native app root after installing dependencies and after
+generating native projects:
+
+```bash
+yarn nitro-geolocation doctor
+
+# npm projects can use the package's local binary
+npx --no-install nitro-geolocation doctor
+```
+
+The command checks:
+
+- a readable app `package.json`;
+- React Native 0.75 or newer;
+- a declared `react-native-nitro-modules` dependency;
+- Android New Architecture configuration;
+- Android coarse and fine location permissions; and
+- the iOS `NSLocationWhenInUseUsageDescription` value.
+
+Each failure includes a remediation. The process exits with status `1` when
+configuration errors are present and `0` when the project has only passes or
+warnings. Missing generated `ios` or `android` directories are warnings because
+an Expo prebuild or another native generation step may not have run yet. Rerun
+the command after generating them to complete the native checks.
+
+## CI and monorepos
+
+Use `--project` when the app is not the current directory and `--json` for
+machine-readable output:
+
+```bash
+nitro-geolocation doctor --project apps/mobile --json
+```
+
+The JSON report contains `ok`, `project`, `summary`, and the complete `checks`
+array. Do not treat warnings as proof that native setup is complete; they are a
+signal to rerun the doctor when the native project exists.
+
+## Scope
+
+The doctor validates install-time prerequisites that can be determined from
+project files. It does not request device permissions, start location updates,
+or prove that a signed native build can receive a position. Keep device-level
+happy-path and denial tests in the app's own E2E suite.

--- a/docs/docs/v2/guide/migration-assistance.md
+++ b/docs/docs/v2/guide/migration-assistance.md
@@ -74,7 +74,8 @@ compatibility fallback.
 | Legacy or compat usage | Modern API target |
 | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
-| cache-first startup location reads | `await getLastKnownPosition(options)` |
+| latest position already observed by this JS module | `getLastKnownPosition()` |
+| cache-first native/provider reads | `await getLastKnownPositionAsync(options)` |
 | `requestAuthorization(success, error)` | `await requestPermission()` |
 | `setRNConfiguration(config)` | `setConfiguration(config)` |
 | `watchPosition` in function components | `useWatchPosition({ enabled, ...options })` |

--- a/docs/docs/v2/guide/migration-assistance.md
+++ b/docs/docs/v2/guide/migration-assistance.md
@@ -1,0 +1,106 @@
+---
+title: Migration Skills
+---
+
+# Migration Skills
+
+Use this guide when migrating an existing app from
+`@react-native-community/geolocation`, `navigator.geolocation`,
+`react-native-geolocation-service`, or `react-native-nitro-geolocation/compat`
+toward the Modern API.
+
+## Agent Skill
+
+This repository publishes Agent Skills-compatible migration playbooks for
+coding agents.
+
+For `@react-native-community/geolocation`, `navigator.geolocation`, or existing
+`/compat` code, use:
+
+[`community-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/community-migration).
+
+Install it with the Vercel Labs `skills` CLI:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
+```
+
+For `react-native-geolocation-service`, migrate directly to the Modern API with:
+
+[`service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
+```
+
+Both skills are migration assistance, not fully automatic migrations.
+
+The community migration skill uses a two-phase workflow:
+
+1. Run a package-manager-aware compat bootstrap script that installs
+   `react-native-nitro-modules` and `react-native-nitro-geolocation`, rewrites
+   `@react-native-community/geolocation` import sources to
+   `react-native-nitro-geolocation/compat`, removes the legacy package, and
+   prints validation commands for scripts that exist in the target app.
+2. Refactor `/compat` call sites to Modern API best practices using explicit
+   criteria for permission timing, React lifecycle ownership, watch cleanup,
+   cache-vs-fresh reads, accuracy, and Android provider/settings handling.
+
+The service migration skill skips `/compat` and targets the Modern API directly.
+It preserves service-specific behavior such as `accuracy`, fused-provider
+intent, Android settings-dialog handling, `mocked`/`provider` metadata, and
+provider-related error codes.
+
+## Choose a Path
+
+For `@react-native-community/geolocation`, first make the mechanical
+dependency/import change and verify the app still builds. Then refactor the
+callback-based compat code to Modern API calls. See
+[Community Migration](/guide/community-migration).
+
+For `react-native-geolocation-service`, migrate directly to named Modern API
+imports. That package's Android fused-provider and settings-dialog options map
+more naturally to Modern APIs such as
+`setConfiguration({ locationProvider: 'playServices' })` and
+`requestLocationSettings()`. See [Service Migration](/guide/service-migration).
+
+The final target state should avoid runtime imports from
+`@react-native-community/geolocation`, `navigator.geolocation`, and
+`react-native-nitro-geolocation/compat` unless the app deliberately keeps a
+compatibility fallback.
+
+## Modern API Targets
+
+| Legacy or compat usage | Modern API target |
+| --- | --- |
+| `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
+| cache-first startup location reads | `await getLastKnownPosition(options)` |
+| `requestAuthorization(success, error)` | `await requestPermission()` |
+| `setRNConfiguration(config)` | `setConfiguration(config)` |
+| `watchPosition` in function components | `useWatchPosition({ enabled, ...options })` |
+| `watchPosition` in services, classes, or tasks | `watchPosition(...)` + `unwatch(token)` |
+| `clearWatch(id)` | `unwatch(token)` |
+| `enableHighAccuracy: true` | `accuracy: { android: 'high', ios: 'best' }` |
+
+Use `checkPermission()` when you only need to read permission status. Use
+`requestPermission()` only when the app is ready to show the native permission
+prompt.
+
+For Android flows that require precise location, consider
+`getLocationAvailability()` or `requestLocationSettings()` before requesting a
+fresh position. Avoid interrupting approximate, passive, or low-power flows
+with settings prompts unless the feature requires it.
+
+## Agent-Readable Docs
+
+The public docs are also available in agent-readable form:
+
+```bash
+curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms.txt
+curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms-full.txt
+```
+
+Use `llms.txt` as the docs index. Use `llms-full.txt` when an agent needs exact
+API names, option semantics, or examples. If the target app pins an older
+`react-native-nitro-geolocation` version, confirm API availability in the
+installed package types before using docs-only APIs.

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -1,0 +1,1172 @@
+---
+title: Modern API (Recommended)
+---
+
+> Simple functional API with direct calls and minimal abstractions
+
+The Modern API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
+
+## Design Philosophy
+
+**Simple and Direct**:
+
+- **Direct function calls**: No complex abstractions or classes
+- **Single hook**: Only `useWatchPosition` for continuous tracking
+- **No Provider required**: Just call functions directly
+- **Automatic cleanup**: Hook handles subscription lifecycle
+
+**Core Principles**:
+
+- **Simple configuration**: Call `setConfiguration()` once at app startup
+- **Direct function calls**: Use `getCurrentPosition()`, `requestPermission()` etc.
+- **One hook for tracking**: `useWatchPosition` for continuous updates
+- **Type-safe**: Full TypeScript support
+- **Battery efficient**: Native subscriptions stop immediately when disabled
+
+## Configuration
+
+Set global configuration once at app startup.
+
+### setConfiguration()
+
+```tsx
+import { setConfiguration } from 'react-native-nitro-geolocation';
+
+// In App.tsx or index.js
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  enableBackgroundLocationUpdates: false,
+  locationProvider: 'auto'
+});
+```
+
+**Options**:
+
+- `autoRequestPermission?: boolean` - Deprecated compatibility option. `setConfiguration()` does not request permission; call `requestPermission()` explicitly when the app is ready to show the native prompt.
+- `authorizationLevel?: 'whenInUse' | 'always' | 'auto'` - iOS: Authorization level
+- `enableBackgroundLocationUpdates?: boolean` - iOS: Enable background location
+- `locationProvider?: 'playServices' | 'android' | 'auto'` - Android: `auto` and `playServices` prefer Google Play Services fused location when available and fall back to Android's platform provider. `android` forces the platform `LocationManager` path.
+
+**Type**:
+
+```typescript
+export type GeolocationConfiguration = {
+  /** @deprecated Call `requestPermission()` explicitly. */
+  autoRequestPermission?: boolean;
+  authorizationLevel?: 'always' | 'whenInUse' | 'auto';
+  enableBackgroundLocationUpdates?: boolean;
+  /** `auto` and `playServices` prefer fused, then platform fallback. */
+  locationProvider?: 'playServices' | 'android' | 'auto';
+};
+
+/**
+ * @deprecated Use `GeolocationConfiguration` instead.
+ * This alias is kept only for backward compatibility.
+ */
+export type ModernGeolocationConfiguration = GeolocationConfiguration;
+```
+
+**When to call**:
+
+- Once at app startup (e.g., in `App.tsx` or `index.js`)
+- Before making any location requests
+
+**Web behavior**:
+
+- Browser builds resolve the root import to a web entry that uses
+  `navigator.geolocation`.
+- `setConfiguration()` is a no-op on web. Browser permission prompts are driven
+  by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
+  request API.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, and
+  `locationProvider` are ignored on web.
+
+## Permission Functions
+
+### checkPermission()
+
+Check current location permission status without requesting it.
+
+```tsx
+import { checkPermission } from 'react-native-nitro-geolocation';
+
+async function checkLocationPermission() {
+  const status = await checkPermission();
+  console.log('Permission status:', status);
+  // status: 'granted' | 'denied' | 'restricted' | 'undetermined'
+}
+```
+
+**Returns**: `Promise<PermissionStatus>`
+
+**Permission Status**:
+
+- `'granted'` - User granted location permission
+- `'denied'` - User denied permission
+- `'restricted'` - Permission restricted (iOS parental controls)
+- `'undetermined'` - Permission not yet requested
+
+### getPermissionDetails()
+
+Read the current foreground status, granted scope, accuracy authorization, and
+the next appropriate permission action without showing a prompt, opening
+settings, or acquiring a location.
+
+```tsx
+import { getPermissionDetails } from 'react-native-nitro-geolocation';
+
+async function prepareLocationPermission() {
+  const details = await getPermissionDetails();
+
+  if (details.settingsGuidance === 'requestPermission') {
+    // Show your in-app rationale before calling requestPermission().
+  } else if (details.settingsGuidance === 'reviewSettings') {
+    // Explain why the user may want to review the app's system settings.
+  }
+
+  return details;
+}
+```
+
+**Returns**: `Promise<PermissionDetails>`
+
+```typescript
+interface PermissionDetails {
+  status: PermissionStatus;
+  scope: 'none' | 'foreground' | 'background';
+  accuracy: 'full' | 'reduced' | 'unknown';
+  canAskAgain: boolean | null;
+  settingsGuidance:
+    | 'none'
+    | 'requestPermission'
+    | 'requestPermissionOrReviewSettings'
+    | 'reviewSettings'
+    | 'managedRestriction'
+    | 'useSupportedEnvironment';
+}
+```
+
+- `scope` is `background` only when both foreground and background access are
+  granted. Browser access is always `foreground`.
+- `accuracy` reports iOS precise/reduced and Android fine/approximate access.
+  Browsers do not expose this distinction and return `unknown`.
+- `canAskAgain` describes whether another **foreground** system permission
+  prompt is known to be possible. It does not describe a later background
+  permission upgrade. `null` means the platform cannot determine the answer
+  without attempting a request.
+- Android exposes the same denied state before the first request and after
+  permanent denial through this read-only API. In that ambiguous state,
+  `canAskAgain` is `null` and `settingsGuidance` is
+  `requestPermissionOrReviewSettings`. After a normal denial, Android's
+  permission-rationale signal makes the state known requestable, so
+  `canAskAgain` is `true` and guidance is `requestPermission`.
+- iOS returns `requestPermission` for `undetermined`, `reviewSettings` for
+  `denied`, and `managedRestriction` for `restricted`.
+- Web uses the Permissions API when available. Without it, a successful
+  position/watch callback or permission-denied error is used as bounded
+  evidence for at most 30 seconds. A denial proves the current state but not
+  whether the browser will prompt again, so `canAskAgain` remains `null` and
+  guidance is `requestPermissionOrReviewSettings`. An authoritative
+  Permissions API `denied` state instead returns `false` and `reviewSettings`.
+  Without observed evidence, foreground prompt capability is also unknown. Without
+  `navigator.geolocation`, guidance is
+  `useSupportedEnvironment`.
+
+
+### requestPermission()
+
+Request location permission from the user.
+
+```tsx
+import { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { requestPermission } from 'react-native-nitro-geolocation';
+
+function PermissionButton() {
+  const [status, setStatus] = useState<string>('unknown');
+  const [loading, setLoading] = useState(false);
+
+  const handlePress = async () => {
+    setLoading(true);
+    try {
+      const result = await requestPermission();
+      setStatus(result);
+      if (result === 'granted') {
+        console.log('Permission granted!');
+      }
+    } catch (err) {
+      console.error('Permission error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View>
+      <Button
+        onPress={handlePress}
+        disabled={loading}
+        title={loading ? 'Requesting...' : 'Enable Location'}
+      />
+      <Text>Status: {status}</Text>
+    </View>
+  );
+}
+```
+
+**Returns**: `Promise<PermissionStatus>`
+
+**Behavior**:
+
+- Shows system permission dialog if `undetermined`
+- Returns immediately if already `granted` or `denied`
+- On iOS, uses `authorizationLevel` from configuration
+- On web, triggers the browser prompt by making a one-shot
+  `navigator.geolocation.getCurrentPosition()` call, then returns the mapped
+  browser permission state.
+
+
+## Location Functions
+
+### Android Provider and Settings
+
+The provider/settings snapshot helpers are available since `v1.2`.
+`watchProviderStatus()` is available since `v1.5`.
+
+Use these helpers before user-facing precise-location flows where the app needs
+to know whether Android device settings can satisfy the request.
+
+```tsx
+import { useEffect } from 'react';
+import {
+  getCurrentPosition,
+  getLocationAvailability,
+  getLocationReadiness,
+  getProviderStatus,
+  hasServicesEnabled,
+  requestLocationSettings,
+  requestLocationSettingsDetailed,
+  unwatch,
+  watchProviderStatus
+} from 'react-native-nitro-geolocation';
+
+async function inspectLocation() {
+  const readiness = await getLocationReadiness();
+  // Show app-owned actions for every remediation, including acquirePosition
+  // when the device is ready but the module cache is still cold.
+  // The diagnosis itself never prompts or opens settings.
+  return readiness.remediations;
+}
+
+async function prepareAccurateLocation() {
+  const availability = await getLocationAvailability();
+  const servicesEnabled = await hasServicesEnabled();
+  const providerStatus = await getProviderStatus();
+
+  if (!availability.available || !servicesEnabled || providerStatus.googleLocationAccuracyEnabled === false) {
+    const settings = await requestLocationSettingsDetailed({
+      accuracy: { android: 'high' },
+      interval: 5000,
+      fastestInterval: 1000
+    });
+    if (settings.outcome !== 'satisfied') return settings;
+  }
+
+  return getCurrentPosition({
+    accuracy: { android: 'high', ios: 'best' },
+    timeout: 15000
+  });
+}
+
+function ProviderStatusObserver() {
+  useEffect(() => {
+    const providerToken = watchProviderStatus((status) => {
+      console.log('Location services:', status.locationServicesEnabled);
+    });
+
+    return () => unwatch(providerToken);
+  }, []);
+
+  return null;
+}
+```
+
+**Functions**:
+
+- `hasServicesEnabled(): Promise<boolean>` - Checks whether device-level
+  location services are enabled.
+- `getProviderStatus(): Promise<LocationProviderStatus>` - Returns provider
+  state such as `locationServicesEnabled`, `gpsAvailable`,
+  `networkAvailable`, `passiveAvailable`, Android Google Play Services
+  availability, and Google Location Accuracy when Google Play Services exposes
+  it.
+- `watchProviderStatus(callback): string` - Delivers an asynchronous initial
+  provider snapshot and then only distinct readiness changes. Pass its token to
+  `unwatch()` for cleanup. Available since `v1.5`.
+- `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
+  Available since `v1.2`. Android reads Fused Location availability when
+  `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
+  configured, then falls back to platform provider/service checks. iOS maps Core
+  Location service and authorization state.
+- `getLocationReadiness(): Promise<LocationReadiness>` - Combines current
+  permission, services, provider, availability, Play Services, Google Location
+  Accuracy, and observed module-cache state into one read-only diagnosis. It
+  returns stable remediation codes such as `requestPermission`,
+  `requestPermissionOrReviewSettings`, `enableLocationServices`,
+  `useSupportedEnvironment`, and `acquirePosition`; it never requests
+  permission, opens settings, starts location acquisition, or changes
+  configuration. On Web, `useSupportedEnvironment` means reopening the app in
+  a secure context and a browser or WebView that exposes the Geolocation API.
+  When the Permissions API cannot report state, Web treats a successful
+  position observation as best-effort granted evidence for at most 30 seconds;
+  a denial, missing Geolocation API, clock rollback, or expiry clears that
+  inference.
+  Android uses `requestPermissionOrReviewSettings` because its existing
+  permission status cannot distinguish a first request from permanent denial;
+  request permission first, then offer app settings if it remains denied.
+  Google Play Services remediations are returned only when
+  `locationProvider: 'playServices'` is explicitly configured; the default
+  `auto` and `android` routes can continue through Android platform providers.
+- `requestLocationSettingsDetailed(options?): Promise<LocationSettingsResult>` -
+  Checks the requested Android location settings and shows Android's native
+  resolution dialog when available. Expected outcomes resolve as `satisfied`,
+  `cancelled`, `unavailable`, or `activityMissing`, together with the latest
+  provider status. Request failures such as a concurrent request still reject.
+- `requestLocationSettings(options?): Promise<LocationSettingsResult>` - The
+  v2 method returns the same deterministic result. The detailed name is
+  provided for code shared with v1.5 and to make result handling explicit.
+
+Both settings methods are Android-focused. On iOS they resolve with the current
+Core Location service status and do not show a settings dialog.
+
+`watchProviderStatus()` only observes readiness: it does not request permission,
+open settings, or start position updates. Android reacts to system provider and
+location-mode broadcasts. iOS rechecks after authorization changes and when the
+app becomes active, which covers returning from Settings. Browser builds recheck
+when the page becomes visible or active. Provider-specific optional fields stay
+`undefined` on platforms that cannot report them.
+
+### Android Reliability Notes
+
+- `locationProvider: 'auto'` and `locationProvider: 'playServices'` prefer
+  Google Play Services fused location when available and fall back to Android's
+  platform provider.
+- `locationProvider: 'android'` forces Android's platform `LocationManager`
+  path.
+- Approximate/coarse location flows are supported through permissions and
+  Android `granularity`.
+- Use `getLastKnownPosition()` when you want an explicit cached read without
+  starting a fresh native request.
+- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
+  `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
+
+### Web Notes
+
+Modern API web support uses the browser standard `navigator.geolocation` API.
+It requires a secure context (`https://`, `localhost`, or another browser-trusted
+origin). Unsupported browsers or unavailable providers reject location requests
+with `POSITION_UNAVAILABLE`.
+
+Supported on web:
+
+- `checkPermission()` maps `navigator.permissions.query({ name:
+  'geolocation' })` to `granted`, `denied`, or `undetermined` when the
+  Permissions API is available.
+- `getPermissionDetails()` enriches that read-only state with foreground scope
+  and settings guidance. Browser accuracy authorization remains `unknown`.
+- `requestPermission()` performs a one-shot browser geolocation request because
+  browsers do not expose a standalone geolocation permission request API.
+- `getCurrentPosition()` uses `navigator.geolocation.getCurrentPosition()` for
+  ordinary requests. When `signal` is provided, it uses a one-shot browser
+  watch so aborting can call `clearWatch()` immediately.
+- `watchPosition()` wraps `navigator.geolocation.watchPosition()` and returns a
+  string token.
+- `watchProviderStatus()` reports whether browser geolocation is available and
+  rechecks on page visibility/focus lifecycle events.
+- `unwatch()` and `stopObserving()` clear position and provider-status watches.
+
+Web option behavior:
+
+- `enableHighAccuracy`, `timeout`, and `maximumAge` are forwarded to the
+  browser.
+- `distanceFilter` is applied in JavaScript for watch updates after the first
+  emitted position.
+- `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`,
+  `interval`, `fastestInterval`, `useSignificantChanges`, Android granularity
+  options, and iOS tuning options are ignored because browsers do not provide
+  matching controls.
+- Geocoding, heading, Android settings, and temporary full-accuracy APIs are
+  native-focused. On web, provider/status helpers return browser availability
+  where possible; unsupported sensor/geocoder calls reject with
+  `POSITION_UNAVAILABLE`.
+
+### getCurrentPosition()
+
+Get current location (one-time request).
+
+```tsx
+import { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import {
+  getCurrentPosition,
+  type GeolocationResponse
+} from 'react-native-nitro-geolocation';
+
+function LocationButton() {
+  const [position, setPosition] = useState<GeolocationResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePress = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const pos = await getCurrentPosition({
+        accuracy: { android: 'high', ios: 'best' },
+        timeout: 15000
+      });
+      setPosition(pos);
+    } catch (err: any) {
+      setError(err?.message || 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View>
+      <Button
+        onPress={handlePress}
+        disabled={loading}
+        title={loading ? 'Loading...' : 'Get Location'}
+      />
+      {error && <Text style={{ color: 'red' }}>Error: {error}</Text>}
+      {position && (
+        <View>
+          <Text>Lat: {position.coords.latitude}</Text>
+          <Text>Lng: {position.coords.longitude}</Text>
+          <Text>Accuracy: {position.coords.accuracy}m</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+```
+
+**Parameters**: `options?: CurrentPositionOptions`
+
+**Options**:
+
+- `timeout?: number` - Request timeout in ms (default: 600000 / 10 min)
+- `maximumAge?: number` - Max age of cached location in ms (default: 0)
+- `signal?: AbortSignal` - Cancels only this request. A signal that is already
+  aborted prevents native or browser location work from starting. The promise
+  rejects with the exact `signal.reason`; runtimes without a reason receive an
+  `AbortError` fallback.
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
+- `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
+- `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
+- `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
+- `maxUpdateDelay?: number` - Android-only maximum batching delay in ms, available since `v1.2`.
+- `maxUpdates?: number` - Android-only maximum watch updates before native cleanup, available since `v1.2`.
+- `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`.
+- `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`.
+- `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`. This only has a visible effect when the app has background location capability and permission.
+
+Use `accuracy` when you need explicit platform-native behavior:
+
+```tsx
+await getCurrentPosition({
+  accuracy: {
+    android: 'high',
+    ios: 'bestForNavigation'
+  },
+  granularity: 'permission',
+  waitForAccurateLocation: true,
+  timeout: 15000
+});
+```
+
+Use an `AbortController` when the screen or operation that owns a one-shot
+request can end before location arrives:
+
+```tsx
+const controller = new AbortController();
+
+const request = getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  maximumAge: 0,
+  timeout: 30000,
+  signal: controller.signal
+});
+
+controller.abort(new Error('Screen closed'));
+await request;
+```
+
+Cancellation is isolated by request ID: aborting one concurrent request does
+not cancel another request or an active watch. Omitting `signal` keeps the
+existing one-shot native/browser path. The callback-based `/compat` API is
+unchanged.
+
+Android maps the presets to native accuracy/priority intent. With `auto` or
+`playServices`, requests prefer Google Play Services fused location and use the
+matching fused priority before platform fallback. With `android`, requests stay
+on `LocationManager`: `high` prefers GPS with a network fallback, `balanced`
+uses the network provider, `low` uses network/passive providers, and `passive`
+only listens through the passive provider. iOS maps the presets to Core
+Location `desiredAccuracy` constants.
+
+iOS tuning options are applied to both one-time requests and watches through
+the shared Core Location manager configuration:
+
+```tsx
+await getCurrentPosition({
+  accuracy: { ios: 'kilometer' },
+  activityType: 'fitness',
+  pausesLocationUpdatesAutomatically: false,
+  showsBackgroundLocationIndicator: false,
+  timeout: 15000
+});
+```
+
+Use `showsBackgroundLocationIndicator` only after configuring background
+location in the app target, including the `location` background mode and the
+required Info.plist location usage descriptions.
+
+**Returns**: `Promise<GeolocationResponse>`
+
+**Response**:
+
+```typescript
+export type LocationProviderUsed =
+  | 'fused'
+  | 'gps'
+  | 'network'
+  | 'passive'
+  | 'unknown';
+
+type LocationResponseSource =
+  | 'currentPosition'
+  | 'watchPosition'
+  | 'platformCache'
+  | 'moduleCache';
+
+type LocationQualityBand = 'high' | 'medium' | 'low' | 'unknown';
+
+interface LocationMetadata {
+  source: LocationResponseSource;
+  age?: number;
+  quality: LocationQualityBand;
+  staleReason?:
+    | 'maximumAgeExceeded'
+    | 'futureTimestamp'
+    | 'invalidTimestamp';
+}
+
+interface GeolocationResponse {
+  coords: {
+    latitude: number;
+    longitude: number;
+    altitude: number | null;
+    accuracy: number;
+    altitudeAccuracy: number | null;
+    heading: number | null;
+    speed: number | null;
+  };
+  timestamp: number;
+  mocked?: boolean;
+  provider?: LocationProviderUsed;
+  metadata?: LocationMetadata;
+}
+```
+
+### Mock and provider metadata
+
+`mocked` and `provider` are optional Modern API metadata fields added in v1.2.
+They describe the source of that particular position sample:
+
+- `mocked` reports whether the sample source identified it as simulated or
+  supplied by a test provider. Native Android responses use `Location.isMock`
+  (or `isFromMockProvider` on older Android versions). Native iOS responses use
+  `CLLocation.sourceInformation` when it is available on iOS 15 and later;
+  otherwise the field can be absent.
+- `provider` identifies the Android provider route as `fused`, `gps`,
+  `network`, or `passive`. iOS and web return `unknown` because those platforms
+  do not expose an equivalent provider name through this API.
+- Web positions omit `mocked` because the browser Geolocation API does not
+  expose trustworthy simulation metadata.
+- The optional development-tools integration returns `mocked: true` for its
+  injected JavaScript samples. That value identifies the tooling source; it is
+  not native platform attestation.
+
+Treat `mocked` as per-sample diagnostic evidence, not as an anti-fraud or
+device-integrity guarantee. A missing value means the platform did not expose
+the signal; it does not mean `false`. Likewise, `provider` describes the route
+used for the sample and does not establish whether the coordinates should be
+trusted.
+
+The synchronous module cache returned by `getLastKnownPosition()` preserves
+the metadata attached to the last position observed by this JavaScript module.
+Disabling a mock-location app or simulator fixture cannot rewrite that cached
+response, so it may still contain `mocked: true`. By contrast,
+`getLastKnownPositionAsync()` converts a native cached sample when it is read
+on Android or iOS; platform metadata is derived again and Android `provider`
+can reflect the current query route. On web it filters the JavaScript module
+cache, while the optional development-tools integration filters its configured
+mock cache. Do not require an asynchronous native-cache response to be
+identical to an earlier JavaScript response. Request or observe a newer sample
+when application policy requires fresher evidence, and apply `maximumAge` when
+reading the platform cache.
+
+The `/compat` entry point keeps the
+`@react-native-community/geolocation` response shape and does not include these
+fields. Compat callers can opt into equivalent metadata by setting
+`includeExtraMetadata: true` on compat `getCurrentPosition()` / `watchPosition()` calls.
+
+#### Testing the signal naturally
+
+- Test `mocked: true` with an emulator or simulator location fixture such as
+  Maestro `setLocation`.
+- Test `mocked: false` only on a physical device receiving a real provider
+  location, without coordinate injection. Do not manufacture the false branch
+  by changing or hiding returned metadata.
+- Assert absence separately on platforms that cannot provide the signal; do
+  not convert an unavailable value to `false`.
+
+**Error Handling**:
+
+```tsx
+import {
+  LocationErrorCode,
+  watchPosition,
+  unwatch,
+} from 'react-native-nitro-geolocation';
+
+const token = watchPosition(
+  (position) => {
+    console.log(position.coords.latitude, position.coords.longitude);
+  },
+  (error) => {
+    if (error.code === LocationErrorCode.SETTINGS_NOT_SATISFIED) {
+      // Device/provider settings do not satisfy the request.
+    }
+    // error.message: Human-readable error
+  }
+);
+
+unwatch(token);
+```
+
+Starting in 2.0, Modern API errors use readable string discriminants. Keep
+comparisons against the `LocationErrorCode` members shown below instead of
+copying their values. The expanded modern-only native setup/provider members
+(`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
+`SETTINGS_NOT_SATISFIED`) were originally added in v1.2; 2.0 keeps those member
+names while replacing every Modern numeric value with a string.
+
+The code is committed by the native layer before a `LocationError` is sent to
+JS. Both `watchPosition` error callbacks and public Promise rejections from
+`getCurrentPosition`/`requestPermission` receive the same `{ code, message }`
+shape; JS only relays that object and does not parse or reclassify native
+messages.
+
+| Value | Name                         | Meaning                                      |
+| ----- | ---------------------------- | -------------------------------------------- |
+| `internalError` | `INTERNAL_ERROR` | Unexpected module/native failure |
+| `permissionDenied` | `PERMISSION_DENIED` | Location permission was denied |
+| `positionUnavailable` | `POSITION_UNAVAILABLE` | A position fix is unavailable |
+| `timeout` | `TIMEOUT` | The request timed out |
+| `playServicesUnavailable` | `PLAY_SERVICE_NOT_AVAILABLE` | Android Google Play Services is unavailable |
+| `settingsNotSatisfied` | `SETTINGS_NOT_SATISFIED` | Device/provider settings do not satisfy the request |
+
+The `/compat` API keeps the legacy numeric browser-style contract with only
+`PERMISSION_DENIED` (`1`), `POSITION_UNAVAILABLE` (`2`), and `TIMEOUT` (`3`).
+See [2.0 Error Migration](./v2-error-migration.md) for the 1.x-to-2.x mapping.
+
+### getLastKnownPosition()
+
+Available since `v1.2`.
+
+Read the best cached native location explicitly without starting a fresh
+location request. This is useful for fast app startup, stale-while-refresh UI,
+and cache-only flows where a fresh GPS/network request would be too expensive.
+
+```tsx
+import { getLastKnownPosition } from 'react-native-nitro-geolocation';
+
+const cached = await getLastKnownPosition({
+  maximumAge: 60_000,
+  accuracy: { android: 'balanced', ios: 'hundredMeters' }
+});
+```
+
+`getLastKnownPosition(options?)` uses the same provider and cache-filtering
+options as `getCurrentPosition()`, but it never falls through to a fresh native
+request. If no cached location satisfies `maximumAge` or permission is denied,
+it rejects with the native `LocationError` contract, usually
+`POSITION_UNAVAILABLE` or `PERMISSION_DENIED`.
+
+### Geocoding APIs
+
+Available since `v1.2`.
+
+Use `geocode()` to convert a human-readable address into candidate coordinates,
+and `reverseGeocode()` to convert coordinates into candidate address fields.
+Both APIs use the platform geocoder, so result quality, language, network
+behavior, and availability can differ between Android `Geocoder` and iOS
+`CLGeocoder`.
+
+```tsx
+import {
+  geocode,
+  reverseGeocode
+} from 'react-native-nitro-geolocation';
+
+const locations = await geocode('City Hall, Seoul, South Korea');
+// locations: Array<{ latitude: number; longitude: number; accuracy?: number }>
+
+const addresses = await reverseGeocode({
+  latitude: 37.5665,
+  longitude: 126.978
+});
+// addresses: Array<{
+//   country?: string;
+//   region?: string;
+//   city?: string;
+//   district?: string;
+//   street?: string;
+//   postalCode?: string;
+//   formattedAddress?: string;
+// }>
+```
+
+`geocode(address)` rejects with `INTERNAL_ERROR` when `address` is blank.
+`reverseGeocode(coords)` rejects with `INTERNAL_ERROR` when latitude or
+longitude is non-finite or outside the valid coordinate range. Platform
+geocoder service failures reject with the same `{ code, message }`
+`LocationError` shape as the rest of the Modern API.
+
+### Heading APIs
+
+Available since `v1.2`.
+
+Use `getHeading()` for a single compass heading and `watchHeading()` for
+continuous heading updates. Stop heading watches with the same `unwatch(token)`
+API used by `watchPosition()`.
+
+```tsx
+import { getHeading, watchHeading, unwatch } from 'react-native-nitro-geolocation';
+
+const heading = await getHeading();
+
+const token = watchHeading(
+  (nextHeading) => {
+    console.log(nextHeading.magneticHeading);
+  },
+  (error) => {
+    console.error(error.message);
+  },
+  { headingFilter: 5 }
+);
+
+unwatch(token);
+```
+
+```typescript
+type Heading = {
+  magneticHeading: number;
+  trueHeading?: number;
+  accuracy?: number;
+  timestamp: number;
+};
+```
+
+Heading APIs require location permission and reject with the same
+`LocationError` contract when permission is denied or heading sensors are not
+available.
+
+### iOS Accuracy Authorization
+
+Available since `v1.2`.
+
+Use `getAccuracyAuthorization()` to read whether iOS currently grants full or
+reduced location accuracy. Android maps fine permission to `full`, coarse-only
+permission to `reduced`, and no location permission to `unknown`.
+
+```tsx
+import {
+  getAccuracyAuthorization,
+  requestTemporaryFullAccuracy
+} from 'react-native-nitro-geolocation';
+
+const authorization = await getAccuracyAuthorization();
+
+if (authorization === 'reduced') {
+  await requestTemporaryFullAccuracy('TurnByTurnNavigation');
+}
+```
+
+For iOS, `requestTemporaryFullAccuracy(purposeKey)` calls Core Location's
+temporary full accuracy API. The `purposeKey` must exist in
+`NSLocationTemporaryUsageDescriptionDictionary` in Info.plist, for example:
+
+```xml
+<key>NSLocationTemporaryUsageDescriptionDictionary</key>
+<dict>
+  <key>TurnByTurnNavigation</key>
+  <string>Precise location improves turn-by-turn navigation.</string>
+</dict>
+```
+
+Passing an empty `purposeKey` rejects with `INTERNAL_ERROR`. Android does not
+show a temporary accuracy prompt and resolves with the current mapped accuracy
+authorization.
+
+
+## React Hook
+
+### useWatchPosition()
+
+Watch for continuous location updates with automatic lifecycle management.
+
+```tsx
+import { useState } from 'react';
+import { Switch, Text, View } from 'react-native';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LiveTracker() {
+  const [enabled, setEnabled] = useState(false);
+
+  const { position, error, isWatching } = useWatchPosition({
+    enabled,
+    accuracy: { android: 'high', ios: 'best' },
+    distanceFilter: 10, // Update every 10 meters
+    interval: 5000, // Update every 5 seconds (Android)
+  });
+
+  return (
+    <View>
+      <Switch
+        value={enabled}
+        onValueChange={setEnabled}
+        label="Track location"
+      />
+
+      <Text>Status: {isWatching ? 'Watching 🟢' : 'Stopped 🔴'}</Text>
+
+      {error && (
+        <Text style={{ color: 'red' }}>Error: {error.message}</Text>
+      )}
+
+      {position && (
+        <View>
+          <Text>Lat: {position.coords.latitude}</Text>
+          <Text>Lng: {position.coords.longitude}</Text>
+          <Text>Accuracy: {position.coords.accuracy}m</Text>
+          {position.coords.speed !== null && (
+            <Text>Speed: {position.coords.speed}m/s</Text>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+```
+
+**Options**:
+
+- `enabled?: boolean` - Start/stop watching (default: `false`)
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`.
+- `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
+- `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
+- `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
+- `maxUpdateDelay?: number` - Android-only batching delay, available since `v1.2`
+- `maxUpdates?: number` - Android-only watch update limit, available since `v1.2`
+- `distanceFilter?: number` - Minimum distance change in meters
+- `interval?: number` - Update interval in ms (Android)
+- `fastestInterval?: number` - Fastest interval in ms (Android)
+- `timeout?: number` - Request timeout
+- `maximumAge?: number` - Max cached location age
+- `useSignificantChanges?: boolean` - Use significant changes mode (iOS)
+- `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`
+- `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`
+- `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`
+
+**Returns**:
+
+- `position: GeolocationResponse | null` - Latest position (null if no update yet)
+- `error: LocationError | null` - Error details if location watching failed
+- `isWatching: boolean` - Whether currently watching
+
+**Key Features**:
+
+- ✅ **Auto cleanup**: Unsubscribes when component unmounts or `enabled` becomes `false`
+- ✅ **Declarative**: Toggle with `enabled` prop
+- ✅ **No watch ID management**: Handled internally
+- ✅ **Battery efficient**: Native subscription stops immediately when disabled
+- ✅ **Reactive**: Changes to options restart the watch
+
+**Common Patterns**:
+
+1.  **Toggle tracking**:
+    ```tsx
+    const [tracking, setTracking] = useState(false);
+    const { position } = useWatchPosition({ enabled: tracking });
+    ```
+2.  **Conditional tracking** (track only when screen is focused):
+    ```tsx
+    const isFocused = useIsFocused(); // React Navigation
+    const { position } = useWatchPosition({ enabled: isFocused });
+    ```
+3.  **Track only when permission granted**:
+    ```tsx
+    const [hasPermission, setHasPermission] = useState(false);
+    const { position, error } = useWatchPosition({
+      enabled: hasPermission,
+      accuracy: { android: 'high', ios: 'best' },
+    });
+    ```
+
+
+## Low-level Functions (Advanced)
+
+For non-React code or advanced use cases, you can use the low-level watch API.
+
+### watchPosition()
+
+```tsx
+import { watchPosition, unwatch } from 'react-native-nitro-geolocation';
+
+const token = watchPosition(
+  (position) => {
+    console.log('Position updated:', position.coords);
+  },
+  (error) => {
+    console.error('Location error:', error.message);
+  },
+  {
+    accuracy: { android: 'high', ios: 'best' },
+    distanceFilter: 10
+  }
+);
+
+// Later: cleanup
+unwatch(token);
+```
+
+**Parameters**:
+- `onUpdate: (position: GeolocationResponse) => void` - Success callback
+- `onError?: (error: LocationError) => void` - Error callback
+- `options?: LocationRequestOptions` - Location options
+
+**Returns**: `string` - Subscription token
+
+### unwatch()
+
+Stop a specific watch subscription.
+
+```tsx
+import { unwatch } from 'react-native-nitro-geolocation';
+
+unwatch(token);
+```
+
+### getActiveWatches()
+
+Read the active Modern API position and heading subscriptions without starting
+or changing location services:
+
+```tsx
+import { getActiveWatches } from 'react-native-nitro-geolocation';
+
+const active = getActiveWatches();
+// [{ token: '...', kind: 'position' }]
+```
+
+See [Watch observability](/guide/watch-observability) for the native merge,
+restart, automatic `maxUpdates` removal, and cleanup contracts.
+
+### stopObserving()
+
+Stop ALL watch subscriptions immediately.
+
+```tsx
+import { stopObserving } from 'react-native-nitro-geolocation';
+
+// Emergency cleanup - stops all location tracking
+stopObserving();
+```
+
+
+## Advanced Patterns
+
+### Permission Check Before Location Request
+
+```tsx
+import {
+  checkPermission,
+  requestPermission,
+  getCurrentPosition
+} from 'react-native-nitro-geolocation';
+
+async function getLocationWithPermission() {
+  // Check permission first
+  let status = await checkPermission();
+
+  // Request if needed
+  if (status !== 'granted') {
+    status = await requestPermission();
+  }
+
+  // Get location if granted
+  if (status === 'granted') {
+    const position = await getCurrentPosition({
+      accuracy: { android: 'high', ios: 'best' }
+    });
+    return position;
+  } else {
+    throw new Error('Permission denied');
+  }
+}
+```
+
+### Conditional Tracking Based on App State
+
+```tsx
+import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function BackgroundTracker() {
+  const [isActive, setIsActive] = useState(AppState.currentState === 'active');
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      setIsActive(state === 'active');
+    });
+    return () => subscription.remove();
+  }, []);
+
+  const { position, error } = useWatchPosition({
+    enabled: isActive,
+    distanceFilter: 50,
+  });
+
+  return (
+    <>
+      {error && <ErrorBanner message={error.message} />}
+      <Map position={position?.coords} />
+    </>
+  );
+}
+```
+
+
+## TypeScript Support
+
+All Modern API exports are fully typed:
+
+```typescript
+import type {
+  PermissionStatus,
+  CurrentPositionOptions,
+  LocationRequestOptions,
+  LocationErrorCode,
+  LocationError,
+  GeolocationResponse,
+  GeolocationCoordinates,
+  LocationProviderUsed,
+  LocationReadiness,
+  LocationReadinessRemediation,
+  GeolocationConfiguration
+} from 'react-native-nitro-geolocation';
+```
+
+`ModernGeolocationConfiguration` is still exported as a deprecated compatibility alias.
+
+### Type Inference
+
+Functions and hooks provide full type inference:
+
+```tsx
+const { position } = useWatchPosition({ enabled: true });
+// position: GeolocationResponse | null (inferred)
+
+const pos = await getCurrentPosition();
+// pos: GeolocationResponse (inferred)
+
+const status = await requestPermission();
+// status: PermissionStatus (inferred)
+```
+
+
+## Comparison with Compat API
+
+| Feature          | Modern API                               | Compat API                               |
+| ---------------- | ---------------------------------------- | ---------------------------------------- |
+| **Import**       | `react-native-nitro-geolocation`         | `react-native-nitro-geolocation/compat`  |
+| **Pattern**      | Functions + Hook                         | Callbacks                                |
+| **Configuration**| `setConfiguration()`                     | `setRNConfiguration()`                   |
+| **Permission**   | `requestPermission()`                    | `requestAuthorization()`                 |
+| **Get Location** | `getCurrentPosition()` (Promise)         | `getCurrentPosition()` (callbacks)       |
+| **Watch**        | `useWatchPosition({ enabled })`          | `watchPosition()` / `clearWatch()`       |
+| **Cleanup**      | Automatic (hook)                         | Manual (`clearWatch`)                    |
+| **Watch ID**     | Hidden (internal)                        | User-managed                             |
+| **TypeScript**   | Full inference                           | Basic types                              |
+| **React Friendly** | ✅ Yes                                  | ⚠️ Requires useEffect boilerplate       |
+
+
+## Migration from Compat
+
+**Before (Compat API)**:
+
+```tsx
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+function LocationTracker() {
+  const [position, setPosition] = useState(null);
+  const watchIdRef = useRef(null);
+
+  useEffect(() => {
+    watchIdRef.current = Geolocation.watchPosition(
+      (pos) => setPosition(pos),
+      (err) => console.error(err),
+      { enableHighAccuracy: true }
+    );
+
+    return () => {
+      if (watchIdRef.current !== null) {
+        Geolocation.clearWatch(watchIdRef.current);
+      }
+    };
+  }, []);
+
+  return <Map position={position} />;
+}
+```
+
+**After (Modern API)**:
+
+```tsx
+import { useWatchPosition } from 'react-native-nitro-geolocation';
+
+function LocationTracker() {
+  const { position } = useWatchPosition({
+    enabled: true,
+    accuracy: { android: 'high', ios: 'best' },
+  });
+
+  return <Map position={position} />;
+}
+```
+
+**Benefits**:
+
+- 70% less code
+- No watch ID management
+- Automatic cleanup
+- Declarative enable/disable
+- Better TypeScript support

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -58,12 +58,6 @@ export type GeolocationConfiguration = {
   /** `auto` and `playServices` prefer fused, then platform fallback. */
   locationProvider?: 'playServices' | 'android' | 'auto';
 };
-
-/**
- * @deprecated Use `GeolocationConfiguration` instead.
- * This alias is kept only for backward compatibility.
- */
-export type ModernGeolocationConfiguration = GeolocationConfiguration;
 ```
 
 **When to call**:
@@ -230,8 +224,9 @@ function PermissionButton() {
 
 ### Android Provider and Settings
 
-The provider/settings snapshot helpers are available since `v1.2`.
-`watchProviderStatus()` is available since `v1.5`.
+The provider/settings snapshot helpers introduced before 2.0 remain available.
+`watchProviderStatus()` and the deterministic settings result are available in
+2.0.
 
 Use these helpers before user-facing precise-location flows where the app needs
 to know whether Android device settings can satisfy the request.
@@ -302,7 +297,7 @@ function ProviderStatusObserver() {
   it.
 - `watchProviderStatus(callback): string` - Delivers an asynchronous initial
   provider snapshot and then only distinct readiness changes. Pass its token to
-  `unwatch()` for cleanup. Available since `v1.5`.
+  `unwatch()` for cleanup. Available in 2.0.
 - `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
@@ -334,7 +329,7 @@ function ProviderStatusObserver() {
   provider status. Request failures such as a concurrent request still reject.
 - `requestLocationSettings(options?): Promise<LocationSettingsResult>` - The
   v2 method returns the same deterministic result. The detailed name is
-  provided for code shared with v1.5 and to make result handling explicit.
+  provided to make result handling explicit in code shared across release lines.
 
 Both settings methods are Android-focused. On iOS they resolve with the current
 Core Location service status and do not show a settings dialog.
@@ -355,8 +350,9 @@ when the page becomes visible or active. Provider-specific optional fields stay
   path.
 - Approximate/coarse location flows are supported through permissions and
   Android `granularity`.
-- Use `getLastKnownPosition()` when you want an explicit cached read without
-  starting a fresh native request.
+- Use `getLastKnownPosition()` for a synchronous read of the module cache. Use
+  `getLastKnownPositionAsync()` to query native/provider caches without starting
+  a fresh request.
 - Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
 
@@ -387,8 +383,8 @@ Supported on web:
 
 Web option behavior:
 
-- `enableHighAccuracy`, `timeout`, and `maximumAge` are forwarded to the
-  browser.
+- `accuracy` maps to the browser's high-accuracy boolean. `timeout` and
+  `maximumAge` are forwarded to the browser.
 - `distanceFilter` is applied in JavaScript for watch updates after the first
   emitted position.
 - `authorizationLevel`, `enableBackgroundLocationUpdates`, `locationProvider`,
@@ -463,8 +459,7 @@ function LocationButton() {
   aborted prevents native or browser location work from starting. The promise
   rejects with the exact `signal.reason`; runtimes without a reason receive an
   `AbortError` fallback.
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
@@ -685,28 +680,32 @@ The `/compat` API keeps the legacy numeric browser-style contract with only
 `PERMISSION_DENIED` (`1`), `POSITION_UNAVAILABLE` (`2`), and `TIMEOUT` (`3`).
 See [2.0 Error Migration](./v2-error-migration.md) for the 1.x-to-2.x mapping.
 
-### getLastKnownPosition()
+### getLastKnownPosition() and getLastKnownPositionAsync()
 
-Available since `v1.2`.
-
-Read the best cached native location explicitly without starting a fresh
-location request. This is useful for fast app startup, stale-while-refresh UI,
-and cache-only flows where a fresh GPS/network request would be too expensive.
+`getLastKnownPosition()` synchronously reads the latest position observed by
+this JavaScript module. It takes no options, never calls native code, and returns
+`undefined` while that module-local cache is cold.
 
 ```tsx
-import { getLastKnownPosition } from 'react-native-nitro-geolocation';
+import {
+  getLastKnownPosition,
+  getLastKnownPositionAsync
+} from 'react-native-nitro-geolocation';
 
-const cached = await getLastKnownPosition({
+const observed = getLastKnownPosition();
+
+const cached = await getLastKnownPositionAsync({
   maximumAge: 60_000,
   accuracy: { android: 'balanced', ios: 'hundredMeters' }
 });
 ```
 
-`getLastKnownPosition(options?)` uses the same provider and cache-filtering
-options as `getCurrentPosition()`, but it never falls through to a fresh native
-request. If no cached location satisfies `maximumAge` or permission is denied,
-it rejects with the native `LocationError` contract, usually
-`POSITION_UNAVAILABLE` or `PERMISSION_DENIED`.
+`getLastKnownPositionAsync(options?)` queries native/provider cache-only sources
+with the same filtering options as `getCurrentPosition()`, but never falls
+through to a fresh request. It resolves `undefined` when no cached location
+satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
+failures, such as permission denial, reject with the Modern `LocationError`
+contract.
 
 ### Geocoding APIs
 
@@ -878,8 +877,7 @@ function LiveTracker() {
 **Options**:
 
 - `enabled?: boolean` - Start/stop watching (default: `false`)
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
 - `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
@@ -1085,7 +1083,8 @@ import type {
 } from 'react-native-nitro-geolocation';
 ```
 
-`ModernGeolocationConfiguration` is still exported as a deprecated compatibility alias.
+The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
+`GeolocationConfiguration` for the root Modern API.
 
 ### Type Inference
 

--- a/docs/docs/v2/guide/privacy-compliance.md
+++ b/docs/docs/v2/guide/privacy-compliance.md
@@ -1,0 +1,182 @@
+# Privacy and Compliance
+
+This page describes the library's behavior and gives integrators an audit
+starting point. It is not legal advice. Your app determines its purposes,
+retention, recipients, disclosures, and lawful basis for location processing.
+
+## Project statement
+
+`react-native-nitro-geolocation` has no maintainer-operated telemetry or
+analytics endpoint. It does not create an advertising identifier, sell location
+data, or automatically transmit runtime data to the maintainers. Installing the
+package does not request location permission and does not start location
+collection.
+
+The source-of-truth short statement is also available in the repository's
+[`PRIVACY.md`](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/main/PRIVACY.md).
+
+## Data-flow inventory
+
+| Feature | Activation | Data and destination | Retention |
+| --- | --- | --- | --- |
+| Current position, foreground watch, heading, provider and lifecycle APIs | An app calls the API after handling permission | Platform results are returned to the app process. The library does not send them to a project server. | No library-managed durable storage for foreground-only calls. |
+| Background records and events | An app configures and starts background location | Location records and enabled background events are processed by the native app. | Android stores records in an app-private SQLite database; iOS uses app-private `UserDefaults`. Records are retained by default unless `persist: false`; configure `maxStoredLocations` and `maxStoredEvents`, then use `clearStoredBackgroundLocations()` and `clearStoredBackgroundEvents()`. |
+| Background configuration | An app calls `configureBackgroundLocation()` or starts with options | The complete configuration, including a sync URL, headers, and `bodyTemplate`, is stored in Android app-private `SharedPreferences` or iOS app-private `UserDefaults`. These stores are not credential vaults. | This happens independently of `persist: false`, record clearing, and sync `autoClear`. `resetBackgroundLocation()` removes the configuration and all library-managed background state. |
+| Geofences | An app calls `addGeofences()` | Region coordinates, radii, transitions, and metadata are stored in Android SQLite or iOS `UserDefaults`. | Independent of `persist: false`. Call `removeGeofences()` (without identifiers to remove all) or `resetBackgroundLocation()`. |
+| Native HTTP sync | An app explicitly supplies `sync.url` | Stored location payloads, configured headers, and `bodyTemplate` values go to the app-selected URL. No project URL is supplied. | `autoClear` removes successfully uploaded location records, not configuration, events, or geofences. The receiving service controls remote retention. |
+| Forward and reverse geocoding | An app calls a geocoding API | The operating-system geocoder may contact Apple, Google, or another platform provider. | Governed by the platform service and the app's own handling of returned results. |
+| Android debug logging | A debug build handles a background location | Debug logging is enabled by default and writes the exact latitude and longitude to the app's logcat stream under `NitroGeolocation`. Release builds disable verbose logs by default. | Governed by logcat access, collection tooling, and the app's log retention. Do not distribute debug builds or collect debug logs without treating them as precise-location data. |
+| Prebuilt native artifacts | Native dependency installation/build | Gradle or CocoaPods may download a matching binary from this project's GitHub Releases. No end-user location is present in this build-time request. | Build-tool and package caches. Set `NITRO_GEOLOCATION_USE_PREBUILT=0` to build from source. |
+
+Do not put long-lived secrets in `sync.headers` unless your threat model accepts
+plain app-private preferences as storage. Prefer short-lived credentials and
+TLS, and validate the configured URL before enabling sync. Android Auto Backup
+and iOS device backup or transfer may include these stores unless the app's
+backup policy excludes them. Test restore and deletion on every supported OS.
+
+## Permissions and store disclosures
+
+The host app owns permission prompts and the final merged declarations. Use
+purpose-specific copy in iOS `Info.plist`, declare Android location permissions
+for the access the app needs, and request permission from a user action.
+Background access needs a separate, clear explanation.
+
+The Android library manifest unconditionally merges these declarations into a
+consumer: `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION`,
+`RECEIVE_BOOT_COMPLETED`, `ACTIVITY_RECOGNITION`, and `WAKE_LOCK`, plus its
+background services and receivers. They support the opt-in background,
+start-on-boot, geofence, and activity-recognition APIs; they do not grant
+location access by themselves. A foreground-only app that never imports or
+calls the background entry point should remove every unused declaration with
+Android manifest-merger markers and inspect the final merged manifest. For
+example:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"
+    tools:node="remove" />
+  <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"
+    tools:node="remove" />
+
+  <application>
+    <receiver
+      android:name="com.margelo.nitro.nitrogeolocation.background.NitroBootReceiver"
+      tools:node="remove" />
+    <!-- Remove the other Nitro background components the app does not use. -->
+  </application>
+</manifest>
+```
+
+Use the exact entries in the published library `AndroidManifest.xml` as the
+removal checklist. Removing a permission or component while calling its feature
+is unsupported. See Android's [manifest-merger marker reference](https://developer.android.com/build/manage-manifests#merge_rule_markers).
+
+The iOS implementation uses `UserDefaults.standard` for app-private background
+state. The SDK therefore ships `PrivacyInfo.xcprivacy` with
+`NSPrivacyAccessedAPICategoryUserDefaults` reason `CA92.1`; CocoaPods packages it
+as the SDK's privacy resource, and release XCFrameworks include it in each
+framework slice. Because the opt-in sync API can transmit exact coordinates to
+an app-selected server and configured headers or body values can associate that
+payload with an account, the manifest conservatively declares linked precise
+location for app functionality, with tracking disabled. This is the SDK's
+declaration, not a substitute for the app's own manifest or App Privacy answers.
+Verify the manifest in the installed Pods resource bundle or XCFramework and in
+Xcode's final privacy report. Apple does not allow a third-party SDK to rely on
+the host manifest for its own required-reason API use; see [Apple's
+required-reason guidance](https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api)
+and [collected-data guidance](https://developer.apple.com/documentation/bundleresources/describing-data-use-in-privacy-manifests).
+
+Before release, reconcile the implementation with:
+
+- the app's privacy notice and consent or lawful-basis flow;
+- Apple App Privacy answers and any app-level `PrivacyInfo.xcprivacy` manifest;
+- Google Play Data safety answers, foreground-service declarations, and the
+  background-location review form when applicable;
+- retention/deletion controls for on-device records and the app's sync server;
+- child, health, workforce, precise-location, and regional rules applicable to
+  the app.
+
+The example app privacy manifest describes that app and cannot be copied
+blindly into every consumer. Audit the final app and all dependencies together.
+
+## Dependency and license disclosure
+
+The published JavaScript package is MIT licensed and ships its `LICENSE`. It has
+no direct npm runtime dependencies. Its peer dependencies are React, React
+Native, and `react-native-nitro-modules`; the consumer chooses their resolved
+versions.
+
+Android always declares direct `implementation` dependencies on React Android,
+the Kotlin standard library, the Nitro Modules project, Google Play Services
+Base (default `18.5.0`), and Google Play Services Location (default `21.3.0`).
+Consumers can override the Google versions with root-project ext properties
+`playServicesBaseVersion` and `playServicesLocationVersion`, or Gradle properties
+`NitroGeolocation_playServicesBaseVersion` and
+`NitroGeolocation_playServicesLocationVersion`. iOS uses React/Nitro CocoaPods
+dependencies plus Apple system frameworks; source and prebuilt installation
+have different artifact provenance.
+
+Do not treat an npm lockfile or final binary scan as a complete native dependency
+inventory. Archive Gradle's resolved dependency report and verification
+metadata, `Podfile.lock` (and `Package.resolved` when using SPM), prebuilt release
+URL/checksum/provenance, and applicable license notices. Final AAB/APK/XCArchive
+scanning is a useful cross-check, but generally cannot reconstruct original
+Maven/CocoaPods coordinates, transitive graph, versions, or license obligations.
+
+On first use, the default prebuilt installers fetch each release asset's
+`.sha256` sidecar, reject malformed or mismatched sidecars, and persist it next
+to the verified artifact. Later installs verify that local pair without network
+access; an integrity mismatch removes only the invalid artifact and downloads a
+fresh copy. The sidecar and artifact share the same GitHub Release/TLS trust
+boundary, and the cached sidecar shares the artifact cache's filesystem trust
+boundary. This detects ordinary corruption and one-sided cache tampering but is
+not an independent signature. Pin or independently attest release digests when
+your supply-chain policy requires stronger publisher authentication.
+
+## Reproducible audit checklist
+
+Run these from a clean checkout of the exact release commit:
+
+```bash
+yarn install --immutable
+yarn pack:check
+yarn npm audit --all --recursive
+```
+
+`pack:check` verifies the intended npm payload. The audit command checks the
+resolved Yarn dependency graph against npm advisories; review findings rather
+than suppressing them solely because they are development dependencies.
+
+For an independent vulnerability scan of the committed lockfile, install
+[OSV-Scanner](https://google.github.io/osv-scanner/installation/) and run:
+
+```bash
+osv-scanner scan -L yarn.lock
+```
+
+For a release SBOM, first create the same package archive that will be reviewed,
+then scan both the archive and the final consumer app. For example, with
+[Syft](https://github.com/anchore/syft):
+
+```bash
+mkdir -p artifacts
+npm pack ./packages/react-native-nitro-geolocation --pack-destination artifacts
+syft artifacts/react-native-nitro-geolocation-*.tgz \
+  -o cyclonedx-json=artifacts/react-native-nitro-geolocation.cdx.json
+```
+
+Build a native SBOM from the recorded Gradle/CocoaPods resolution inputs, then
+scan the final Android AAB/APK and iOS archive as a complementary artifact
+check. Feed the resulting CycloneDX or SPDX documents into the organization's
+license and vulnerability scanner, review unknown licenses manually, and
+archive the resolution reports, SBOM, scanner version, advisory database
+timestamp, and disposition with the release.
+
+## Incident response
+
+If a release changes a data flow, permission, default persistence behavior,
+sync payload, or dependency, update this page and the app's disclosures before
+shipping. Report suspected library security or privacy issues through the
+[private security advisory form](https://github.com/jingjing2222/react-native-nitro-geolocation/security/advisories/new),
+not a public issue containing user data.

--- a/docs/docs/v2/guide/quick-start.md
+++ b/docs/docs/v2/guide/quick-start.md
@@ -8,11 +8,11 @@ Before installing the module, make sure your app uses React Native 0.75+ with
 the New Architecture and Nitro Modules enabled.
 
 ```bash
-# Install Nitro core and Geolocation module
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+# Install Nitro core and the 2.0 release candidate
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 
 # or using npm
-npm install react-native-nitro-modules react-native-nitro-geolocation
+npm install react-native-nitro-modules react-native-nitro-geolocation@rc
 ```
 
 After installation, rebuild your native app to ensure the new module is linked.
@@ -127,7 +127,7 @@ from the [Modern API reference](/guide/modern-api).
 
 ```tsx
 import {
-  getLastKnownPosition,
+  getLastKnownPositionAsync,
   requestLocationSettings
 } from 'react-native-nitro-geolocation';
 
@@ -135,7 +135,7 @@ await requestLocationSettings({
   accuracy: { android: 'high' }
 });
 
-const cached = await getLastKnownPosition({
+const cached = await getLastKnownPositionAsync({
   maximumAge: 60_000,
   accuracy: { android: 'balanced', ios: 'hundredMeters' }
 });

--- a/docs/docs/v2/guide/quick-start.md
+++ b/docs/docs/v2/guide/quick-start.md
@@ -1,0 +1,155 @@
+# Quick Start
+
+This guide walks you through installing and setting up **React Native Nitro Geolocation** in your React Native project.
+
+## 1. Installation
+
+Before installing the module, make sure your app uses React Native 0.75+ with
+the New Architecture and Nitro Modules enabled.
+
+```bash
+# Install Nitro core and Geolocation module
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+
+# or using npm
+npm install react-native-nitro-modules react-native-nitro-geolocation
+```
+
+After installation, rebuild your native app to ensure the new module is linked.
+
+```bash
+cd ios && bundle exec pod install
+```
+
+Use `pod install` directly when your app does not check in a `Gemfile`.
+React Native 0.87's Swift Package Manager workflow is not yet compatible with
+the required Nitro Modules native target. Keep CocoaPods for iOS and see the
+[Swift Package Manager compatibility guide](/guide/swift-package-manager)
+before migrating an RN 0.87 app.
+
+Released npm builds try to use the matching GitHub Release prebuilts first:
+Android downloads the release AAR and reuses its native `.so` files, while iOS
+downloads the release XCFramework. If the prebuilt asset is unavailable, the
+native source build is used automatically. Android prebuilts are used only when
+the app's React Native and Nitro Modules major/minor versions match the release
+asset build. To force source builds, set:
+
+```bash
+NITRO_GEOLOCATION_USE_PREBUILT=0
+```
+
+This package requires native Nitro bindings. Expo Go is not supported. For Expo
+apps, use prebuild, a development build, or another custom native build flow;
+see the [Expo development build guide](/guide/expo-development-build).
+
+After configuring the native projects, run the read-only install doctor:
+
+```bash
+yarn nitro-geolocation doctor
+```
+
+It reports dependency, architecture, and permission setup errors without
+editing the app. See the [Install Doctor guide](/guide/install-doctor) for CI,
+monorepo, and JSON output options.
+
+
+## 2. iOS Setup
+
+### Permissions
+
+Add the following keys to your **Info.plist**:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>This app requires access to your location while it's in use.</string>
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>This app requires access to your location at all times.</string>
+```
+
+For background tracking, also enable the `location` background mode in
+`UIBackgroundModes`; see [iOS background setup](/background/setup-ios).
+
+
+## 3. Android Setup
+
+Add the following permissions to your **android/app/src/main/AndroidManifest.xml**:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+Optional (for background access):
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+Full background tracking uses a foreground service on Android. Add the full
+permission set from [Android background setup](/background/setup-android) when
+using `react-native-nitro-geolocation/background`, including Android 13+
+`POST_NOTIFICATIONS` for the tracking notification.
+
+## 4. Get Your First Location
+
+Configure once at app startup. Ask for permission from a user action, then read
+one position.
+
+```tsx
+import {
+  getCurrentPosition,
+  requestPermission,
+  setConfiguration
+} from 'react-native-nitro-geolocation';
+
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  locationProvider: 'auto'
+});
+
+async function handleUseMyLocation() {
+  const status = await requestPermission();
+
+  if (status === 'granted') {
+    const position = await getCurrentPosition({
+      accuracy: { android: 'high', ios: 'best' },
+      timeout: 15000
+    });
+  }
+}
+```
+
+## 5. Android Accuracy Helpers (Optional)
+
+If Android needs a settings prompt or an explicit cached read, configure the
+provider in your startup `setConfiguration()` call and add the settings helpers
+from the [Modern API reference](/guide/modern-api).
+
+```tsx
+import {
+  getLastKnownPosition,
+  requestLocationSettings
+} from 'react-native-nitro-geolocation';
+
+await requestLocationSettings({
+  accuracy: { android: 'high' }
+});
+
+const cached = await getLastKnownPosition({
+  maximumAge: 60_000,
+  accuracy: { android: 'balanced', ios: 'hundredMeters' }
+});
+```
+
+
+## Next Steps
+
+- [Modern API Reference](/guide/modern-api) — Complete documentation
+- [Swift Package Manager](/guide/swift-package-manager) — RN 0.87 compatibility and migration gate
+- [Compat API Reference](/guide/compat-api) — Compatibility methods
+- [Background Location](/background/overview) — Native background tracking, geofencing, and storage recovery
+- [Migration Guides](/guide/migration-assistance) — Move from community/service geolocation packages
+- [Expo Development Builds](/guide/expo-development-build) — Use the package in Expo custom native builds
+- [DevTools Plugin Guide](/guide/devtools) — Mock locations in development
+- [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
+- [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/v2/guide/react-native-directory.md
+++ b/docs/docs/v2/guide/react-native-directory.md
@@ -1,0 +1,45 @@
+---
+title: React Native Directory
+---
+
+# React Native Directory Submission
+
+Use this checklist before submitting `react-native-nitro-geolocation` to React
+Native Directory.
+
+## Support Matrix
+
+| Capability | Status |
+| --- | --- |
+| iOS | Supported |
+| Android | Supported |
+| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
+| New Architecture | Required target; implemented through Nitro Modules |
+| Expo Go | Not supported |
+| Expo development builds | Supported with native setup |
+| Full background tracking/geofencing | Supported through `react-native-nitro-geolocation/background` |
+
+## Directory Positioning
+
+Recommended short description:
+
+```txt
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
+```
+
+Recommended caveat:
+
+```txt
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
+```
+
+## Pre-Submission Checklist
+
+- README explains when to use the package and when not to use it.
+- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
+- npm package has discoverability keywords.
+- Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
+- Docs include Expo development build guidance.
+- Docs include community and service migration paths.
+- Benchmark docs clearly state cached-read and JS-native latency scope.
+- Roadmap issue tracks compatibility matrix, extra benchmarks, and real migration examples.

--- a/docs/docs/v2/guide/service-migration.md
+++ b/docs/docs/v2/guide/service-migration.md
@@ -1,0 +1,207 @@
+---
+title: Service Migration
+---
+
+# Service Migration
+
+Apps that use `react-native-geolocation-service` should migrate directly to the
+Modern API:
+
+```ts
+import {
+  getCurrentPosition,
+  getLastKnownPosition,
+  hasServicesEnabled,
+  LocationErrorCode,
+  requestPermission,
+  requestLocationSettings,
+  setConfiguration,
+  stopObserving,
+  unwatch,
+  watchPosition
+} from 'react-native-nitro-geolocation';
+```
+
+Do not migrate through `react-native-nitro-geolocation/compat`. The service
+package exposes Android fused-provider and settings-dialog behavior that maps
+more closely to Nitro Geolocation's Modern Android provider/settings API.
+
+## Agent Skill
+
+This repository ships an Agent Skills-compatible migration playbook for this
+path:
+
+```bash
+npx skills add jingjing2222/react-native-nitro-geolocation --skill service-migration
+```
+
+The skill source is
+[`skills/service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
+
+The bundled helper script can inventory and safely transform the first pass:
+
+```bash
+node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inventory-only
+node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
+```
+
+If the app startup file is obvious, the script can also add the Modern startup
+configuration:
+
+```bash
+node <skill-dir>/scripts/migrate-geolocation-service.mjs \
+  --root <app-root> \
+  --startup-file <app-root>/src/App.tsx
+```
+
+## Startup Configuration
+
+Configure Nitro Geolocation once near app startup.
+
+Normal `react-native-geolocation-service` migrations should explicitly use
+Google Play Services fused location on Android:
+
+```ts
+setConfiguration({
+  authorizationLevel: 'whenInUse',
+  enableBackgroundLocationUpdates: false,
+  locationProvider: 'playServices'
+});
+```
+
+Use `locationProvider: 'android'` only when the legacy app intentionally used
+`forceLocationManager: true` or the product requires Android `LocationManager`.
+
+## API Mapping
+
+| `react-native-geolocation-service` | Nitro Modern API |
+| --- | --- |
+| `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` |
+| `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` |
+| `Geolocation.clearWatch(id)` | `unwatch(token)` |
+| `Geolocation.stopObserving()` | `stopObserving()` |
+| `requestAuthorization('whenInUse' \| 'always')` | `setConfiguration({ authorizationLevel })` plus `requestPermission()` |
+| `accuracy: { android, ios }` | `accuracy: { android, ios }` |
+| `enableHighAccuracy: true` | `accuracy: { android: 'high', ios: 'best' }` |
+| `showLocationDialog: true` | `requestLocationSettings()` before the request |
+| `forceLocationManager: true` | `setConfiguration({ locationProvider: 'android' })` |
+| default fused provider intent | `setConfiguration({ locationProvider: 'playServices' })` |
+| `position.mocked` | `GeolocationResponse.mocked` |
+| `position.provider` | `GeolocationResponse.provider` |
+| numeric service error code | readable 2.x `LocationErrorCode` discriminant |
+
+`forceRequestLocation` has no direct Modern option. Preserve that fallback
+behavior manually only after reviewing the intended UX.
+
+## One-Shot Location
+
+Prefer a Promise chain for mechanical migrations so the containing function does
+not need to become `async` immediately.
+
+```diff
+- import Geolocation from 'react-native-geolocation-service';
++ import {
++   getCurrentPosition,
++   requestLocationSettings
++ } from 'react-native-nitro-geolocation';
+
+  export function loadLocation(onSuccess, onError) {
+-   Geolocation.getCurrentPosition(onSuccess, onError, {
+-     enableHighAccuracy: true,
+-     timeout: 15000,
+-     maximumAge: 10000,
+-     showLocationDialog: true
+-   });
++   requestLocationSettings({
++     accuracy: { android: 'high', ios: 'best' }
++   })
++     .then(() =>
++       getCurrentPosition({
++         accuracy: { android: 'high', ios: 'best' },
++         timeout: 15000,
++         maximumAge: 10000
++       })
++     )
++     .then(onSuccess)
++     .catch(onError);
+  }
+```
+
+Do not add `requestLocationSettings()` when the legacy call explicitly used
+`showLocationDialog: false`.
+
+When `showLocationDialog` was omitted, review the flow manually. The service
+package default was `true`; Nitro Modern API requires an explicit settings flow.
+
+## Watches
+
+Use the low-level Modern watch API as the first safe target:
+
+```diff
+- const watchId = Geolocation.watchPosition(onPosition, onError, {
+-   enableHighAccuracy: true,
+-   distanceFilter: 10,
+-   interval: 5000,
+-   fastestInterval: 2000
+- });
++ const watchToken = watchPosition(onPosition, onError, {
++   accuracy: { android: 'high', ios: 'best' },
++   distanceFilter: 10,
++   interval: 5000,
++   fastestInterval: 2000
++ });
+
+- Geolocation.clearWatch(watchId);
++ unwatch(watchToken);
+```
+
+Upgrade to `useWatchPosition()` only when the watch is owned by a React function
+component or custom hook and the existing callbacks do not contain
+ordering-sensitive side effects such as analytics, navigation, mutation, or
+debouncing.
+
+## Permission Differences
+
+Legacy `requestAuthorization()` can return `disabled`. Modern
+`requestPermission()` returns permission status only:
+
+```ts
+const status = await requestPermission();
+```
+
+If the old code handled `disabled`, check device-level service state separately:
+
+```ts
+const servicesEnabled = await hasServicesEnabled();
+
+if (!servicesEnabled) {
+  showLocationServicesDisabledMessage();
+  return;
+}
+
+const status = await requestPermission();
+```
+
+## Default Differences
+
+Review call sites that omit options:
+
+| Option | Service default | Nitro Modern default |
+| --- | --- | --- |
+| `getCurrentPosition.timeout` | `Infinity` | `600000` |
+| `getCurrentPosition.maximumAge` | `Infinity` | `0` |
+| `distanceFilter` | `100` | Review per API flow |
+| `showLocationDialog` | `true` | No implicit dialog; call `requestLocationSettings()` |
+
+For fresh user-facing location, choose explicit options such as:
+
+```ts
+await getCurrentPosition({
+  accuracy: { android: 'high', ios: 'best' },
+  maximumAge: 0,
+  timeout: 15000
+});
+```
+
+For cached UI, read cached state explicitly with `getLastKnownPosition()` and
+then refresh if the product flow needs it.

--- a/docs/docs/v2/guide/swift-package-manager.md
+++ b/docs/docs/v2/guide/swift-package-manager.md
@@ -1,0 +1,78 @@
+---
+title: Swift Package Manager
+---
+
+# Swift Package Manager
+
+React Native 0.87 introduced a Swift Package Manager (SwiftPM) build path for
+iOS. It is optional: CocoaPods remains the supported iOS installation path for
+`react-native-nitro-geolocation`.
+
+## Current Compatibility
+
+Do not run `npx react-native spm` in an app that installs this package yet.
+The React Native 0.87 SwiftPM autolinker requires every native dependency to
+resolve through a compatible `Package.swift`, either shipped by the library or
+generated from a supported podspec. The required `react-native-nitro-modules`
+peer dependency does not currently ship one.
+
+This package and Nitro Modules also contain a mixed Swift, Objective-C++, and
+C++ target with Swift/C++ interop. React Native's generated SwiftPM scaffold
+cannot safely translate that target. Running `npx react-native spm scaffold`
+does not make this combination supported.
+
+| iOS dependency manager | React Native 0.87 | Status |
+| --- | --- | --- |
+| CocoaPods | Supported | Recommended |
+| SwiftPM-only | Not yet supported | Wait for an official Nitro Modules SwiftPM package |
+
+## Supported RN 0.87 Installation
+
+Install both JavaScript packages normally, then keep the CocoaPods integration
+for iOS:
+
+```bash
+yarn add react-native-nitro-modules react-native-nitro-geolocation
+cd ios
+bundle exec pod install
+```
+
+Use `pod install` instead of `bundle exec pod install` when the app does not
+check in a `Gemfile`. Open the generated `.xcworkspace` and rebuild the native
+app.
+
+Android setup is unchanged. The iOS dependency-manager choice does not affect
+the package's JavaScript API.
+
+## Avoid Unsupported Workarounds
+
+Do not:
+
+- disable iOS autolinking for `react-native-nitro-modules`;
+- add an empty manifest or use a generated scaffold for these mixed-language
+  Nitro targets in `node_modules`;
+- split the generated Nitro target into independent Swift and C++ targets;
+- link the same React or Nitro native symbols through both CocoaPods and
+  SwiftPM.
+
+These workarounds can pass package resolution while producing missing native
+registrations, duplicate symbols, or configuration-specific linker failures.
+
+## When SwiftPM Becomes Available
+
+SwiftPM-only installation can be documented as supported after all of these
+conditions are met:
+
+1. `react-native-nitro-modules` publishes an official SwiftPM product.
+2. `react-native-nitro-geolocation` publishes a manifest or binary package that
+   preserves Nitro's Swift/C++ interop settings.
+3. Debug and Release builds pass on both an iOS simulator and a physical-device
+   archive with React Native 0.87.
+4. The app can run Modern, `/compat`, and background registration checks
+   without CocoaPods products in the link graph.
+
+Until then, choose CocoaPods for apps that use this package. React Native's
+[0.87 changelog](https://github.com/facebook/react-native/blob/v0.87.0/CHANGELOG.md)
+and the upstream
+[Nitro Modules repository](https://github.com/mrousavy/nitro) are the source of
+truth for the two prerequisite implementations.

--- a/docs/docs/v2/guide/swift-package-manager.md
+++ b/docs/docs/v2/guide/swift-package-manager.md
@@ -32,7 +32,7 @@ Install both JavaScript packages normally, then keep the CocoaPods integration
 for iOS:
 
 ```bash
-yarn add react-native-nitro-modules react-native-nitro-geolocation
+yarn add react-native-nitro-modules react-native-nitro-geolocation@rc
 cd ios
 bundle exec pod install
 ```

--- a/docs/docs/v2/guide/v2-error-migration.md
+++ b/docs/docs/v2/guide/v2-error-migration.md
@@ -1,0 +1,100 @@
+---
+title: 2.0 Error Migration
+---
+
+# 2.0 Error Migration
+
+React Native Nitro Geolocation 2.0 replaces numeric error codes in the Modern
+API with readable string discriminants. This is a Modern API change only. The
+`/compat` entry point keeps the W3C-style numeric `1`, `2`, and `3` contract.
+
+## Update comparisons
+
+Keep comparisons against `LocationErrorCode` instead of copying either the old
+number or the new string into application code:
+
+```diff
+ import {
+   LocationErrorCode,
+   getCurrentPosition
+ } from 'react-native-nitro-geolocation';
+
+ try {
+   await getCurrentPosition();
+ } catch (error) {
+-  if ((error as { code?: number }).code === 1) {
++  if (
++    (error as { code?: string }).code ===
++    LocationErrorCode.PERMISSION_DENIED
++  ) {
+     showPermissionHelp();
+   }
+ }
+```
+
+The constants now carry their meaning in logs and serialized data:
+
+| 1.x number | 2.x `LocationErrorCode` | 2.x wire value |
+| ---: | --- | --- |
+| `-1` | `INTERNAL_ERROR` | `internalError` |
+| `1` | `PERMISSION_DENIED` | `permissionDenied` |
+| `2` | `POSITION_UNAVAILABLE` | `positionUnavailable` |
+| `3` | `TIMEOUT` | `timeout` |
+| `4` | `PLAY_SERVICE_NOT_AVAILABLE` | `playServicesUnavailable` |
+| `5` | `SETTINGS_NOT_SATISFIED` | `settingsNotSatisfied` |
+
+## Narrow unknown errors
+
+JavaScript can throw any value. Use the exported guard when a catch boundary
+needs a trusted location code:
+
+```tsx
+import {
+  isLocationErrorCode,
+  LocationErrorCode
+} from 'react-native-nitro-geolocation';
+
+function describeLocationFailure(error: unknown): string {
+  const candidate = error as { code?: unknown; message?: unknown };
+
+  if (!isLocationErrorCode(candidate.code)) {
+    return 'Unexpected location failure';
+  }
+
+  if (candidate.code === LocationErrorCode.TIMEOUT) {
+    return 'Location took too long. Try again.';
+  }
+
+  return typeof candidate.message === 'string'
+    ? candidate.message
+    : candidate.code;
+}
+```
+
+## Migrate persisted errors
+
+Do not reinterpret an old number as a new string. If an app stores Modern API
+errors, translate known 1.x values once with the table above, write the 2.x
+string, and discard unknown values. The native Android background status store
+does this migration automatically for errors recorded by this package.
+
+## Keep `/compat` numeric
+
+No change is required for code imported from
+`react-native-nitro-geolocation/compat`:
+
+```tsx
+import Geolocation from 'react-native-nitro-geolocation/compat';
+
+Geolocation.getCurrentPosition(
+  () => undefined,
+  (error) => {
+    if (error.code === error.PERMISSION_DENIED) {
+      showPermissionHelp();
+    }
+  }
+);
+```
+
+Keeping the two contracts separate prevents a Modern-only provider error from
+leaking into the browser-compatible surface.

--- a/docs/docs/v2/guide/v2-unified-background-events.md
+++ b/docs/docs/v2/guide/v2-unified-background-events.md
@@ -1,0 +1,65 @@
+---
+title: 2.0 Unified Background Events
+---
+
+# 2.0 Unified Background Events
+
+React Native Nitro Geolocation 2.0 routes provider status and iOS Core Location
+lifecycle changes through `onBackgroundEvent`. A single subscription now
+observes every background event kind.
+
+```ts
+import { onBackgroundEvent } from 'react-native-nitro-geolocation/background';
+
+const subscription = onBackgroundEvent((event) => {
+  switch (event.type) {
+    case 'providerChange':
+      console.log(event.providerStatus.locationServicesEnabled);
+      break;
+    case 'lifecycle':
+      console.log(event.lifecycle.state, event.lifecycle.timestamp);
+      break;
+    default:
+      handleExistingBackgroundEvent(event);
+  }
+});
+
+subscription.remove();
+```
+
+On Android and iOS, each subscription receives its own initial
+`providerChange` snapshot. Later provider changes are delivered once per active
+subscriber. Removing a subscription removes its provider watcher as well, so a
+direct `getProviderStatus()` call can return a newer value without changing
+removed event counters. Web background listeners remain no-op subscriptions and
+do not emit an initial provider snapshot.
+
+Provider snapshots are live-only and are not stored. iOS `lifecycle` events are
+stored when the background configuration has persistence enabled, matching
+location, geofence, activity, and HTTP sync events. Android does not synthesize
+Core Location lifecycle events.
+
+## Migrate lifecycle listeners
+
+`onLocationLifecycleChange()` remains as a convenience API, but in 2.x it is a
+filter over the unified stream rather than a separate native listener channel.
+Existing call sites can remain unchanged:
+
+```ts
+import { onLocationLifecycleChange } from 'react-native-nitro-geolocation/background';
+
+const subscription = onLocationLifecycleChange(({ state }) => {
+  if (state === 'paused') showPausedTrackingState();
+});
+```
+
+The behavior is still observational. A pause does not automatically restart
+tracking, and start/stop calls do not fabricate lifecycle events.
+
+## Update exhaustive event handling
+
+`BackgroundEvent` now includes the `lifecycle` discriminant. Add that case to
+exhaustive switches before upgrading. The native-only
+`addLocationLifecycleListener` and `removeLocationLifecycleListener` methods
+are no longer part of the generated Nitro contract; application code should
+use the public functions above.

--- a/docs/docs/v2/guide/watch-observability.md
+++ b/docs/docs/v2/guide/watch-observability.md
@@ -1,0 +1,126 @@
+# Watch observability
+
+Use `getActiveWatches()` to inspect the Modern API watches that currently own
+native position or heading subscriptions:
+
+```ts
+import {
+  getActiveWatches,
+  stopObserving,
+  unwatch,
+  watchPosition,
+} from 'react-native-nitro-geolocation';
+
+const token = watchPosition(
+  (position) => console.log(position.coords),
+  (error) => console.error(error),
+  { distanceFilter: 10 },
+);
+
+console.log(getActiveWatches());
+// [{ token: '...', kind: 'position' }]
+
+unwatch(token);
+console.log(getActiveWatches()); // []
+
+// Emergency or session-level cleanup:
+stopObserving();
+```
+
+`getActiveWatches()` is a synchronous, point-in-time snapshot. It does not
+request permission, start a provider, retain callbacks, or subscribe to future
+changes. Entries are sorted by token and contain:
+
+- `token`: the value accepted by `unwatch()`.
+- `kind`: `position` for `watchPosition()` or `heading` for `watchHeading()`.
+
+The snapshot covers the Modern API root import. It does not include Compat API
+watches, one-shot position or heading requests, or Background Location.
+Android watches that finish because of `maxUpdates` disappear from the next
+snapshot automatically. Web snapshots include active browser position watches;
+unsupported web heading requests are not reported as active.
+
+## Cleanup semantics
+
+- `unwatch(token)` removes a matching position or heading watch. Repeating it,
+  or passing an unknown token, is safe and has no effect.
+- `stopObserving()` removes every Modern API position and heading watch,
+  including development-tool and browser watches. It does not cancel one-shot
+  position requests or Background Location. On iOS it also leaves one-shot
+  heading requests running. On Android, the current native heading manager
+  discards pending one-shot heading requests and their timeouts without invoking
+  a callback; avoid calling `stopObserving()` while `getHeading()` is pending.
+- `useWatchPosition()` owns its token and calls `unwatch()` during React effect
+  cleanup. Low-level `watchPosition()` callers own cleanup themselves.
+- On Android, adding or removing a position watch restarts the one shared native
+  position request when another watch remains. On iOS, it reconfigures the
+  shared `CLLocationManager`; it restarts only when the selected Core Location
+  mode changes.
+
+## Watch Manager v2 default
+
+Multiple position watches share native resources. Options are merged to serve
+the most demanding active acquisition, while callback delivery is evaluated
+against each subscription's own thresholds. A one-shot request or a second
+watch may make native acquisition more demanding, but cannot lower an existing
+watch's delivery threshold or move its last-delivered baseline.
+
+### Android
+
+Active position watches share one Fused Location or platform request. The
+native request uses:
+
+- the most demanding accuracy;
+- the smallest `interval`, `fastestInterval`, `distanceFilter`,
+  `maxUpdateAge`, and `maxUpdateDelay` values;
+- `waitForAccurateLocation` when any watch requests it;
+- coarse granularity when any watch explicitly requires coarse, otherwise fine
+  when any watch explicitly requires fine, otherwise permission granularity.
+
+`maxUpdates` remains per subscription. Reaching the limit removes only that
+watch, then stops or restarts the shared request as needed. For callback
+delivery, the first native position establishes each watch's baseline. Later
+positions must satisfy that watch's own `interval` and `distanceFilter`, both
+measured from its last delivered position; suppressed native updates do not move
+the baseline or count toward `maxUpdates`. `fastestInterval` still contributes
+to the shared native request, while `interval` is the per-watch minimum callback
+period. Position watch registration, removal, native restart decisions, and
+callback delivery are serialized on Android's main looper. `unwatch()` prevents
+delivery from subsequent native updates, but a callback already handed to the
+asynchronous JS bridge may still finish. Heading watches use the Android sensor
+manager separately and apply each subscription's `headingFilter` independently.
+
+### iOS
+
+Position watches and pending one-shot position requests share one
+`CLLocationManager`. The manager uses:
+
+- the most precise requested accuracy and smallest distance filter;
+- the highest-ranked activity type used by the current implementation;
+- automatic pausing only when every explicit preference allows it;
+- the background indicator or significant-change mode when any consumer asks
+  for it.
+
+Changing significant-change mode stops and restarts Core Location. Other
+position option changes reconfigure the existing manager. Each position watch
+receives its first native position, then applies its own `distanceFilter` from
+the last position delivered to that watch. A nearby update accepted for a more
+demanding watch or one-shot request no longer leaks into a less frequent watch.
+Core Location does not expose the Android `interval` option. Heading watches
+share the same manager's heading sensor separately and apply each subscription's
+`headingFilter` independently.
+
+### Web
+
+Each position watch maps to its own `navigator.geolocation.watchPosition()`
+call. Browser watches are not merged. The package applies each watch's
+`distanceFilter` in JavaScript.
+
+## Migration note
+
+The v1.x native managers delivered every shared native position to every watch,
+so adding a more demanding watch or one-shot request could increase callbacks
+for existing consumers. In v2, code that intentionally relied on that leakage
+must lower the affected watch's own `interval` or `distanceFilter`. Continue to
+call `unwatch(token)` for component-local cleanup and reserve `stopObserving()`
+for session-wide cleanup.

--- a/docs/docs/v2/guide/why-nitro-module.md
+++ b/docs/docs/v2/guide/why-nitro-module.md
@@ -1,0 +1,129 @@
+# Why Nitro Module?
+
+The **Nitro Module** system provides the next generation of native modules for React Native.
+Instead of using the bridge-based approach (JSON serialization between JS and native), Nitro Modules communicate directly through **JSI (JavaScript Interface)**.
+
+This enables:
+
+- ⚡ **Direct native calls** — reduced overhead
+- 🧠 **Synchronous APIs** for critical paths
+- 🔧 **Better integration** with the new Fabric renderer
+- 🧩 **Cross-platform consistency** and simpler maintenance
+
+In short, Nitro Geolocation builds on the proven API design of
+`@react-native-community/geolocation` while leveraging the new React Native
+architecture, providing a **forward-compatible foundation** with a
+migration-friendly `/compat` API.
+
+## Architecture Comparison
+
+### Origin: Event-based Architecture (`@react-native-community/geolocation`)
+
+```
+JavaScript Layer
+  ↓ EventEmitter.addListener('geolocationDidChange', callback)
+  ↓ (Callback stored in JS only)
+React Native Bridge (JSON serialization)
+  ↓
+Native Layer (Android/iOS)
+  ↓ LocationListener receives updates
+  ↓ emit('geolocationDidChange', data) → Bridge
+  ↓
+EventEmitter dispatches to all listeners
+  ↓
+User callback executed
+```
+
+**Key characteristics:**
+- Callbacks **not passed** to native — stored in JS EventEmitter
+- Native emits generic events through Bridge
+- Multiple listeners share one event stream
+- Requires JSON serialization on every update
+
+### Modern API: Direct Callback Architecture (`React Native Nitro Geolocation`)
+
+```
+JavaScript Layer
+  ↓ nitroGeolocation.watchPosition(success, error, options)
+  ↓ (Callbacks passed directly to native via JSI)
+JSI Layer (No Bridge!)
+  ↓
+Native Layer (Kotlin/Swift)
+  ↓ LocationListener receives updates
+  ↓ callback.success(position) → JSI direct call
+  ↓
+User callback executed immediately
+```
+
+**Key characteristics:**
+- Callbacks **passed directly** to native as JSI function references
+- Native calls JS functions directly (no Bridge)
+- Each watch has its own callback (no shared event stream)
+- Minimal serialization (C++ structs → JS objects)
+
+## Hook Layer
+
+React Native Nitro Geolocation now provides a React-friendly layer on top of the JSI architecture:
+
+```
+User Code (React Components)
+  ↓ useWatchPosition({ enabled: true })
+  ↓ Declarative, auto-cleanup
+Modern API Layer (direct functions + hooks)
+  ↓ watchPosition(callback)
+JSI Layer (Nitro Modules)
+  ↓ Direct callbacks, no Bridge
+Native Layer (Kotlin/Swift)
+  ↓ CLLocationManager / FusedLocationProvider
+Device GPS/Network
+```
+
+**Benefits of Hook Layer**:
+- **TanStack Query-inspired**: Familiar patterns for React developers
+- **Declarative**: `{ enabled }` prop instead of imperative start/stop
+- **Auto-cleanup**: No manual `clearWatch()` required
+- **Type-safe**: Full TypeScript inference
+- **Best practices**: Encourages proper React patterns
+
+**Architecture Layers**:
+1. **Presentation** (Hooks): `useWatchPosition`
+2. **Modern API** (Functions): `getCurrentPosition`, `watchPosition`, `unwatch`
+3. **JSI Bridge** (Nitro): Direct native communication
+4. **Native** (Platform): iOS/Android location APIs
+
+## How JSI Enables Direct Callbacks
+
+Nitro Modules use **Nitrogen** code generation to create JSI bindings:
+
+1. **TypeScript spec** (`NitroGeolocation.nitro.ts`) defines the interface
+2. **Nitrogen generates C++ code** that bridges Kotlin/Swift ↔ JSI
+3. **HybridObject** in native code implements the spec
+4. **JSI** holds references to JS functions and calls them directly
+
+**Result:** When `watchPosition(callback)` is called, the `callback` function becomes a JSI function reference in native code, callable without the Bridge.
+
+## When to Use Each Approach
+
+### Use Event-based if:
+- Supporting React Native < 0.68
+- Team unfamiliar with JSI/New Architecture
+- Stability over performance
+
+### Use Nitro (Direct Callback) if:
+- Performance-critical (real-time tracking, animations)
+- Using React Native New Architecture
+- Need type safety at compile-time
+- Building for the future
+
+## Summary
+
+`React Native Nitro Geolocation` transforms the geolocation API at multiple levels:
+
+1. **Low-level**: Bridge-based events → JSI direct callbacks (Nitro Modules)
+2. **High-level**: Imperative callbacks → Declarative hooks (Modern API)
+
+This provides:
+- **Performance**: Native-level speed via JSI
+- **Developer Experience**: React-friendly hooks with TanStack Query patterns
+- **Flexibility**: Choose Modern API (hooks) or Compat API (callbacks)
+- **Compatibility**: Drop-in compatible with the core native community API via `/compat`

--- a/docs/docs/v2/index.md
+++ b/docs/docs/v2/index.md
@@ -1,0 +1,47 @@
+---
+pageType: home
+
+hero:
+  name: React Native Nitro Geolocation
+  text: 2.x release candidate documentation
+  tagline: Preview the breaking 2.x contracts, migration paths, and unified background APIs before the stable release.
+  actions:
+    - theme: brand
+      text: Read the 2.x guide
+      link: /guide/
+    - theme: alt
+      text: Review migrations
+      link: /guide/v2-error-migration/
+  image:
+    src: /logo.png
+    alt: Nitro Geolocation Logo
+
+features:
+  - title: Simple Functional API
+    details: Direct function calls and a single hook for tracking. No complex abstractions, just simple and effective.
+    icon: 🎯
+  - title: Fully native implementation
+    details: Access device geolocation data through JSI and Nitro Modules for maximum performance.
+    icon: 📡
+  - title: Drop-in replacement (via /compat)
+    details: Compat API is drop-in compatible with the core native @react-native-community/geolocation API for easy migration.
+    icon: 🔁
+  - title: Consistent Android & iOS behavior
+    details: Unified permission handling, background location consistency, and improved accuracy tuning.
+    icon: 📱
+  - title: Direct JSI communication
+    details: Built with Nitro Modules, enabling direct JS-to-native calls without bridge serialization overhead.
+    icon: ⚙️
+  - title: Automatic cleanup
+    details: useWatchPosition automatically manages subscriptions with component lifecycle—no manual cleanup needed.
+    icon: 🧹
+  - title: DevTools Plugin for Rozenite
+    details: Mock locations in development with an interactive map interface, city presets, and keyboard controls.
+    icon: 🛠️
+  - title: TypeScript ready
+    details: Full type definitions for all APIs with complete type inference for functions and hooks.
+    icon: 📘
+  - title: Easy integration
+    details: Works in bare React Native, RN CLI, Expo development builds, and other custom native builds.
+    icon: 🧩
+---

--- a/docs/docs/v2/index.md
+++ b/docs/docs/v2/index.md
@@ -8,10 +8,10 @@ hero:
   actions:
     - theme: brand
       text: Read the 2.x guide
-      link: /guide/
+      link: /v2/guide/index.html
     - theme: alt
       text: Review migrations
-      link: /guide/v2-error-migration/
+      link: /v2/guide/v2-error-migration.html
   image:
     src: /logo.png
     alt: Nitro Geolocation Logo

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "rspress build",
+    "check:versions": "node scripts/check-version-sources.mjs && node scripts/check-version-routes.mjs",
     "dev": "rspress dev",
     "preview": "rspress preview",
     "typecheck": "tsc --noEmit"

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   icon: "/logo.png",
   logo: "/logo.png",
   logoText: "React Native Nitro Geolocation",
+  multiVersion: {
+    default: "v1",
+    versions: ["v1", "v2"]
+  },
+  route: {
+    exclude: ["./index.md", "./guide/**", "./background/**"]
+  },
   head: [
     [
       "meta",

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -1,5 +1,37 @@
 import * as path from "node:path";
-import { defineConfig } from "@rspress/core";
+import { type RspressPlugin, defineConfig } from "@rspress/core";
+
+const v2OnlyRoutes = [
+  "background/location-lifecycle",
+  "background/reliability-contract",
+  "guide/consumer-e2e-contract-kit",
+  "guide/gps-offline-recipe",
+  "guide/install-doctor",
+  "guide/privacy-compliance",
+  "guide/swift-package-manager",
+  "guide/v2-error-migration",
+  "guide/v2-unified-background-events",
+  "guide/watch-observability"
+];
+
+const versionFallbacks: RspressPlugin = {
+  name: "version-fallbacks",
+  addPages() {
+    return v2OnlyRoutes.map((route) => ({
+      routePath: `/${route}`,
+      content: `---
+title: Available in 2.x
+---
+
+# Available in 2.x
+
+This page documents a 2.x feature and is not part of the 1.x API snapshot.
+
+[Open the 2.x page](/v2/${route}.html) or [return to the 1.x guide](/guide/index.html).
+`
+    }));
+  }
+};
 
 export default defineConfig({
   root: path.join(__dirname, "docs"),
@@ -15,6 +47,7 @@ export default defineConfig({
   route: {
     exclude: ["./index.md", "./guide/**", "./background/**"]
   },
+  plugins: [versionFallbacks],
   head: [
     [
       "meta",

--- a/docs/scripts/check-version-routes.mjs
+++ b/docs/scripts/check-version-routes.mjs
@@ -1,0 +1,48 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const buildRoot = path.resolve(import.meta.dirname, "../doc_build");
+const requiredRoutes = [
+  "index.html",
+  "guide/modern-api.html",
+  "v2/index.html",
+  "v2/guide/modern-api.html",
+  "v2/guide/swift-package-manager.html",
+  "v2/guide/v2-unified-background-events.html",
+  "background/location-lifecycle.html",
+  "background/reliability-contract.html",
+  "guide/consumer-e2e-contract-kit.html",
+  "guide/gps-offline-recipe.html",
+  "guide/install-doctor.html",
+  "guide/privacy-compliance.html",
+  "guide/swift-package-manager.html",
+  "guide/v2-error-migration.html",
+  "guide/v2-unified-background-events.html",
+  "guide/watch-observability.html"
+];
+
+await Promise.all(
+  requiredRoutes.map(async (route) => {
+    try {
+      await access(path.join(buildRoot, route));
+    } catch {
+      throw new Error(`Missing versioned documentation route: ${route}`);
+    }
+  })
+);
+
+const v2Home = await readFile(path.join(buildRoot, "v2/index.html"), "utf8");
+const requiredV2Links = [
+  "/v2/guide/index.html",
+  "/v2/guide/v2-error-migration.html"
+];
+
+for (const href of requiredV2Links) {
+  if (!v2Home.includes(`href="${href}"`)) {
+    throw new Error(`The v2 home page does not link to its v2 route: ${href}`);
+  }
+}
+
+console.log(
+  `Versioned documentation routes OK: ${requiredRoutes.length} checked.`
+);

--- a/docs/scripts/check-version-sources.mjs
+++ b/docs/scripts/check-version-sources.mjs
@@ -1,0 +1,54 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const docsRoot = path.resolve(import.meta.dirname, "../docs");
+const v2Root = path.join(docsRoot, "v2");
+
+async function listFiles(directory, prefix = "") {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const relativePath = path.posix.join(prefix, entry.name);
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await listFiles(path.join(directory, entry.name), relativePath))
+      );
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+const canonicalFiles = (await listFiles(docsRoot)).filter(
+  (file) =>
+    !file.startsWith("public/") &&
+    !file.startsWith("v1/") &&
+    !file.startsWith("v2/")
+);
+const v2Files = await listFiles(v2Root);
+
+if (canonicalFiles.join("\n") !== v2Files.join("\n")) {
+  throw new Error(
+    "The canonical and v2 documentation file lists differ. Mirror every excluded canonical source into docs/v2."
+  );
+}
+
+for (const file of canonicalFiles) {
+  const [canonical, versioned] = await Promise.all([
+    readFile(path.join(docsRoot, file)),
+    readFile(path.join(v2Root, file))
+  ]);
+
+  if (!canonical.equals(versioned)) {
+    throw new Error(
+      `The excluded canonical source has drifted from docs/v2: ${file}`
+    );
+  }
+}
+
+console.log(
+  `Versioned documentation sources OK: ${canonicalFiles.length} mirrored.`
+);

--- a/docs/scripts/check-version-sources.mjs
+++ b/docs/scripts/check-version-sources.mjs
@@ -47,6 +47,18 @@ for (const file of canonicalFiles) {
       `The excluded canonical source has drifted from docs/v2: ${file}`
     );
   }
+
+  if (file.endsWith(".md")) {
+    for (const line of versioned.toString("utf8").split("\n")) {
+      const tokens = line.trim().split(/\s+/);
+      if (
+        tokens.includes("react-native-nitro-geolocation") &&
+        !tokens.includes("react-native-nitro-geolocation@rc")
+      ) {
+        throw new Error(`The v2 install command is not pinned to @rc: ${file}`);
+      }
+    }
+  }
 }
 
 console.log(


### PR DESCRIPTION
## Summary

- publish the last stable 1.x documentation from `react-native-nitro-geolocation@1.4.3` as the default snapshot
- publish a separate `/v2` RC guide containing every prepared 2.0 roadmap contract, migration, background-event, Watch Manager, install-doctor, Expo, privacy, consumer E2E, and RN 0.87 SwiftPM boundary
- install the prerelease explicitly with `react-native-nitro-geolocation@rc`, while 1.x remains npm `latest`
- keep the flat docs as the excluded canonical 2.x source and require byte-identical mirrors under `docs/v2`, so a later docs-bearing feature change cannot be silently unpublished
- provide 1.x fallback pages for v2-only version-switch targets instead of returning 404
- use an empty changeset because this changes documentation only

## Merge order

Merge after the prepared docs-bearing feature PRs (#167, #171-#177). The canonical-to-v2 CI contract makes any drift visible if one changes before this PR lands. The PR remains based directly on `main`; it is not an unnecessary stacked PR.

## Validation

- v1 snapshot matches `react-native-nitro-geolocation@1.4.3` byte-for-byte (29 files)
- canonical 2.x sources and `docs/v2` match byte-for-byte (39 files)
- Rspress emits default v1 routes, `/v2` routes, and all ten v2-only fallback routes
- built v2 home CTAs are pinned to existing `/v2` HTML routes
- `yarn format:check`
- `yarn lint`
- `yarn typecheck`
- `yarn build:all`
- `yarn deadcode:prod`
- `yarn pack:check`
- `yarn source-lines:check`
- `yarn changeset status --output=...` (`2.0.0-rc.0`, pre tag `rc`)

No mobile E2E was run because this PR cannot affect runtime behavior.
