### PR TITLE
fix: keep RC workspace lockfile immutable

### DIFF
--- a/.changeset/calm-workspaces-sync.md
+++ b/.changeset/calm-workspaces-sync.md
@@ -1,0 +1,5 @@
+---
+---
+
+Normalize the example app workspace protocol so Changesets release PRs keep
+the generated lockfile immutable without changing published package behavior.

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -33,7 +33,7 @@
     "@react-navigation/native": "^7.1.26",
     "react": "19.1.0",
     "react-native": "0.81.1",
-    "react-native-nitro-geolocation": "workspace: *",
+    "react-native-nitro-geolocation": "workspace:*",
     "react-native-nitro-modules": "^0.35.10",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "4.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14760,7 +14760,7 @@ __metadata:
     react-native: "npm:0.81.1"
     react-native-builder-bob: "npm:^0.40.13"
     react-native-monorepo-config: "npm:^0.1.9"
-    react-native-nitro-geolocation: "workspace: *"
+    react-native-nitro-geolocation: "workspace:*"
     react-native-nitro-modules: "npm:^0.35.10"
     react-native-safe-area-context: "npm:^5.5.2"
     react-native-screens: "npm:4.19.0"
@@ -14789,7 +14789,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-nitro-geolocation@workspace: *, react-native-nitro-geolocation@workspace:*, react-native-nitro-geolocation@workspace:packages/react-native-nitro-geolocation":
+"react-native-nitro-geolocation@workspace:*, react-native-nitro-geolocation@workspace:packages/react-native-nitro-geolocation":
   version: 0.0.0-use.local
   resolution: "react-native-nitro-geolocation@workspace:packages/react-native-nitro-geolocation"
   dependencies:


### PR DESCRIPTION
## Summary

- normalize the example dependency from `workspace: *` to the canonical `workspace:*` protocol
- regenerate the Yarn lockfile so Changesets keeps the workspace selector stable while producing prerelease PRs
- add an empty changeset because this only fixes release automation and does not change the published package

## Reproduction and validation

- reproduced #153 CI failures after `changeset version` rewrote the non-canonical workspace range to `workspace:2.0.0-rc.0` without regenerating `yarn.lock`
- ran `yarn changeset version` in an isolated worktree with this patch; the dependency remained `workspace:*`
- verified `yarn install --immutable` succeeds after versioning
- `yarn install --immutable`
- `yarn format:check`
- `yarn lint`
- `yarn changeset status --since=origin/main`

No runtime code is affected, so mobile E2E is not required for this fix.