### PR TITLE
fix: use Changesets v3 release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,7 @@ jobs:
         run: yarn install
 
       - name: Create release PR or publish packages
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          publish: yarn changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: yarn changeset publish


### PR DESCRIPTION
## Summary

- upgrade the release workflow to `changesets/action@v2`, which supports Changesets CLI v3
- migrate the renamed `publish-script` and `github-token` inputs
- keep the RC publish command unchanged

## Root cause

`changesets/action@v1` uses the Changesets v2 prerelease state layout and tried to read `.changeset/pre/changes.md`. This repository uses `@changesets/cli@3.0.0`, whose prerelease state layout is supported by action v2.

## Validation

- `actionlint .github/workflows/release.yml`
- `yarn format:check .github/workflows/release.yml`
- `yarn changeset status`
- `yarn pack:check`
- `git diff --check`

No runtime code changed, so device E2E is not applicable.