### PR TITLE
fix: configure Yarn release authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,6 @@ jobs:
           mise trust --yes
           mise install node
 
-      - name: Configure npm registry
-        run: |
-          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
-
       - name: Enable Corepack
         run: |
           corepack enable
@@ -51,3 +46,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           publish-script: yarn changeset publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org


### PR DESCRIPTION
## Summary

- provide the npm token through Yarn 4’s `YARN_NPM_AUTH_TOKEN` setting
- explicitly publish to the npm registry
- remove the ineffective `.npmrc` placeholder that Yarn did not consume

## Root cause

The release reached `yarn changeset publish`, but Yarn 4 reported `YN0033: No authentication configured for request`. The repository secret exists; it was not mapped into Yarn’s `npmAuthToken` setting.

## Validation

- `actionlint .github/workflows/release.yml`
- `yarn format:check .github/workflows/release.yml`
- `yarn changeset status`
- `yarn pack:check`
- verified test values map to Yarn `npmAuthToken` and `npmPublishRegistry`
- `git diff --check`

No runtime code changed, so device E2E is not applicable.