### PR TITLE
fix: publish releases with npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,4 @@ jobs:
         uses: changesets/action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          publish-script: yarn changeset publish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
+          publish-script: yarn release:publish

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:check": "biome ci --formatter-enabled=true --linter-enabled=false .",
     "lint": "biome ci --formatter-enabled=false --linter-enabled=true .",
     "lint:fix": "biome check --write .",
+    "release:publish": "node scripts/publish-release.mjs",
     "test:unit": "yarn workspace react-native-nitro-geolocation test",
     "test:ios-location-lifecycle": "bash scripts/test-ios-location-lifecycle.sh",
     "test:e2e:web": "yarn workspace react-native-nitro-geolocation-web-e2e build",

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dryRun = process.argv.includes("--dry-run");
+
+const run = (command, args, { changesetsOutput = true } = {}) => {
+  const env = { ...process.env };
+  if (!changesetsOutput) {
+    env.CHANGESETS_OUTPUT = "";
+  }
+
+  execFileSync(command, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: "inherit"
+  });
+};
+
+const workspaceLocations = new Map(
+  execFileSync("yarn", ["workspaces", "list", "--json"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"]
+  })
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line))
+    .map((workspace) => [workspace.name, workspace.location])
+);
+const workDir = await mkdtemp(
+  path.join(tmpdir(), "nitro-geolocation-publish-")
+);
+const planPath = path.join(workDir, "publish-plan.json");
+
+try {
+  run("yarn", ["changeset", "publish-plan", "--output", planPath], {
+    changesetsOutput: false
+  });
+
+  const publishPlan = JSON.parse(await readFile(planPath, "utf8"));
+  const releases = publishPlan.plan
+    .flat()
+    .filter((release) => release.kind === "publish");
+
+  for (const release of releases) {
+    const workspaceLocation = workspaceLocations.get(release.name);
+    if (workspaceLocation === undefined) {
+      throw new Error(`Release workspace not found: ${release.name}`);
+    }
+
+    const args = [
+      "publish",
+      path.resolve(workspaceLocation),
+      "--access",
+      release.access,
+      "--tag",
+      release.tag,
+      "--registry",
+      "https://registry.npmjs.org",
+      "--loglevel",
+      "warn"
+    ];
+    if (dryRun) {
+      args.push("--dry-run");
+    }
+    run("npm", args);
+  }
+
+  if (!dryRun) {
+    run("yarn", ["changeset", "git-tag"]);
+  }
+} finally {
+  await rm(workDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- keep Changesets v3 responsible for the publish plan and release tags
- publish planned workspaces with npm CLI so the configured trusted publisher can use GitHub OIDC
- use npm’s package selection rules, avoiding Yarn pack accidentally including ignored Vitest cache podspecs
- add a non-publishing `--dry-run` path for release verification

## Root cause

Yarn 4 does not exchange the GitHub OIDC identity for npm trusted publishing. The repository’s legacy `NPM_TOKEN` is no longer authorized, so Yarn’s authenticated PUT was rejected with a masked 404. npm CLI 11.5.1+ supports trusted publishing and the workflow already grants `id-token: write`.

## Validation

- `yarn release:publish --dry-run`
  - planned `react-native-nitro-geolocation@2.0.0-rc.0`
  - selected `rc` dist-tag and public access
  - packed 566 files / 2,274,002 bytes
- `yarn pack:check` (same 566 files / 2,274,002 bytes)
- `actionlint .github/workflows/release.yml`
- targeted Biome format and lint
- `yarn source-lines:check`
- `git diff --check`

No runtime code changed, so device E2E is not applicable.