### PR TITLE
fix: tighten v2 public API contracts

### DIFF
--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -4,4 +4,6 @@
 
 Align the native and browser public API surfaces, export a named
 `UseWatchPositionResult`, and keep background function declarations expressed
-in public types instead of inferred Nitro spec signatures.
+in public types instead of inferred Nitro spec signatures. Background provider
+configuration now uses the same public `"android"` spelling as the root and
+compat APIs while retaining `"android_platform"` only inside the Nitro bridge.

--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -7,3 +7,5 @@ Align the native and browser public API surfaces, export a named
 in public types instead of inferred Nitro spec signatures. Background provider
 configuration now uses the same public `"android"` spelling as the root and
 compat APIs while retaining `"android_platform"` only inside the Nitro bridge.
+The `LocationErrorCode` type and `LocationErrorCodes` runtime constants now
+have distinct names so type-only and value imports are unambiguous.

--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -1,0 +1,7 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Align the native and browser public API surfaces, export a named
+`UseWatchPositionResult`, and keep background function declarations expressed
+in public types instead of inferred Nitro spec signatures.

--- a/docs/docs/background/start-stop.md
+++ b/docs/docs/background/start-stop.md
@@ -37,6 +37,7 @@ async function startIfAllowed(permission) {
       distanceFilter: 25,
       persist: true,
       android: {
+        locationProvider: 'auto',
         foregroundService: {
           notificationTitle: 'Location tracking active',
           notificationText: 'Your location is being recorded',
@@ -55,6 +56,11 @@ export async function stopTracking() {
   subscription = undefined;
 }
 ```
+
+`android.locationProvider` uses the same public values as the root API:
+`'auto'`, `'playServices'`, or `'android'`. Use `'android'` to force the
+platform `LocationManager`; the Nitro-only `'android_platform'` spelling is not
+part of the public API.
 
 Use [Activity Recognition](/background/activity-recognition) before switching to
 `trackingMode: 'activityAware'`. Use [Android Setup](/background/setup-android)

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -634,7 +634,7 @@ fields. Compat callers can opt into equivalent metadata by setting
 
 ```tsx
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   watchPosition,
   unwatch,
 } from 'react-native-nitro-geolocation';
@@ -644,7 +644,7 @@ const token = watchPosition(
     console.log(position.coords.latitude, position.coords.longitude);
   },
   (error) => {
-    if (error.code === LocationErrorCode.SETTINGS_NOT_SATISFIED) {
+    if (error.code === LocationErrorCodes.SETTINGS_NOT_SATISFIED) {
       // Device/provider settings do not satisfy the request.
     }
     // error.message: Human-readable error
@@ -655,7 +655,7 @@ unwatch(token);
 ```
 
 Starting in 2.0, Modern API errors use readable string discriminants. Keep
-comparisons against the `LocationErrorCode` members shown below instead of
+comparisons against the `LocationErrorCodes` members shown below instead of
 copying their values. The expanded modern-only native setup/provider members
 (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
 `SETTINGS_NOT_SATISFIED`) were originally added in v1.2; 2.0 keeps those member

--- a/docs/docs/guide/service-migration.md
+++ b/docs/docs/guide/service-migration.md
@@ -12,7 +12,7 @@ import {
   getCurrentPosition,
   getLastKnownPosition,
   hasServicesEnabled,
-  LocationErrorCode,
+  LocationErrorCodes,
   requestPermission,
   requestLocationSettings,
   setConfiguration,

--- a/docs/docs/guide/v2-error-migration.md
+++ b/docs/docs/guide/v2-error-migration.md
@@ -10,12 +10,12 @@ API with readable string discriminants. This is a Modern API change only. The
 
 ## Update comparisons
 
-Keep comparisons against `LocationErrorCode` instead of copying either the old
+Keep comparisons against `LocationErrorCodes` instead of copying either the old
 number or the new string into application code:
 
 ```diff
  import {
-   LocationErrorCode,
+   LocationErrorCodes,
    getCurrentPosition
  } from 'react-native-nitro-geolocation';
 
@@ -25,7 +25,7 @@ number or the new string into application code:
 -  if ((error as { code?: number }).code === 1) {
 +  if (
 +    (error as { code?: string }).code ===
-+    LocationErrorCode.PERMISSION_DENIED
++    LocationErrorCodes.PERMISSION_DENIED
 +  ) {
      showPermissionHelp();
    }
@@ -34,7 +34,7 @@ number or the new string into application code:
 
 The constants now carry their meaning in logs and serialized data:
 
-| 1.x number | 2.x `LocationErrorCode` | 2.x wire value |
+| 1.x number | 2.x `LocationErrorCodes` member | 2.x wire value |
 | ---: | --- | --- |
 | `-1` | `INTERNAL_ERROR` | `internalError` |
 | `1` | `PERMISSION_DENIED` | `permissionDenied` |
@@ -51,7 +51,7 @@ needs a trusted location code:
 ```tsx
 import {
   isLocationErrorCode,
-  LocationErrorCode
+  LocationErrorCodes
 } from 'react-native-nitro-geolocation';
 
 function describeLocationFailure(error: unknown): string {
@@ -61,7 +61,7 @@ function describeLocationFailure(error: unknown): string {
     return 'Unexpected location failure';
   }
 
-  if (candidate.code === LocationErrorCode.TIMEOUT) {
+  if (candidate.code === LocationErrorCodes.TIMEOUT) {
     return 'Location took too long. Try again.';
   }
 

--- a/docs/docs/v2/background/start-stop.md
+++ b/docs/docs/v2/background/start-stop.md
@@ -37,6 +37,7 @@ async function startIfAllowed(permission) {
       distanceFilter: 25,
       persist: true,
       android: {
+        locationProvider: 'auto',
         foregroundService: {
           notificationTitle: 'Location tracking active',
           notificationText: 'Your location is being recorded',
@@ -55,6 +56,11 @@ export async function stopTracking() {
   subscription = undefined;
 }
 ```
+
+`android.locationProvider` uses the same public values as the root API:
+`'auto'`, `'playServices'`, or `'android'`. Use `'android'` to force the
+platform `LocationManager`; the Nitro-only `'android_platform'` spelling is not
+part of the public API.
 
 Use [Activity Recognition](/background/activity-recognition) before switching to
 `trackingMode: 'activityAware'`. Use [Android Setup](/background/setup-android)

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -634,7 +634,7 @@ fields. Compat callers can opt into equivalent metadata by setting
 
 ```tsx
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   watchPosition,
   unwatch,
 } from 'react-native-nitro-geolocation';
@@ -644,7 +644,7 @@ const token = watchPosition(
     console.log(position.coords.latitude, position.coords.longitude);
   },
   (error) => {
-    if (error.code === LocationErrorCode.SETTINGS_NOT_SATISFIED) {
+    if (error.code === LocationErrorCodes.SETTINGS_NOT_SATISFIED) {
       // Device/provider settings do not satisfy the request.
     }
     // error.message: Human-readable error
@@ -655,7 +655,7 @@ unwatch(token);
 ```
 
 Starting in 2.0, Modern API errors use readable string discriminants. Keep
-comparisons against the `LocationErrorCode` members shown below instead of
+comparisons against the `LocationErrorCodes` members shown below instead of
 copying their values. The expanded modern-only native setup/provider members
 (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
 `SETTINGS_NOT_SATISFIED`) were originally added in v1.2; 2.0 keeps those member

--- a/docs/docs/v2/guide/service-migration.md
+++ b/docs/docs/v2/guide/service-migration.md
@@ -12,7 +12,7 @@ import {
   getCurrentPosition,
   getLastKnownPosition,
   hasServicesEnabled,
-  LocationErrorCode,
+  LocationErrorCodes,
   requestPermission,
   requestLocationSettings,
   setConfiguration,

--- a/docs/docs/v2/guide/v2-error-migration.md
+++ b/docs/docs/v2/guide/v2-error-migration.md
@@ -10,12 +10,12 @@ API with readable string discriminants. This is a Modern API change only. The
 
 ## Update comparisons
 
-Keep comparisons against `LocationErrorCode` instead of copying either the old
+Keep comparisons against `LocationErrorCodes` instead of copying either the old
 number or the new string into application code:
 
 ```diff
  import {
-   LocationErrorCode,
+   LocationErrorCodes,
    getCurrentPosition
  } from 'react-native-nitro-geolocation';
 
@@ -25,7 +25,7 @@ number or the new string into application code:
 -  if ((error as { code?: number }).code === 1) {
 +  if (
 +    (error as { code?: string }).code ===
-+    LocationErrorCode.PERMISSION_DENIED
++    LocationErrorCodes.PERMISSION_DENIED
 +  ) {
      showPermissionHelp();
    }
@@ -34,7 +34,7 @@ number or the new string into application code:
 
 The constants now carry their meaning in logs and serialized data:
 
-| 1.x number | 2.x `LocationErrorCode` | 2.x wire value |
+| 1.x number | 2.x `LocationErrorCodes` member | 2.x wire value |
 | ---: | --- | --- |
 | `-1` | `INTERNAL_ERROR` | `internalError` |
 | `1` | `PERMISSION_DENIED` | `permissionDenied` |
@@ -51,7 +51,7 @@ needs a trusted location code:
 ```tsx
 import {
   isLocationErrorCode,
-  LocationErrorCode
+  LocationErrorCodes
 } from 'react-native-nitro-geolocation';
 
 function describeLocationFailure(error: unknown): string {
@@ -61,7 +61,7 @@ function describeLocationFailure(error: unknown): string {
     return 'Unexpected location failure';
   }
 
-  if (candidate.code === LocationErrorCode.TIMEOUT) {
+  if (candidate.code === LocationErrorCodes.TIMEOUT) {
     return 'Location took too long. Try again.';
   }
 

--- a/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
+++ b/examples/v0.81.1/src/screens/AccuracyPresetsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition
 } from "react-native-nitro-geolocation";
 import type {
@@ -59,7 +59,7 @@ const isRetryableLocationError = (error: unknown) => {
     return true;
   }
 
-  return captureLocationError(error).code === LocationErrorCode.TIMEOUT;
+  return captureLocationError(error).code === LocationErrorCodes.TIMEOUT;
 };
 
 const sleep = (durationMs: number) =>
@@ -300,7 +300,7 @@ export default function AccuracyPresetsScreen() {
 
       setResult("denied", {
         status:
-          code === LocationErrorCode.PERMISSION_DENIED ? "passed" : "failed",
+          code === LocationErrorCodes.PERMISSION_DENIED ? "passed" : "failed",
         message: getDisplayErrorMessage(error)
       });
     }

--- a/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Text, View } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLocationErrorCodeName
 } from "react-native-nitro-geolocation";
@@ -31,35 +31,35 @@ const TIMEOUT_CONTRACT_OPTIONS = {
 
 const ERROR_CODE_CONTRACT = [
   {
-    code: LocationErrorCode.INTERNAL_ERROR,
-    name: getLocationErrorCodeName(LocationErrorCode.INTERNAL_ERROR),
+    code: LocationErrorCodes.INTERNAL_ERROR,
+    name: getLocationErrorCodeName(LocationErrorCodes.INTERNAL_ERROR),
     meaning: "Modern-only internal/native failure"
   },
   {
-    code: LocationErrorCode.PERMISSION_DENIED,
-    name: getLocationErrorCodeName(LocationErrorCode.PERMISSION_DENIED),
+    code: LocationErrorCodes.PERMISSION_DENIED,
+    name: getLocationErrorCodeName(LocationErrorCodes.PERMISSION_DENIED),
     meaning: "Permission was denied"
   },
   {
-    code: LocationErrorCode.POSITION_UNAVAILABLE,
-    name: getLocationErrorCodeName(LocationErrorCode.POSITION_UNAVAILABLE),
+    code: LocationErrorCodes.POSITION_UNAVAILABLE,
+    name: getLocationErrorCodeName(LocationErrorCodes.POSITION_UNAVAILABLE),
     meaning: "Position fix is unavailable"
   },
   {
-    code: LocationErrorCode.TIMEOUT,
-    name: getLocationErrorCodeName(LocationErrorCode.TIMEOUT),
+    code: LocationErrorCodes.TIMEOUT,
+    name: getLocationErrorCodeName(LocationErrorCodes.TIMEOUT),
     meaning: "Request timed out"
   },
   {
-    code: LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE,
+    code: LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE,
     name: getLocationErrorCodeName(
-      LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE
+      LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE
     ),
     meaning: "Modern-only Google Play Services failure"
   },
   {
-    code: LocationErrorCode.SETTINGS_NOT_SATISFIED,
-    name: getLocationErrorCodeName(LocationErrorCode.SETTINGS_NOT_SATISFIED),
+    code: LocationErrorCodes.SETTINGS_NOT_SATISFIED,
+    name: getLocationErrorCodeName(LocationErrorCodes.SETTINGS_NOT_SATISFIED),
     meaning: "Modern-only provider/settings failure"
   }
 ] as const;

--- a/examples/v0.81.1/src/screens/GeocodingScreen.tsx
+++ b/examples/v0.81.1/src/screens/GeocodingScreen.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   geocode,
   reverseGeocode
 } from "react-native-nitro-geolocation";
 import type {
   GeocodedLocation,
+  LocationErrorCode,
   ReverseGeocodedAddress
 } from "react-native-nitro-geolocation";
 import {
@@ -164,7 +165,7 @@ export default function GeocodingScreen() {
         status: "passed",
         message: await expectLocationError(
           () => geocode("   "),
-          LocationErrorCode.INTERNAL_ERROR
+          LocationErrorCodes.INTERNAL_ERROR
         )
       });
     } catch (error) {
@@ -179,7 +180,7 @@ export default function GeocodingScreen() {
         status: "passed",
         message: await expectLocationError(
           () => reverseGeocode(INVALID_COORDS),
-          LocationErrorCode.INTERNAL_ERROR
+          LocationErrorCodes.INTERNAL_ERROR
         )
       });
     } catch (error) {

--- a/examples/v0.81.1/src/screens/HeadingScreen.tsx
+++ b/examples/v0.81.1/src/screens/HeadingScreen.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getActiveWatches,
   getHeading,
   unwatch,
@@ -228,7 +228,7 @@ export default function HeadingScreen() {
               unwatch(token);
             }
             try {
-              assertLocationErrorCode(error, LocationErrorCode.INTERNAL_ERROR);
+              assertLocationErrorCode(error, LocationErrorCodes.INTERNAL_ERROR);
               resolve();
             } catch (assertionError) {
               reject(assertionError);
@@ -277,7 +277,7 @@ export default function HeadingScreen() {
       try {
         const locationError = assertLocationErrorCode(
           error,
-          LocationErrorCode.PERMISSION_DENIED
+          LocationErrorCodes.PERMISSION_DENIED
         );
         setResult(
           "denied",

--- a/examples/v0.81.1/src/screens/IOSAccuracyAuthorizationScreen.tsx
+++ b/examples/v0.81.1/src/screens/IOSAccuracyAuthorizationScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getAccuracyAuthorization,
   requestTemporaryFullAccuracy
 } from "react-native-nitro-geolocation";
@@ -123,7 +123,7 @@ export default function IOSAccuracyAuthorizationScreen() {
       try {
         const locationError = assertLocationErrorCode(
           error,
-          LocationErrorCode.INTERNAL_ERROR
+          LocationErrorCodes.INTERNAL_ERROR
         );
         setResult("invalid", {
           status: "passed",

--- a/examples/v0.81.1/src/screens/IOSLocationTuningScreen.tsx
+++ b/examples/v0.81.1/src/screens/IOSLocationTuningScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   unwatch,
   watchPosition
@@ -172,7 +172,7 @@ export default function IOSLocationTuningScreen() {
       try {
         const locationError = assertLocationErrorCode(
           error,
-          LocationErrorCode.PERMISSION_DENIED
+          LocationErrorCodes.PERMISSION_DENIED
         );
         setResult("denied", {
           status: "passed",

--- a/examples/v0.81.1/src/screens/Issue132Screen.tsx
+++ b/examples/v0.81.1/src/screens/Issue132Screen.tsx
@@ -37,7 +37,7 @@ const options: BackgroundLocationOptions = {
   stopOnTerminate: true,
   startOnBoot: false,
   android: {
-    locationProvider: "android_platform",
+    locationProvider: "android",
     requestNotificationPermission: false,
     foregroundService: {
       notificationTitle: "Issue 132 foreground listener",

--- a/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
+++ b/examples/v0.81.1/src/screens/LastKnownPositionScreen.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLastKnownPosition,
   getLastKnownPositionAsync
@@ -209,7 +209,7 @@ export default function LastKnownPositionScreen() {
       try {
         const locationError = assertLocationErrorCode(
           error,
-          LocationErrorCode.PERMISSION_DENIED
+          LocationErrorCodes.PERMISSION_DENIED
         );
         setResult("denied", {
           status: "passed",

--- a/examples/v0.81.1/src/screens/LocationAvailabilityScreen.tsx
+++ b/examples/v0.81.1/src/screens/LocationAvailabilityScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLocationAvailability,
   setConfiguration
@@ -103,7 +103,7 @@ export default function LocationAvailabilityScreen() {
         );
         throw new Error("Denied getCurrentPosition unexpectedly resolved.");
       } catch (error) {
-        assertLocationErrorCode(error, LocationErrorCode.PERMISSION_DENIED);
+        assertLocationErrorCode(error, LocationErrorCodes.PERMISSION_DENIED);
       }
 
       setResult("denied", {

--- a/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ProviderSettingsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLocationErrorCodeName,
   getProviderStatus,
@@ -87,8 +87,8 @@ export default function ProviderSettingsScreen() {
       if (permission !== "granted") {
         setSettingsStatus("permission required");
         setError({
-          code: LocationErrorCode.PERMISSION_DENIED,
-          name: getLocationErrorCodeName(LocationErrorCode.PERMISSION_DENIED),
+          code: LocationErrorCodes.PERMISSION_DENIED,
+          name: getLocationErrorCodeName(LocationErrorCodes.PERMISSION_DENIED),
           message: "Location permission is required before check-in."
         });
         return;

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/androidRequestOptions.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/androidRequestOptions.ts
@@ -1,5 +1,5 @@
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLastKnownPositionAsync,
   unwatch,
@@ -227,7 +227,7 @@ export const useAndroidRequestOptionsScenario = () => {
                 try {
                   const locationError = assertLocationErrorCode(
                     error,
-                    LocationErrorCode.INTERNAL_ERROR
+                    LocationErrorCodes.INTERNAL_ERROR
                   );
                   assertErrorMessageIncludes(
                     error,
@@ -286,7 +286,7 @@ export const useAndroidRequestOptionsScenario = () => {
       try {
         const locationError = assertLocationErrorCode(
           error,
-          LocationErrorCode.PERMISSION_DENIED
+          LocationErrorCodes.PERMISSION_DENIED
         );
         assertErrorMessageIncludes(
           error,

--- a/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
+++ b/examples/v0.81.1/src/screens/scenario/native-e2e/iosReleaseOptionsBridge.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Platform } from "react-native";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLastKnownPositionAsync,
   unwatch,
@@ -348,7 +348,7 @@ export const useIOSReleaseOptionsBridgeScenario = () => {
       setResult(
         "headingFilter",
         createScenarioResult(
-          locationError.code === LocationErrorCode.INTERNAL_ERROR &&
+          locationError.code === LocationErrorCodes.INTERNAL_ERROR &&
             locationError.message.includes("headingFilter")
             ? "passed"
             : "failed",

--- a/examples/v0.81.1/src/screens/scenario/utils/locationErrors.ts
+++ b/examples/v0.81.1/src/screens/scenario/utils/locationErrors.ts
@@ -1,8 +1,9 @@
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getLocationErrorCodeName,
   isLocationErrorCode
 } from "react-native-nitro-geolocation";
+import type { LocationErrorCode } from "react-native-nitro-geolocation";
 import type { CapturedLocationError } from "../types";
 
 /**
@@ -19,7 +20,7 @@ import type { CapturedLocationError } from "../types";
  *
  * @param {unknown} error - Unknown value caught from a native geolocation call.
  * If it has a known string `code` property, that code is used; otherwise the helper
- * falls back to `LocationErrorCode.INTERNAL_ERROR`.
+ * falls back to `LocationErrorCodes.INTERNAL_ERROR`.
  * @returns {CapturedLocationError} Normalized location error with string
  * `code`, human-readable `name` from `getLocationErrorCodeName`, and a string
  * `message` suitable for rendering in scenario UI.
@@ -28,7 +29,7 @@ export const captureLocationError = (error: unknown): CapturedLocationError => {
   const maybeError = error as { code?: unknown; message?: unknown };
   const code = isLocationErrorCode(maybeError.code)
     ? maybeError.code
-    : LocationErrorCode.INTERNAL_ERROR;
+    : LocationErrorCodes.INTERNAL_ERROR;
   const message =
     typeof maybeError.message === "string" ? maybeError.message : String(error);
 
@@ -71,7 +72,7 @@ export const getDisplayErrorMessage = (error: unknown) => {
  * ```ts
  * const locationError = assertLocationErrorCode(
  *   error,
- *   LocationErrorCode.PERMISSION_DENIED
+ *   LocationErrorCodes.PERMISSION_DENIED
  * );
  *
  * setResult(
@@ -83,7 +84,7 @@ export const getDisplayErrorMessage = (error: unknown) => {
  * @param {unknown} error - Unknown value caught from a native geolocation call.
  * The value is normalized before comparing codes.
  * @param {LocationErrorCode} expectedCode - Native `LocationErrorCode` expected
- * by the contract, such as `LocationErrorCode.PERMISSION_DENIED`.
+ * by the contract, such as `LocationErrorCodes.PERMISSION_DENIED`.
  * @returns {CapturedLocationError} Normalized location error when its code
  * matches `expectedCode`; screens can reuse it in pass messages.
  * @throws {Error} Throws when the normalized code differs from `expectedCode`.

--- a/examples/web-e2e/src/edgeCaseRunner.ts
+++ b/examples/web-e2e/src/edgeCaseRunner.ts
@@ -1,5 +1,5 @@
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   getCurrentPosition,
   getLocationReadiness,
   getPermissionDetails
@@ -23,7 +23,7 @@ export async function runDeniedCheck() {
     );
   } catch (error) {
     const code = getErrorCode(error);
-    if (code !== LocationErrorCode.PERMISSION_DENIED) {
+    if (code !== LocationErrorCodes.PERMISSION_DENIED) {
       setScenario(
         "permission-denied",
         "fail",
@@ -90,18 +90,18 @@ export async function runUnavailableCheck() {
   } catch (error) {
     const code = getErrorCode(error);
     const status =
-      code === LocationErrorCode.POSITION_UNAVAILABLE
+      code === LocationErrorCodes.POSITION_UNAVAILABLE
         ? "pass"
-        : code === LocationErrorCode.TIMEOUT
+        : code === LocationErrorCodes.TIMEOUT
           ? "manual"
           : "fail";
     setScenario(
       "position-unavailable",
       status,
       error,
-      code === LocationErrorCode.POSITION_UNAVAILABLE
+      code === LocationErrorCodes.POSITION_UNAVAILABLE
         ? "Browser returned POSITION_UNAVAILABLE."
-        : code === LocationErrorCode.TIMEOUT
+        : code === LocationErrorCodes.TIMEOUT
           ? "Browser returned TIMEOUT while provider/location services were disabled. Platform does not expose provider-disabled state."
           : `Expected POSITION_UNAVAILABLE or platform TIMEOUT, got ${String(code)}.`
     );
@@ -126,9 +126,9 @@ export async function runTimeoutCheck() {
     const code = getErrorCode(error);
     setScenario(
       "timeout",
-      code === LocationErrorCode.TIMEOUT ? "pass" : "manual",
+      code === LocationErrorCodes.TIMEOUT ? "pass" : "manual",
       error,
-      code === LocationErrorCode.TIMEOUT
+      code === LocationErrorCodes.TIMEOUT
         ? "Browser returned TIMEOUT."
         : `Got ${String(code)}. Timeout is browser/provider timing dependent.`
     );

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -1,6 +1,6 @@
 import {
   type GeolocationResponse,
-  LocationErrorCode,
+  LocationErrorCodes,
   type PermissionStatus,
   checkPermission,
   getCurrentPosition,
@@ -161,8 +161,8 @@ async function getCurrentPositionUntilSuccess(timeoutMs: number) {
       transientErrors.push(error);
       const code = getErrorCode(error);
       if (
-        (code !== LocationErrorCode.POSITION_UNAVAILABLE &&
-          code !== LocationErrorCode.TIMEOUT) ||
+        (code !== LocationErrorCodes.POSITION_UNAVAILABLE &&
+          code !== LocationErrorCodes.TIMEOUT) ||
         Date.now() - startedAt >= timeoutMs
       ) {
         throw error;
@@ -203,8 +203,8 @@ async function getCurrentPositionUntilExpected({
       transientErrors.push(error);
       const code = getErrorCode(error);
       if (
-        (code !== LocationErrorCode.POSITION_UNAVAILABLE &&
-          code !== LocationErrorCode.TIMEOUT) ||
+        (code !== LocationErrorCodes.POSITION_UNAVAILABLE &&
+          code !== LocationErrorCodes.TIMEOUT) ||
         Date.now() - startedAt >= timeoutMs
       ) {
         throw error;

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -3,7 +3,7 @@ import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsLastKnownPosition } from "../devtools/getLastKnownPosition";
 import type { GeolocationResponse } from "../publicTypes";
-import { LocationErrorCode } from "../utils/errors";
+import { LocationErrorCodes } from "../utils/errors";
 import { decoratePositionWithMetadata } from "./locationMetadata";
 import { readLastKnownPosition, rememberPosition } from "./positionCache";
 
@@ -60,7 +60,7 @@ export function getLastKnownPositionAsync(
       typeof error === "object" &&
       error !== null &&
       "code" in error &&
-      error.code === LocationErrorCode.POSITION_UNAVAILABLE
+      error.code === LocationErrorCodes.POSITION_UNAVAILABLE
     ) {
       return undefined;
     }

--- a/packages/react-native-nitro-geolocation/src/background/index.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.ts
@@ -3,17 +3,26 @@ import type { LocationError } from "../NitroGeolocation.nitro";
 import type { NitroBackgroundLocation } from "./NitroBackgroundLocation.nitro";
 import { createLocationLifecycleSubscription } from "./locationLifecycle";
 import type {
-  BackgroundActivityEventEnvelope,
+  ActivityRecognitionOptions,
   BackgroundEvent,
   BackgroundEventEnvelope,
-  BackgroundGeofenceEventEnvelope,
-  BackgroundHttpSyncEvent,
+  BackgroundHttpSyncResult,
   BackgroundLocation,
+  BackgroundLocationDiagnosis,
+  BackgroundLocationOptions,
   BackgroundLocationStatus,
+  BackgroundPermissionResult,
   BackgroundSubscription,
+  DetectedActivity,
+  GeofenceEvent,
+  GeofenceRegion,
+  GeofencingOptions,
+  GetStoredBackgroundEventsOptions,
+  GetStoredBackgroundLocationsOptions,
   LocationLifecycleEvent,
   StoredBackgroundEvent,
-  StoredBackgroundEventEnvelope
+  StoredBackgroundEventEnvelope,
+  StoredBackgroundLocation
 } from "./types";
 
 const NativeBackgroundLocation =
@@ -53,50 +62,66 @@ function narrowBackgroundEvent(
 export * from "./types";
 export { BACKGROUND_LOCATION_TASK_NAME, registerBackgroundTask } from "./task";
 
-export const checkBackgroundPermission =
-  NativeBackgroundLocation.checkBackgroundPermission.bind(
-    NativeBackgroundLocation
-  );
-export const requestBackgroundPermission =
-  NativeBackgroundLocation.requestBackgroundPermission.bind(
-    NativeBackgroundLocation
-  );
-export const openAppLocationSettings =
-  NativeBackgroundLocation.openAppLocationSettings.bind(
-    NativeBackgroundLocation
-  );
-export const configureBackgroundLocation =
-  NativeBackgroundLocation.configureBackgroundLocation.bind(
-    NativeBackgroundLocation
-  );
-export const getBackgroundConfiguration =
-  NativeBackgroundLocation.getBackgroundConfiguration.bind(
-    NativeBackgroundLocation
-  );
-export const startBackgroundLocation: NitroBackgroundLocation["startBackgroundLocation"] =
-  (options) => NativeBackgroundLocation.startBackgroundLocation(options);
-export const stopBackgroundLocation =
-  NativeBackgroundLocation.stopBackgroundLocation.bind(
-    NativeBackgroundLocation
-  );
-export const resetBackgroundLocation =
-  NativeBackgroundLocation.resetBackgroundLocation.bind(
-    NativeBackgroundLocation
-  );
-export const getBackgroundLocationStatus =
-  NativeBackgroundLocation.getBackgroundLocationStatus.bind(
-    NativeBackgroundLocation
-  );
-export const getStoredBackgroundLocations: NitroBackgroundLocation["getStoredBackgroundLocations"] =
-  (options) => NativeBackgroundLocation.getStoredBackgroundLocations(options);
-export const clearStoredBackgroundLocations: NitroBackgroundLocation["clearStoredBackgroundLocations"] =
-  (ids) => NativeBackgroundLocation.clearStoredBackgroundLocations(ids);
-export const markStoredBackgroundLocationsDelivered =
-  NativeBackgroundLocation.markStoredBackgroundLocationsDelivered.bind(
-    NativeBackgroundLocation
-  );
+export function checkBackgroundPermission(): Promise<BackgroundPermissionResult> {
+  return NativeBackgroundLocation.checkBackgroundPermission();
+}
+
+export function requestBackgroundPermission(): Promise<BackgroundPermissionResult> {
+  return NativeBackgroundLocation.requestBackgroundPermission();
+}
+
+export function openAppLocationSettings(): Promise<void> {
+  return NativeBackgroundLocation.openAppLocationSettings();
+}
+
+export function configureBackgroundLocation(
+  options: BackgroundLocationOptions
+): Promise<void> {
+  return NativeBackgroundLocation.configureBackgroundLocation(options);
+}
+
+export function getBackgroundConfiguration(): Promise<
+  BackgroundLocationOptions | undefined
+> {
+  return NativeBackgroundLocation.getBackgroundConfiguration();
+}
+
+export function startBackgroundLocation(
+  options?: BackgroundLocationOptions
+): Promise<void> {
+  return NativeBackgroundLocation.startBackgroundLocation(options);
+}
+
+export function stopBackgroundLocation(): Promise<void> {
+  return NativeBackgroundLocation.stopBackgroundLocation();
+}
+
+export function resetBackgroundLocation(): Promise<void> {
+  return NativeBackgroundLocation.resetBackgroundLocation();
+}
+
+export function getBackgroundLocationStatus(): Promise<BackgroundLocationStatus> {
+  return NativeBackgroundLocation.getBackgroundLocationStatus();
+}
+
+export function getStoredBackgroundLocations(
+  options?: GetStoredBackgroundLocationsOptions
+): Promise<StoredBackgroundLocation[]> {
+  return NativeBackgroundLocation.getStoredBackgroundLocations(options);
+}
+
+export function clearStoredBackgroundLocations(ids?: string[]): Promise<void> {
+  return NativeBackgroundLocation.clearStoredBackgroundLocations(ids);
+}
+
+export function markStoredBackgroundLocationsDelivered(
+  ids: string[]
+): Promise<void> {
+  return NativeBackgroundLocation.markStoredBackgroundLocationsDelivered(ids);
+}
+
 export async function getStoredBackgroundEvents(
-  options?: Parameters<NitroBackgroundLocation["getStoredBackgroundEvents"]>[0]
+  options?: GetStoredBackgroundEventsOptions
 ): Promise<StoredBackgroundEvent[]> {
   const events =
     await NativeBackgroundLocation.getStoredBackgroundEvents(options);
@@ -105,38 +130,44 @@ export async function getStoredBackgroundEvents(
     event: narrowBackgroundEvent(event.event)
   }));
 }
-export const clearStoredBackgroundEvents: NitroBackgroundLocation["clearStoredBackgroundEvents"] =
-  (ids) => NativeBackgroundLocation.clearStoredBackgroundEvents(ids);
-export const markStoredBackgroundEventsDelivered =
-  NativeBackgroundLocation.markStoredBackgroundEventsDelivered.bind(
-    NativeBackgroundLocation
-  );
-export const addGeofences = NativeBackgroundLocation.addGeofences.bind(
-  NativeBackgroundLocation
-);
-export const removeGeofences: NitroBackgroundLocation["removeGeofences"] = (
-  identifiers
-) => NativeBackgroundLocation.removeGeofences(identifiers);
-export const getRegisteredGeofences =
-  NativeBackgroundLocation.getRegisteredGeofences.bind(
-    NativeBackgroundLocation
-  );
-export const startActivityRecognition: NitroBackgroundLocation["startActivityRecognition"] =
-  (options) => NativeBackgroundLocation.startActivityRecognition(options);
-export const stopActivityRecognition =
-  NativeBackgroundLocation.stopActivityRecognition.bind(
-    NativeBackgroundLocation
-  );
-export const syncStoredLocations =
-  NativeBackgroundLocation.syncStoredLocations.bind(NativeBackgroundLocation);
 
-export interface BackgroundLocationDiagnosis {
-  /** True when no blocking issues were found. */
-  healthy: boolean;
-  /** The raw status the diagnosis was derived from. */
-  status: BackgroundLocationStatus;
-  /** Human-readable, actionable reasons delivery may not be working. Empty when healthy. */
-  issues: string[];
+export function clearStoredBackgroundEvents(ids?: string[]): Promise<void> {
+  return NativeBackgroundLocation.clearStoredBackgroundEvents(ids);
+}
+
+export function markStoredBackgroundEventsDelivered(
+  ids: string[]
+): Promise<void> {
+  return NativeBackgroundLocation.markStoredBackgroundEventsDelivered(ids);
+}
+
+export function addGeofences(
+  regions: GeofenceRegion[],
+  options?: GeofencingOptions
+): Promise<void> {
+  return NativeBackgroundLocation.addGeofences(regions, options);
+}
+
+export function removeGeofences(identifiers?: string[]): Promise<void> {
+  return NativeBackgroundLocation.removeGeofences(identifiers);
+}
+
+export function getRegisteredGeofences(): Promise<GeofenceRegion[]> {
+  return NativeBackgroundLocation.getRegisteredGeofences();
+}
+
+export function startActivityRecognition(
+  options?: ActivityRecognitionOptions
+): Promise<void> {
+  return NativeBackgroundLocation.startActivityRecognition(options);
+}
+
+export function stopActivityRecognition(): Promise<void> {
+  return NativeBackgroundLocation.stopActivityRecognition();
+}
+
+export function syncStoredLocations(): Promise<BackgroundHttpSyncResult> {
+  return NativeBackgroundLocation.syncStoredLocations();
 }
 
 /**
@@ -250,7 +281,7 @@ export function onLocationLifecycleChange(
 }
 
 export function onGeofence(
-  listener: (event: BackgroundGeofenceEventEnvelope["geofence"]) => void
+  listener: (event: GeofenceEvent) => void
 ): BackgroundSubscription {
   return onBackgroundEvent((event) => {
     if (event.type === "geofence") {
@@ -260,7 +291,7 @@ export function onGeofence(
 }
 
 export function onActivityChange(
-  listener: (activity: BackgroundActivityEventEnvelope["activity"]) => void
+  listener: (activity: DetectedActivity) => void
 ): BackgroundSubscription {
   return onBackgroundEvent((event) => {
     if (event.type === "activity") {
@@ -270,7 +301,7 @@ export function onActivityChange(
 }
 
 export function onHttpSync(
-  listener: (result: BackgroundHttpSyncEvent["result"]) => void
+  listener: (result: BackgroundHttpSyncResult) => void
 ): BackgroundSubscription {
   return onBackgroundEvent((event) => {
     if (event.type === "httpSync") {

--- a/packages/react-native-nitro-geolocation/src/background/index.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.ts
@@ -2,6 +2,10 @@ import { NitroModules } from "react-native-nitro-modules";
 import type { LocationError } from "../NitroGeolocation.nitro";
 import type { NitroBackgroundLocation } from "./NitroBackgroundLocation.nitro";
 import { createLocationLifecycleSubscription } from "./locationLifecycle";
+import {
+  fromNativeBackgroundLocationOptions,
+  toNativeBackgroundLocationOptions
+} from "./options";
 import type {
   ActivityRecognitionOptions,
   BackgroundEvent,
@@ -23,7 +27,7 @@ import type {
   StoredBackgroundEvent,
   StoredBackgroundEventEnvelope,
   StoredBackgroundLocation
-} from "./types";
+} from "./publicTypes";
 
 const NativeBackgroundLocation =
   NitroModules.createHybridObject<NitroBackgroundLocation>(
@@ -59,7 +63,7 @@ function narrowBackgroundEvent(
   }
 }
 
-export * from "./types";
+export * from "./publicTypes";
 export { BACKGROUND_LOCATION_TASK_NAME, registerBackgroundTask } from "./task";
 
 export function checkBackgroundPermission(): Promise<BackgroundPermissionResult> {
@@ -77,19 +81,24 @@ export function openAppLocationSettings(): Promise<void> {
 export function configureBackgroundLocation(
   options: BackgroundLocationOptions
 ): Promise<void> {
-  return NativeBackgroundLocation.configureBackgroundLocation(options);
+  return NativeBackgroundLocation.configureBackgroundLocation(
+    toNativeBackgroundLocationOptions(options)
+  );
 }
 
-export function getBackgroundConfiguration(): Promise<
+export async function getBackgroundConfiguration(): Promise<
   BackgroundLocationOptions | undefined
 > {
-  return NativeBackgroundLocation.getBackgroundConfiguration();
+  const options = await NativeBackgroundLocation.getBackgroundConfiguration();
+  return fromNativeBackgroundLocationOptions(options);
 }
 
 export function startBackgroundLocation(
   options?: BackgroundLocationOptions
 ): Promise<void> {
-  return NativeBackgroundLocation.startBackgroundLocation(options);
+  return NativeBackgroundLocation.startBackgroundLocation(
+    options ? toNativeBackgroundLocationOptions(options) : undefined
+  );
 }
 
 export function stopBackgroundLocation(): Promise<void> {

--- a/packages/react-native-nitro-geolocation/src/background/index.web.test.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.web.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  diagnoseBackgroundLocation,
+  registerBackgroundTask
+} from "./index.web";
+
+describe("background web API parity", () => {
+  it("rejects background diagnosis as unsupported", async () => {
+    await expect(diagnoseBackgroundLocation()).rejects.toThrow(
+      "Background location is not available in the browser."
+    );
+  });
+
+  it("accepts the native task handler signature before throwing", () => {
+    expect(() => registerBackgroundTask(() => undefined)).toThrow(
+      "Background location is not available in the browser."
+    );
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/background/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.web.ts
@@ -4,10 +4,12 @@ import type {
   BackgroundEvent,
   BackgroundHttpSyncResult,
   BackgroundLocation,
+  BackgroundLocationDiagnosis,
   BackgroundLocationOptions,
   BackgroundLocationStatus,
   BackgroundPermissionResult,
   BackgroundSubscription,
+  BackgroundTaskHandler,
   DetectedActivity,
   GeofenceEvent,
   GeofenceRegion,
@@ -28,7 +30,7 @@ const unsupported = (): Error =>
 
 const rejectUnsupported = <T>(): Promise<T> => Promise.reject(unsupported());
 
-export function registerBackgroundTask(): void {
+export function registerBackgroundTask(_handler: BackgroundTaskHandler): void {
   throw unsupported();
 }
 
@@ -81,6 +83,10 @@ export const startActivityRecognition = (
 export const stopActivityRecognition = (): Promise<void> => rejectUnsupported();
 export const syncStoredLocations = (): Promise<BackgroundHttpSyncResult> =>
   rejectUnsupported();
+
+export function diagnoseBackgroundLocation(): Promise<BackgroundLocationDiagnosis> {
+  return rejectUnsupported();
+}
 
 const noopSubscription = (): BackgroundSubscription => ({ remove() {} });
 

--- a/packages/react-native-nitro-geolocation/src/background/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.web.ts
@@ -19,9 +19,9 @@ import type {
   LocationLifecycleEvent,
   StoredBackgroundEvent,
   StoredBackgroundLocation
-} from "./types";
+} from "./publicTypes";
 
-export * from "./types";
+export * from "./publicTypes";
 
 export const BACKGROUND_LOCATION_TASK_NAME = "NitroBackgroundLocationTask";
 

--- a/packages/react-native-nitro-geolocation/src/background/options.test.ts
+++ b/packages/react-native-nitro-geolocation/src/background/options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  fromNativeBackgroundLocationOptions,
+  toNativeBackgroundLocationOptions
+} from "./options";
+
+const foregroundService = {
+  notificationTitle: "Location",
+  notificationText: "Tracking location"
+};
+
+describe("background option boundary", () => {
+  it("maps the public Android provider to the Nitro-safe spelling", () => {
+    expect(
+      toNativeBackgroundLocationOptions({
+        android: { foregroundService, locationProvider: "android" }
+      }).android?.locationProvider
+    ).toBe("android_platform");
+  });
+
+  it("maps native configuration snapshots back to the public spelling", () => {
+    expect(
+      fromNativeBackgroundLocationOptions({
+        android: { foregroundService, locationProvider: "android_platform" }
+      })?.android?.locationProvider
+    ).toBe("android");
+  });
+
+  it("preserves provider-independent options", () => {
+    expect(
+      toNativeBackgroundLocationOptions({
+        interval: 5_000,
+        persist: true
+      })
+    ).toEqual({ interval: 5_000, persist: true });
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/background/options.ts
+++ b/packages/react-native-nitro-geolocation/src/background/options.ts
@@ -1,0 +1,46 @@
+import type { BackgroundLocationOptions } from "./publicTypes";
+import type { BackgroundLocationOptions as NativeBackgroundLocationOptions } from "./types";
+
+export function toNativeBackgroundLocationOptions(
+  options: BackgroundLocationOptions
+): NativeBackgroundLocationOptions {
+  const { android, ...sharedOptions } = options;
+  if (!android) {
+    return sharedOptions;
+  }
+
+  return {
+    ...sharedOptions,
+    android: {
+      ...android,
+      locationProvider:
+        android.locationProvider === "android"
+          ? "android_platform"
+          : android.locationProvider
+    }
+  };
+}
+
+export function fromNativeBackgroundLocationOptions(
+  options: NativeBackgroundLocationOptions | undefined
+): BackgroundLocationOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const { android, ...sharedOptions } = options;
+  if (!android) {
+    return sharedOptions;
+  }
+
+  return {
+    ...sharedOptions,
+    android: {
+      ...android,
+      locationProvider:
+        android.locationProvider === "android_platform"
+          ? "android"
+          : android.locationProvider
+    }
+  };
+}

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -1,0 +1,48 @@
+import type {
+  AndroidGranularity,
+  LocationAccuracyOptions
+} from "../publicTypes";
+import type {
+  ActivityRecognitionOptions,
+  AndroidForegroundServiceOptions,
+  BackgroundHttpSyncOptions,
+  BackgroundTrackingMode,
+  GeofencingOptions,
+  IOSBackgroundLocationOptions
+} from "./types";
+
+export * from "./types";
+
+/** Android provider selection exposed by the public background API. */
+export type AndroidBackgroundProvider = "auto" | "playServices" | "android";
+
+export interface AndroidBackgroundLocationOptions {
+  locationProvider?: AndroidBackgroundProvider;
+  foregroundService: AndroidForegroundServiceOptions;
+  requestNotificationPermission?: boolean;
+  requestIgnoreBatteryOptimizations?: boolean;
+}
+
+/** Options accepted by background configuration and start operations. */
+export interface BackgroundLocationOptions {
+  trackingMode?: BackgroundTrackingMode;
+  accuracy?: LocationAccuracyOptions;
+  granularity?: AndroidGranularity;
+  interval?: number;
+  fastestInterval?: number;
+  distanceFilter?: number;
+  maxUpdateDelay?: number;
+  waitForAccurateLocation?: boolean;
+  persist?: boolean;
+  /** Unset uses the native safety cap; `0` selects unbounded storage. */
+  maxStoredLocations?: number;
+  /** Unset uses the native safety cap; `0` selects unbounded storage. */
+  maxStoredEvents?: number;
+  stopOnTerminate?: boolean;
+  startOnBoot?: boolean;
+  android?: AndroidBackgroundLocationOptions;
+  ios?: IOSBackgroundLocationOptions;
+  geofencing?: GeofencingOptions;
+  activityRecognition?: ActivityRecognitionOptions;
+  sync?: BackgroundHttpSyncOptions;
+}

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -352,6 +352,16 @@ export interface BackgroundSubscription {
   remove(): void;
 }
 
+/** Result returned by `diagnoseBackgroundLocation()`. */
+export interface BackgroundLocationDiagnosis {
+  /** True when no blocking issues were found. */
+  healthy: boolean;
+  /** The raw status the diagnosis was derived from. */
+  status: BackgroundLocationStatus;
+  /** Human-readable, actionable reasons. Empty when healthy. */
+  issues: string[];
+}
+
 export type BackgroundTaskHandler = (
   event: BackgroundEvent
 ) => void | Promise<void>;

--- a/packages/react-native-nitro-geolocation/src/devtools/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/getCurrentPosition.ts
@@ -1,5 +1,5 @@
 import type { GeolocationResponse } from "../publicTypes";
-import { LocationErrorCode, createLocationError } from "../utils/errors";
+import { LocationErrorCodes, createLocationError } from "../utils/errors";
 import { getDevtoolsState } from "./index";
 
 export function getDevtoolsCurrentPosition(): Promise<GeolocationResponse> | null {
@@ -10,7 +10,7 @@ export function getDevtoolsCurrentPosition(): Promise<GeolocationResponse> | nul
   // Devtools is JS-only, but keep the public rejection shape aligned.
   return Promise.reject(
     createLocationError(
-      LocationErrorCode.INTERNAL_ERROR,
+      LocationErrorCodes.INTERNAL_ERROR,
       "Geolocation devtools not connected. Press 'j' in Metro to open devtools and enable the geolocation plugin."
     )
   );

--- a/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
@@ -1,7 +1,7 @@
 import type { LocationError } from "../NitroGeolocation.nitro";
 import type { GeolocationResponse } from "../publicTypes";
 import type { ActiveWatch } from "../publicTypes";
-import { LocationErrorCode } from "../utils/errors";
+import { LocationErrorCodes } from "../utils/errors";
 import { getDevtoolsState } from "./index";
 
 function nextDevtoolsWatchToken(): string {
@@ -21,7 +21,7 @@ export function devtoolsWatchPosition(
     // Call error callback immediately if provided
     if (error) {
       error({
-        code: LocationErrorCode.POSITION_UNAVAILABLE,
+        code: LocationErrorCodes.POSITION_UNAVAILABLE,
         message:
           "Geolocation devtools not connected. Press 'j' in Metro to open devtools and enable the geolocation plugin."
       });

--- a/packages/react-native-nitro-geolocation/src/hooks/index.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/index.ts
@@ -4,4 +4,7 @@
  */
 
 export { useWatchPosition } from "./useWatchPosition";
-export type { UseWatchPositionOptions } from "./useWatchPosition";
+export type {
+  UseWatchPositionOptions,
+  UseWatchPositionResult
+} from "./types";

--- a/packages/react-native-nitro-geolocation/src/hooks/types.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/types.ts
@@ -1,0 +1,22 @@
+import type {
+  LocationError,
+  LocationRequestOptions
+} from "../NitroGeolocation.nitro";
+import type { GeolocationResponse } from "../publicTypes";
+
+/** Options for the declarative position watcher. */
+export interface UseWatchPositionOptions extends LocationRequestOptions {
+  /**
+   * Whether to actively watch for location updates.
+   * When false, watching is paused and cleanup is performed.
+   * @default false
+   */
+  enabled?: boolean;
+}
+
+/** State returned by `useWatchPosition()`. */
+export interface UseWatchPositionResult {
+  position: GeolocationResponse | null;
+  error: LocationError | null;
+  isWatching: boolean;
+}

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
@@ -1,22 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import type {
-  LocationError,
-  LocationRequestOptions
-} from "../NitroGeolocation.nitro";
+import type { LocationError } from "../NitroGeolocation.nitro";
 import { unwatch, watchPosition } from "../api";
 import type { GeolocationResponse } from "../publicTypes";
-
-/**
- * Options for useWatchPosition hook.
- */
-export interface UseWatchPositionOptions extends LocationRequestOptions {
-  /**
-   * Whether to actively watch for location updates.
-   * When false, watching is paused and cleanup is performed.
-   * @default false
-   */
-  enabled?: boolean;
-}
+import type { UseWatchPositionOptions, UseWatchPositionResult } from "./types";
 
 /**
  * Hook for continuous location tracking.
@@ -50,7 +36,9 @@ export interface UseWatchPositionOptions extends LocationRequestOptions {
  * }
  * ```
  */
-export function useWatchPosition(options?: UseWatchPositionOptions) {
+export function useWatchPosition(
+  options?: UseWatchPositionOptions
+): UseWatchPositionResult {
   const [position, setPosition] = useState<GeolocationResponse | null>(null);
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -86,8 +86,7 @@ export * from "./hooks";
 export type {
   PermissionStatus,
   LocationRequestOptions,
-  LocationSettingsOptions,
-  LocationError
+  LocationSettingsOptions
 } from "./NitroGeolocation.nitro";
 
 export type { CurrentPositionOptions } from "./api/currentPositionOptions";

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -11,8 +11,7 @@ export * from "./background/index.web";
 export type {
   PermissionStatus,
   LocationRequestOptions,
-  LocationSettingsOptions,
-  LocationError
+  LocationSettingsOptions
 } from "./NitroGeolocation.nitro";
 
 export type { CurrentPositionOptions } from "./api/currentPositionOptions";

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -1,8 +1,4 @@
-import type {
-  NitroGeolocation,
-  PermissionStatus
-} from "./NitroGeolocation.nitro";
-import type { CompatGeolocationConfigurationInternal } from "./NitroGeolocationCompat.nitro";
+import type { PermissionStatus } from "./NitroGeolocation.nitro";
 import type {
   AccuracyAuthorization as SchemaAccuracyAuthorization,
   ActiveWatch as SchemaActiveWatch,
@@ -28,13 +24,6 @@ import type {
   LocationSettingsResult as SchemaLocationSettingsResult,
   ReverseGeocodedAddress as SchemaReverseGeocodedAddress
 } from "./types";
-
-type NativeGeolocationConfiguration = Parameters<
-  NitroGeolocation["setConfiguration"]
->[0];
-type NativeLocationProvider = NonNullable<
-  NativeGeolocationConfiguration["locationProvider"]
->;
 
 /** API path that delivered a Modern location response. */
 export type LocationResponseSource =
@@ -167,17 +156,10 @@ export type CompatGeolocationOptionsWithMetadata = Omit<
   includeExtraMetadata: true;
 };
 
-export type AuthorizationLevel = NonNullable<
-  NativeGeolocationConfiguration["authorizationLevel"]
->;
-export type LocationProvider =
-  | Exclude<NativeLocationProvider, "android_platform">
-  | "android";
+export type AuthorizationLevel = "always" | "whenInUse" | "auto";
+export type LocationProvider = "playServices" | "android" | "auto";
 
-export type GeolocationConfiguration = Omit<
-  NativeGeolocationConfiguration,
-  "autoRequestPermission" | "locationProvider"
-> & {
+export interface GeolocationConfiguration {
   /**
    * @deprecated This option is accepted for backward compatibility only.
    * `setConfiguration()` does not request permission. Call
@@ -188,6 +170,16 @@ export type GeolocationConfiguration = Omit<
   autoRequestPermission?: boolean;
 
   /**
+   * iOS authorization level.
+   *
+   * `auto` selects a level from the usage-description keys in Info.plist.
+   */
+  authorizationLevel?: AuthorizationLevel;
+
+  /** Enable iOS background location updates. */
+  enableBackgroundLocationUpdates?: boolean;
+
+  /**
    * Android location provider.
    *
    * `auto` and `playServices` prefer Google Play Services fused location when
@@ -195,12 +187,18 @@ export type GeolocationConfiguration = Omit<
    * force Android's platform `LocationManager` path.
    */
   locationProvider?: LocationProvider;
-};
+}
 
-export type CompatGeolocationConfiguration = Omit<
-  CompatGeolocationConfigurationInternal,
-  "locationProvider"
-> & {
+export interface CompatGeolocationConfiguration {
+  /** Preserve the community API's manual permission-request behavior. */
+  skipPermissionRequests: boolean;
+
+  /** iOS authorization level. */
+  authorizationLevel?: AuthorizationLevel;
+
+  /** Enable iOS background location updates. */
+  enableBackgroundLocationUpdates?: boolean;
+
   /**
    * Android location provider compatibility option.
    *
@@ -208,4 +206,4 @@ export type CompatGeolocationConfiguration = Omit<
    * API root import when you need Android fused/provider selection.
    */
   locationProvider?: LocationProvider;
-};
+}

--- a/packages/react-native-nitro-geolocation/src/utils/errors.test.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  LocationErrorCode,
+  LocationErrorCodes,
   createLocationError,
   getLocationErrorCodeName,
   isLocationErrorCode,
@@ -8,62 +8,64 @@ import {
   mapCLErrorCode
 } from "./errors";
 
-describe("LocationErrorCode", () => {
+describe("LocationErrorCodes", () => {
   it("uses readable, platform-independent Modern API codes", () => {
-    expect(LocationErrorCode.INTERNAL_ERROR).toBe("internalError");
-    expect(LocationErrorCode.PERMISSION_DENIED).toBe("permissionDenied");
-    expect(LocationErrorCode.POSITION_UNAVAILABLE).toBe("positionUnavailable");
-    expect(LocationErrorCode.TIMEOUT).toBe("timeout");
-    expect(LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE).toBe(
+    expect(LocationErrorCodes.INTERNAL_ERROR).toBe("internalError");
+    expect(LocationErrorCodes.PERMISSION_DENIED).toBe("permissionDenied");
+    expect(LocationErrorCodes.POSITION_UNAVAILABLE).toBe("positionUnavailable");
+    expect(LocationErrorCodes.TIMEOUT).toBe("timeout");
+    expect(LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE).toBe(
       "playServicesUnavailable"
     );
-    expect(LocationErrorCode.SETTINGS_NOT_SATISFIED).toBe(
+    expect(LocationErrorCodes.SETTINGS_NOT_SATISFIED).toBe(
       "settingsNotSatisfied"
     );
   });
 
   it("creates the same plain LocationError shape native sends to JS", () => {
     const error = createLocationError(
-      LocationErrorCode.SETTINGS_NOT_SATISFIED,
+      LocationErrorCodes.SETTINGS_NOT_SATISFIED,
       "Location settings are disabled"
     );
 
     expect(error).toEqual({
-      code: LocationErrorCode.SETTINGS_NOT_SATISFIED,
+      code: LocationErrorCodes.SETTINGS_NOT_SATISFIED,
       message: "Location settings are disabled"
     });
   });
 
   it("maps platform-specific error sources", () => {
-    expect(mapCLErrorCode(0)).toBe(LocationErrorCode.POSITION_UNAVAILABLE);
-    expect(mapCLErrorCode(1)).toBe(LocationErrorCode.PERMISSION_DENIED);
+    expect(mapCLErrorCode(0)).toBe(LocationErrorCodes.POSITION_UNAVAILABLE);
+    expect(mapCLErrorCode(1)).toBe(LocationErrorCodes.PERMISSION_DENIED);
     expect(mapAndroidException("SecurityException")).toBe(
-      LocationErrorCode.PERMISSION_DENIED
+      LocationErrorCodes.PERMISSION_DENIED
     );
     expect(mapAndroidException("ResolvableApiException")).toBe(
-      LocationErrorCode.SETTINGS_NOT_SATISFIED
+      LocationErrorCodes.SETTINGS_NOT_SATISFIED
     );
     expect(mapAndroidException("GooglePlayServicesNotAvailableException")).toBe(
-      LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE
+      LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE
     );
   });
 
   it("returns stable names for known codes and rejects legacy numbers", () => {
-    expect(getLocationErrorCodeName(LocationErrorCode.INTERNAL_ERROR)).toBe(
+    expect(getLocationErrorCodeName(LocationErrorCodes.INTERNAL_ERROR)).toBe(
       "INTERNAL_ERROR"
     );
-    expect(getLocationErrorCodeName(LocationErrorCode.PERMISSION_DENIED)).toBe(
+    expect(getLocationErrorCodeName(LocationErrorCodes.PERMISSION_DENIED)).toBe(
       "PERMISSION_DENIED"
     );
     expect(
-      getLocationErrorCodeName(LocationErrorCode.POSITION_UNAVAILABLE)
+      getLocationErrorCodeName(LocationErrorCodes.POSITION_UNAVAILABLE)
     ).toBe("POSITION_UNAVAILABLE");
-    expect(getLocationErrorCodeName(LocationErrorCode.TIMEOUT)).toBe("TIMEOUT");
+    expect(getLocationErrorCodeName(LocationErrorCodes.TIMEOUT)).toBe(
+      "TIMEOUT"
+    );
     expect(
-      getLocationErrorCodeName(LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE)
+      getLocationErrorCodeName(LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE)
     ).toBe("PLAY_SERVICE_NOT_AVAILABLE");
     expect(
-      getLocationErrorCodeName(LocationErrorCode.SETTINGS_NOT_SATISFIED)
+      getLocationErrorCodeName(LocationErrorCodes.SETTINGS_NOT_SATISFIED)
     ).toBe("SETTINGS_NOT_SATISFIED");
     expect(getLocationErrorCodeName(1)).toBe("UNKNOWN_LOCATION_ERROR");
   });

--- a/packages/react-native-nitro-geolocation/src/utils/errors.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/errors.ts
@@ -1,7 +1,10 @@
-import type {
-  LocationError as NativeLocationError,
-  LocationErrorCode as NativeLocationErrorCode
-} from "../NitroGeolocation.nitro";
+export type LocationErrorCode =
+  | "internalError"
+  | "permissionDenied"
+  | "positionUnavailable"
+  | "timeout"
+  | "playServicesUnavailable"
+  | "settingsNotSatisfied";
 
 /**
  * Readable Modern API error codes.
@@ -10,7 +13,7 @@ import type {
  * discriminants so logs and serialized errors remain meaningful without a
  * numeric lookup table.
  */
-export const LocationErrorCode = {
+export const LocationErrorCodes = {
   /** Unexpected module/native failure */
   INTERNAL_ERROR: "internalError",
   /** User denied the request for Geolocation */
@@ -23,40 +26,40 @@ export const LocationErrorCode = {
   PLAY_SERVICE_NOT_AVAILABLE: "playServicesUnavailable",
   /** Device/provider settings do not satisfy the request */
   SETTINGS_NOT_SATISFIED: "settingsNotSatisfied"
-} as const satisfies Record<string, NativeLocationErrorCode>;
-
-export type LocationErrorCode =
-  (typeof LocationErrorCode)[keyof typeof LocationErrorCode];
+} as const satisfies Record<string, LocationErrorCode>;
 
 /**
  * Geolocation error object.
  */
-export type LocationError = NativeLocationError;
+export interface LocationError {
+  code: LocationErrorCode;
+  message: string;
+}
 
 const locationErrorCodes = new Set<LocationErrorCode>(
-  Object.values(LocationErrorCode)
+  Object.values(LocationErrorCodes)
 );
 
 const locationErrorCodeNames: Record<LocationErrorCode, string> = {
-  [LocationErrorCode.INTERNAL_ERROR]: "INTERNAL_ERROR",
-  [LocationErrorCode.PERMISSION_DENIED]: "PERMISSION_DENIED",
-  [LocationErrorCode.POSITION_UNAVAILABLE]: "POSITION_UNAVAILABLE",
-  [LocationErrorCode.TIMEOUT]: "TIMEOUT",
-  [LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE]: "PLAY_SERVICE_NOT_AVAILABLE",
-  [LocationErrorCode.SETTINGS_NOT_SATISFIED]: "SETTINGS_NOT_SATISFIED"
+  [LocationErrorCodes.INTERNAL_ERROR]: "INTERNAL_ERROR",
+  [LocationErrorCodes.PERMISSION_DENIED]: "PERMISSION_DENIED",
+  [LocationErrorCodes.POSITION_UNAVAILABLE]: "POSITION_UNAVAILABLE",
+  [LocationErrorCodes.TIMEOUT]: "TIMEOUT",
+  [LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE]: "PLAY_SERVICE_NOT_AVAILABLE",
+  [LocationErrorCodes.SETTINGS_NOT_SATISFIED]: "SETTINGS_NOT_SATISFIED"
 };
 
 /**
  * Creates a standardized LocationError object.
  *
- * @param code - The error code from LocationErrorCode enum
+ * @param code - A Modern API location error code
  * @param message - A human-readable error message
  * @returns A LocationError object
  *
  * @example
  * ```ts
  * const error = createLocationError(
- *   LocationErrorCode.PERMISSION_DENIED,
+ *   LocationErrorCodes.PERMISSION_DENIED,
  *   'User denied location permission'
  * );
  * ```
@@ -95,11 +98,11 @@ export function getLocationErrorCodeName(code: unknown): string {
 export function mapCLErrorCode(clErrorCode: number): LocationErrorCode {
   switch (clErrorCode) {
     case 0: // kCLErrorLocationUnknown
-      return LocationErrorCode.POSITION_UNAVAILABLE;
+      return LocationErrorCodes.POSITION_UNAVAILABLE;
     case 1: // kCLErrorDenied
-      return LocationErrorCode.PERMISSION_DENIED;
+      return LocationErrorCodes.PERMISSION_DENIED;
     default:
-      return LocationErrorCode.POSITION_UNAVAILABLE;
+      return LocationErrorCodes.POSITION_UNAVAILABLE;
   }
 }
 
@@ -111,19 +114,19 @@ export function mapCLErrorCode(clErrorCode: number): LocationErrorCode {
  */
 export function mapAndroidException(exceptionType: string): LocationErrorCode {
   if (exceptionType === "SecurityException") {
-    return LocationErrorCode.PERMISSION_DENIED;
+    return LocationErrorCodes.PERMISSION_DENIED;
   }
   if (
     exceptionType === "GooglePlayServicesNotAvailableException" ||
     exceptionType === "GooglePlayServicesRepairableException"
   ) {
-    return LocationErrorCode.PLAY_SERVICE_NOT_AVAILABLE;
+    return LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE;
   }
   if (
     exceptionType === "ResolvableApiException" ||
     exceptionType === "LocationSettingsException"
   ) {
-    return LocationErrorCode.SETTINGS_NOT_SATISFIED;
+    return LocationErrorCodes.SETTINGS_NOT_SATISFIED;
   }
-  return LocationErrorCode.POSITION_UNAVAILABLE;
+  return LocationErrorCodes.POSITION_UNAVAILABLE;
 }

--- a/packages/react-native-nitro-geolocation/src/utils/index.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/index.ts
@@ -5,13 +5,14 @@
 
 export { isCachedLocationValid } from "./cache";
 export {
-  LocationErrorCode,
+  LocationErrorCodes,
   createLocationError,
   getLocationErrorCodeName,
   isLocationErrorCode,
   mapCLErrorCode,
   mapAndroidException
 } from "./errors";
+export type { LocationError, LocationErrorCode } from "./errors";
 export {
   isBetterLocation,
   type LocationQuality

--- a/packages/react-native-nitro-geolocation/src/web/browser.ts
+++ b/packages/react-native-nitro-geolocation/src/web/browser.ts
@@ -3,7 +3,7 @@ import type {
   LocationRequestOptions
 } from "../NitroGeolocation.nitro";
 import type { GeolocationResponse } from "../publicTypes";
-import { LocationErrorCode, createLocationError } from "../utils/errors";
+import { LocationErrorCodes, createLocationError } from "../utils/errors";
 
 type BrowserPermissionState = "granted" | "denied" | "prompt";
 
@@ -117,7 +117,7 @@ export function mapPermissionState(
 
 export function createUnsupportedError(): LocationError {
   return createLocationError(
-    LocationErrorCode.POSITION_UNAVAILABLE,
+    LocationErrorCodes.POSITION_UNAVAILABLE,
     "Browser geolocation is unavailable. Use a secure context and a browser that supports navigator.geolocation."
   );
 }
@@ -126,17 +126,17 @@ export function mapBrowserError(error: BrowserPositionError): LocationError {
   switch (error.code) {
     case 1:
       return createLocationError(
-        LocationErrorCode.PERMISSION_DENIED,
+        LocationErrorCodes.PERMISSION_DENIED,
         error.message || "User denied geolocation permission."
       );
     case 3:
       return createLocationError(
-        LocationErrorCode.TIMEOUT,
+        LocationErrorCodes.TIMEOUT,
         error.message || "Geolocation request timed out."
       );
     default:
       return createLocationError(
-        LocationErrorCode.POSITION_UNAVAILABLE,
+        LocationErrorCodes.POSITION_UNAVAILABLE,
         error.message || "Position is unavailable."
       );
   }

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -16,7 +16,7 @@ import {
   watchProviderStatus
 } from ".";
 import { clearLastKnownPositionCache } from "../api/positionCache";
-import { LocationErrorCode } from "../utils/errors";
+import { LocationErrorCodes } from "../utils/errors";
 import { clearWebPermissionDetailsEvidence } from "./permissionDetailsEvidence";
 import { clearWebPermissionEvidence } from "./permissionEvidence";
 
@@ -217,7 +217,7 @@ describe("web Modern API", () => {
     });
 
     await expect(getCurrentPosition()).rejects.toEqual({
-      code: LocationErrorCode.PERMISSION_DENIED,
+      code: LocationErrorCodes.PERMISSION_DENIED,
       message: "denied"
     });
   });
@@ -508,7 +508,7 @@ describe("web Modern API", () => {
     });
 
     await expect(getCurrentPosition()).rejects.toMatchObject({
-      code: LocationErrorCode.PERMISSION_DENIED
+      code: LocationErrorCodes.PERMISSION_DENIED
     });
 
     await expect(getPermissionDetails()).resolves.toEqual({
@@ -779,7 +779,7 @@ describe("web Modern API", () => {
 
     await getCurrentPosition();
     await expect(getCurrentPosition()).rejects.toMatchObject({
-      code: LocationErrorCode.PERMISSION_DENIED
+      code: LocationErrorCodes.PERMISSION_DENIED
     });
 
     await expect(getLocationReadiness()).resolves.toMatchObject({

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -60,10 +60,11 @@ export {
   watchPosition,
   watchProviderStatus
 } from "./watch";
-export {
-  useWatchPosition,
-  type UseWatchPositionOptions
-} from "./useWatchPosition";
+export { useWatchPosition } from "./useWatchPosition";
+export type {
+  UseWatchPositionOptions,
+  UseWatchPositionResult
+} from "../hooks/types";
 
 export function setConfiguration(_config: GeolocationConfiguration): void {
   // Browser geolocation has no global configuration API.

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -30,7 +30,7 @@ import type {
   PermissionDetails,
   ReverseGeocodedAddress
 } from "../publicTypes";
-import { LocationErrorCode } from "../utils/errors";
+import { LocationErrorCodes } from "../utils/errors";
 import {
   createUnsupportedError,
   getGeolocation,
@@ -154,7 +154,9 @@ export async function requestPermission(): Promise<PermissionStatus> {
     await getCurrentPosition({ maximumAge: 0, timeout: 10000 });
     return "granted";
   } catch (error) {
-    if ((error as LocationError).code === LocationErrorCode.PERMISSION_DENIED) {
+    if (
+      (error as LocationError).code === LocationErrorCodes.PERMISSION_DENIED
+    ) {
       return "denied";
     }
     return checkPermission();
@@ -280,7 +282,7 @@ export function getCurrentPosition(
     error: Parameters<typeof mapBrowserError>[0]
   ): LocationError => {
     const mappedError = mapBrowserError(error);
-    if (mappedError.code === LocationErrorCode.PERMISSION_DENIED) {
+    if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
       rememberWebPermissionDenial();
       rememberWebPermissionDetailsEvidence("denied");
     }

--- a/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from "react";
+import type { LocationError } from "../NitroGeolocation.nitro";
 import type {
-  LocationError,
-  LocationRequestOptions
-} from "../NitroGeolocation.nitro";
+  UseWatchPositionOptions,
+  UseWatchPositionResult
+} from "../hooks/types";
 import type { GeolocationResponse } from "../publicTypes";
 import { unwatch, watchPosition } from "./watch";
 
-export interface UseWatchPositionOptions extends LocationRequestOptions {
-  enabled?: boolean;
-}
-
-export function useWatchPosition(options?: UseWatchPositionOptions) {
+export function useWatchPosition(
+  options?: UseWatchPositionOptions
+): UseWatchPositionResult {
   const [position, setPosition] = useState<GeolocationResponse | null>(null);
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -11,7 +11,7 @@ import type {
   HeadingOptions,
   LocationProviderStatus
 } from "../publicTypes";
-import { LocationErrorCode } from "../utils/errors";
+import { LocationErrorCodes } from "../utils/errors";
 import {
   createUnsupportedError,
   distanceMeters,
@@ -160,7 +160,7 @@ export function watchPosition(
     },
     (browserError) => {
       const mappedError = mapBrowserError(browserError);
-      if (mappedError.code === LocationErrorCode.PERMISSION_DENIED) {
+      if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
         rememberWebPermissionDenial();
         rememberWebPermissionDetailsEvidence("denied");
       }

--- a/packages/react-native-nitro-geolocation/tsconfig.json
+++ b/packages/react-native-nitro-geolocation/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "lib",
     "types": []
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "type-tests/**/*"],
   "exclude": [
     "node_modules",
     "lib",

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -1,13 +1,24 @@
-import { LocationErrorCode } from "../src";
+import { LocationErrorCodes } from "../src";
 import type {
+  GeolocationConfiguration,
   LocationError,
   LocationErrorCode as LocationErrorCodeType,
   UseWatchPositionResult
 } from "../src";
 import type {
+  GeolocationConfiguration as NativeGeolocationConfiguration,
+  LocationError as NativeLocationError,
+  LocationProvider as NativeLocationProvider
+} from "../src/NitroGeolocation.nitro";
+import type {
+  CompatGeolocationConfigurationInternal,
+  LocationProviderInternal
+} from "../src/NitroGeolocationCompat.nitro";
+import type {
   AndroidBackgroundProvider,
   BackgroundLocationDiagnosis
 } from "../src/background";
+import type { CompatGeolocationConfiguration } from "../src/publicTypes";
 
 type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
   Value
@@ -15,9 +26,13 @@ type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
   ? true
   : false;
 type Expect<Value extends true> = Value;
+type Simplify<Value> = { [Key in keyof Value]: Value[Key] };
 
 type _LocationErrorUsesPublicCode = Expect<
   Equal<LocationError["code"], LocationErrorCodeType>
+>;
+type _LocationErrorMatchesNativeContract = Expect<
+  Equal<LocationError, NativeLocationError>
 >;
 type _LocationErrorCodeIsExact = Expect<
   Equal<
@@ -39,8 +54,34 @@ type _BackgroundDiagnosisIsNamed = Expect<
 type _BackgroundProviderIsPublic = Expect<
   Equal<AndroidBackgroundProvider, "auto" | "playServices" | "android">
 >;
+type _RootConfigurationMatchesNativeContract = Expect<
+  Equal<
+    Simplify<
+      Omit<GeolocationConfiguration, "locationProvider"> & {
+        locationProvider?: NativeLocationProvider;
+      }
+    >,
+    NativeGeolocationConfiguration
+  >
+>;
+type _CompatConfigurationMatchesNativeContract = Expect<
+  Equal<
+    Simplify<
+      Omit<CompatGeolocationConfiguration, "locationProvider"> & {
+        locationProvider?: LocationProviderInternal;
+      }
+    >,
+    CompatGeolocationConfigurationInternal
+  >
+>;
 
-const timeoutCode: LocationErrorCodeType = LocationErrorCode.TIMEOUT;
+const timeoutCode: LocationErrorCodeType = LocationErrorCodes.TIMEOUT;
+type _LocationErrorCodesMatchType = Expect<
+  Equal<
+    (typeof LocationErrorCodes)[keyof typeof LocationErrorCodes],
+    LocationErrorCodeType
+  >
+>;
 void timeoutCode;
 
 declare const nativeRoot: typeof import("../src/index");

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -1,0 +1,59 @@
+import { LocationErrorCode } from "../src";
+import type {
+  LocationError,
+  LocationErrorCode as LocationErrorCodeType,
+  UseWatchPositionResult
+} from "../src";
+import type { BackgroundLocationDiagnosis } from "../src/background";
+
+type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
+  Value
+>() => Value extends Right ? 1 : 2
+  ? true
+  : false;
+type Expect<Value extends true> = Value;
+
+type _LocationErrorUsesPublicCode = Expect<
+  Equal<LocationError["code"], LocationErrorCodeType>
+>;
+type _LocationErrorCodeIsExact = Expect<
+  Equal<
+    LocationErrorCodeType,
+    | "internalError"
+    | "permissionDenied"
+    | "positionUnavailable"
+    | "timeout"
+    | "playServicesUnavailable"
+    | "settingsNotSatisfied"
+  >
+>;
+type _HookResultIsNamed = Expect<
+  Equal<UseWatchPositionResult["error"], LocationError | null>
+>;
+type _BackgroundDiagnosisIsNamed = Expect<
+  Equal<BackgroundLocationDiagnosis["healthy"], boolean>
+>;
+
+const timeoutCode: LocationErrorCodeType = LocationErrorCode.TIMEOUT;
+void timeoutCode;
+
+declare const nativeRoot: typeof import("../src/index");
+declare const webRoot: typeof import("../src/index.web");
+const nativeRootFromWeb: typeof nativeRoot = webRoot;
+const webRootFromNative: typeof webRoot = nativeRoot;
+void nativeRootFromWeb;
+void webRootFromNative;
+
+declare const nativeCompat: typeof import("../src/compat/index");
+declare const webCompat: typeof import("../src/compat/index.web");
+const nativeCompatFromWeb: typeof nativeCompat = webCompat;
+const webCompatFromNative: typeof webCompat = nativeCompat;
+void nativeCompatFromWeb;
+void webCompatFromNative;
+
+declare const nativeBackground: typeof import("../src/background/index");
+declare const webBackground: typeof import("../src/background/index.web");
+const nativeBackgroundFromWeb: typeof nativeBackground = webBackground;
+const webBackgroundFromNative: typeof webBackground = nativeBackground;
+void nativeBackgroundFromWeb;
+void webBackgroundFromNative;

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -4,7 +4,10 @@ import type {
   LocationErrorCode as LocationErrorCodeType,
   UseWatchPositionResult
 } from "../src";
-import type { BackgroundLocationDiagnosis } from "../src/background";
+import type {
+  AndroidBackgroundProvider,
+  BackgroundLocationDiagnosis
+} from "../src/background";
 
 type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
   Value
@@ -32,6 +35,9 @@ type _HookResultIsNamed = Expect<
 >;
 type _BackgroundDiagnosisIsNamed = Expect<
   Equal<BackgroundLocationDiagnosis["healthy"], boolean>
+>;
+type _BackgroundProviderIsPublic = Expect<
+  Equal<AndroidBackgroundProvider, "auto" | "playServices" | "android">
 >;
 
 const timeoutCode: LocationErrorCodeType = LocationErrorCode.TIMEOUT;

--- a/skills/community-migration/SKILL.md
+++ b/skills/community-migration/SKILL.md
@@ -109,7 +109,7 @@ The final migration is not just "no type errors." Prefer this target state:
   code. Do not hide prompts or global cleanup in utility functions unless that
   is already the app's architecture.
 - Use typed Modern errors where handling is specific. Match on
-  `LocationErrorCode` for permission denied, timeout, settings-not-satisfied,
+  `LocationErrorCodes` for permission denied, timeout, settings-not-satisfied,
   or provider/setup failures instead of parsing error messages.
 
 ## Selection Criteria

--- a/skills/service-migration/SKILL.md
+++ b/skills/service-migration/SKILL.md
@@ -102,7 +102,7 @@ app.
 - Do not introduce React hooks unless the file is a function component or
   custom hook and the call is at hook-safe top level.
 - Use low-level `watchPosition` plus `unwatch` as the first safe Modern target.
-- Replace numeric error-code checks with `LocationErrorCode` where possible.
+- Replace numeric error-code checks with `LocationErrorCodes` where possible.
 - Do not remove `PermissionsAndroid` code unless it is clearly only for
   location permission and replaced by `requestPermission()`.
 
@@ -123,7 +123,7 @@ app.
 | `forceRequestLocation` | no direct option | Report and preserve intent manually. |
 | `position.mocked` | `GeolocationResponse.mocked` | Available in Modern API. |
 | `position.provider` | `GeolocationResponse.provider` | Available in Modern API. |
-| error codes `-1`, `1`, `2`, `3`, `4`, `5` | `LocationErrorCode` | Prefer enum comparisons. |
+| error codes `-1`, `1`, `2`, `3`, `4`, `5` | `LocationErrorCodes` | Prefer named constant comparisons. |
 
 ## Transform Patterns
 
@@ -138,7 +138,7 @@ import {
   requestPermission,
   setConfiguration,
   requestLocationSettings,
-  LocationErrorCode,
+  LocationErrorCodes,
 } from "react-native-nitro-geolocation";
 ```
 

--- a/skills/service-migration/scripts/migrate-geolocation-service.mjs
+++ b/skills/service-migration/scripts/migrate-geolocation-service.mjs
@@ -780,7 +780,7 @@ function buildWatchPositionCall(t, args, transformedOptions) {
 
 function enumMember(t, name) {
   return t.memberExpression(
-    t.identifier("LocationErrorCode"),
+    t.identifier("LocationErrorCodes"),
     t.identifier(name)
   );
 }
@@ -843,7 +843,7 @@ function rewriteInlineErrorCodeComparisons(t, callbackPath, requiredImports) {
       const codeName = numericErrorCodeName(t, literalSide);
       if (!codeName) return;
 
-      requiredImports.add("LocationErrorCode");
+      requiredImports.add("LocationErrorCodes");
       if (leftObject) {
         path.node.right = enumMember(t, codeName);
       } else {
@@ -1140,7 +1140,7 @@ function transformSourceFile(
       if (path.parentPath.isCallExpression({ callee: path.node })) return;
       if (!ERROR_CONSTANT_NAMES.has(info.propertyName)) return;
 
-      requiredImports.add("LocationErrorCode");
+      requiredImports.add("LocationErrorCodes");
       path.replaceWith(enumMember(t, info.propertyName));
     }
   });


### PR DESCRIPTION
## Summary

- export a named `UseWatchPositionResult` shared by native and web hooks
- replace inferred Nitro background signatures with explicit public contracts
- restore native/web parity for background diagnosis and task registration
- expose `android` consistently while keeping `android_platform` inside the Nitro bridge
- separate the `LocationErrorCode` type from `LocationErrorCodes` runtime constants
- move shared public schemas out of Nitro spec declarations and remove internal declaration references
- keep nullable background bridge envelopes private and expose named discriminated event types
- add action-specific `StartActivityRecognitionOptions`, `LastKnownPositionOptions`, and one-shot options without watch-only `maxUpdates`
- expose stable typed `LocationAvailabilityReason` codes and normalize unknown native values
- add compile-time contracts for export parity, error codes, option shapes, and bridge boundaries

## Why

The 2.0 RC mixed public API contracts with Nitro/codegen shapes. That leaked inferred helper types and nullable bridge envelopes, made some native and web exports disagree, and exposed provider spellings intended only for codegen. Several operations also accepted broad configuration objects containing fields they do not support.

The public facade now owns the user-facing contracts. Native-only wire shapes stay behind conversion boundaries, browser and native entries export the same symbols, and operation parameters advertise only meaningful fields. Runtime error constants and their annotation type also have distinct names: `LocationErrorCodes.TIMEOUT` for comparisons and `import type { LocationErrorCode }` for annotations.

Location availability previously returned an unbounded string and used different native/web text. It now returns stable reason codes; unknown future native strings safely map to `unknown` without changing the Nitro ABI.

## Validation

- `yarn format:check`
- `yarn lint`
- `yarn typecheck`
- `yarn test:unit` (24 files, 195 tests)
- `yarn pack:check`
- `yarn source-lines:check`
- declaration emit audit: no Nitro spec references, inferred helper signatures, bridge envelope names, internal names, or `android_platform` remain on public entry declarations
- compiler-symbol audit: root 160/160, compat 14/14, and background 77/77 native/web exports match; no public export is both a runtime value and a type
