### PR TITLE
fix: finish v2 public type boundary audit

### DIFF
--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -14,4 +14,10 @@ bridge envelopes remain internal, and activity recognition and last-known
 position use option types limited to the fields those operations support.
 One-shot position options no longer advertise the watch-only `maxUpdates`.
 Location availability reasons are also exposed as a consistent typed union
-across native and web implementations.
+across native and web implementations. The `/background` entry point now
+re-exports every named root type referenced by its public options, status, and
+event contracts, so consumers do not need cross-entrypoint type imports. The
+root also exports the `NullableDouble` used by nullable coordinate fields. The
+`/compat` entry point exports all supporting types referenced by its
+configuration, options, and response contracts, and legacy TypeScript `node`
+module resolution can resolve both public subpaths through `typesVersions`.

--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -8,16 +8,4 @@ in public types instead of inferred Nitro spec signatures. Background provider
 configuration now uses the same public `"android"` spelling as the root and
 compat APIs while retaining `"android_platform"` only inside the Nitro bridge.
 The `LocationErrorCode` type and `LocationErrorCodes` runtime constants now
-have distinct names so type-only and value imports are unambiguous. Public
-schema types no longer originate from Nitro spec declarations, background
-bridge envelopes remain internal, and activity recognition and last-known
-position use option types limited to the fields those operations support.
-One-shot position options no longer advertise the watch-only `maxUpdates`.
-Location availability reasons are also exposed as a consistent typed union
-across native and web implementations. The `/background` entry point now
-re-exports every named root type referenced by its public options, status, and
-event contracts, so consumers do not need cross-entrypoint type imports. The
-root also exports the `NullableDouble` used by nullable coordinate fields. The
-`/compat` entry point exports all supporting types referenced by its
-configuration, options, and response contracts, and legacy TypeScript `node`
-module resolution can resolve both public subpaths through `typesVersions`.
+have distinct names so type-only and value imports are unambiguous.

--- a/.changeset/clean-public-api-types.md
+++ b/.changeset/clean-public-api-types.md
@@ -8,4 +8,10 @@ in public types instead of inferred Nitro spec signatures. Background provider
 configuration now uses the same public `"android"` spelling as the root and
 compat APIs while retaining `"android_platform"` only inside the Nitro bridge.
 The `LocationErrorCode` type and `LocationErrorCodes` runtime constants now
-have distinct names so type-only and value imports are unambiguous.
+have distinct names so type-only and value imports are unambiguous. Public
+schema types no longer originate from Nitro spec declarations, background
+bridge envelopes remain internal, and activity recognition and last-known
+position use option types limited to the fields those operations support.
+One-shot position options no longer advertise the watch-only `maxUpdates`.
+Location availability reasons are also exposed as a consistent typed union
+across native and web implementations.

--- a/.changeset/tidy-public-entrypoint-types.md
+++ b/.changeset/tidy-public-entrypoint-types.md
@@ -1,0 +1,10 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Harden the v2 public type boundary by moving shared schemas out of Nitro
+codegen declarations, keeping bridge envelopes internal, narrowing
+operation-specific options, and exposing stable location availability reason
+codes. The root, `/compat`, and `/background` entry points now export every
+named supporting type referenced by their public contracts, while legacy
+TypeScript `node` module resolution can resolve both public subpaths.

--- a/docs/docs/background/activity-recognition.md
+++ b/docs/docs/background/activity-recognition.md
@@ -7,7 +7,6 @@ import {
 } from 'react-native-nitro-geolocation/background';
 
 await startActivityRecognition({
-  enabled: true,
   interval: 10_000,
   stopOnStill: true,
   minimumConfidence: 70,
@@ -17,6 +16,11 @@ const sub = onActivityChange((activity) => {
   console.log(activity.type, activity.confidence);
 });
 ```
+
+Calling `startActivityRecognition()` enables the standalone activity stream, so
+its options do not include `enabled`. Use `activityRecognition.enabled` only
+inside `BackgroundLocationOptions` when activity recognition is controlled by
+background tracking configuration.
 
 Activity events are delivered through the same native event pipeline as location
 and geofence events. Android uses Activity Recognition APIs. iOS uses Core

--- a/docs/docs/background/overview.md
+++ b/docs/docs/background/overview.md
@@ -16,6 +16,38 @@ import {
 Prefer `react-native-nitro-geolocation/background` so foreground and background
 imports stay explicit and tree-shakable.
 
+## Type imports
+
+The `/background` entry point is self-contained. Background contracts and the
+named coordinate, accuracy, permission, provider, and error types they reference
+can all be imported from the same subpath:
+
+```ts
+import type {
+  BackgroundLocation,
+  BackgroundLocationOptions,
+  GeolocationResponse,
+  GeolocationCoordinates,
+  NullableDouble,
+  LocationAccuracyOptions,
+  AndroidAccuracyPreset,
+  AndroidGranularity,
+  IOSAccuracyPreset,
+  AccuracyAuthorization,
+  PermissionStatus,
+  LocationProviderStatus,
+  LocationProviderUsed,
+  LocationError,
+  LocationErrorCode,
+} from 'react-native-nitro-geolocation/background';
+```
+
+The background `GeolocationResponse` is the raw native background payload
+shape. The Modern root response additionally allows delivery metadata. No root
+type import is required for a background-only integration. TypeScript can
+resolve this subpath with `node`, `node16`, `nodenext`, and `bundler` module
+resolution.
+
 ## Where to go next
 
 - [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.

--- a/docs/docs/guide/compat-api.md
+++ b/docs/docs/guide/compat-api.md
@@ -19,6 +19,34 @@ import {
 } from 'react-native-nitro-geolocation/compat';
 ```
 
+### Type imports
+
+The `/compat` entry point is self-contained. Import the callback API contracts
+and every named supporting type from the same subpath:
+
+```ts
+import type {
+  GeolocationConfiguration,
+  GeolocationOptions,
+  GeolocationOptionsWithMetadata,
+  GeolocationResponse,
+  GeolocationResponseWithMetadata,
+  GeolocationError,
+  GeolocationCoordinates,
+  NullableDouble,
+  AuthorizationLevel,
+  LocationProvider,
+  LocationProviderUsed,
+  LocationAccuracyOptions,
+  AndroidAccuracyPreset,
+  IOSAccuracyPreset,
+  IOSActivityType,
+} from 'react-native-nitro-geolocation/compat';
+```
+
+No type import from the Modern root is required. TypeScript can resolve this
+subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
+
 ## Compatibility Scope
 
 This API is drop-in compatible with the core native

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -1082,6 +1082,7 @@ import type {
   LocationProviderUsed,
   LocationAvailability,
   LocationAvailabilityReason,
+  NullableDouble,
   LocationReadiness,
   LocationReadinessRemediation,
   GeolocationConfiguration

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -1089,6 +1089,9 @@ import type {
 } from 'react-native-nitro-geolocation';
 ```
 
+`NullableDouble` is `number | null`. It is the shared scalar used by
+`GeolocationCoordinates.altitude`, `altitudeAccuracy`, `heading`, and `speed`.
+
 The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
 `GeolocationConfiguration` for the root Modern API.
 

--- a/docs/docs/guide/modern-api.md
+++ b/docs/docs/guide/modern-api.md
@@ -298,11 +298,12 @@ function ProviderStatusObserver() {
 - `watchProviderStatus(callback): string` - Delivers an asynchronous initial
   provider snapshot and then only distinct readiness changes. Pass its token to
   `unwatch()` for cleanup. Available in 2.0.
-- `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
+- `getLocationAvailability(): Promise<LocationAvailability>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
   configured, then falls back to platform provider/service checks. iOS maps Core
-  Location service and authorization state.
+  Location service and authorization state. When unavailable, `reason` is a
+  typed `LocationAvailabilityReason` code rather than platform-specific text.
 - `getLocationReadiness(): Promise<LocationReadiness>` - Combines current
   permission, services, provider, availability, Play Services, Google Location
   Accuracy, and observed module-cache state into one read-only diagnosis. It
@@ -464,7 +465,6 @@ function LocationButton() {
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
 - `maxUpdateDelay?: number` - Android-only maximum batching delay in ms, available since `v1.2`.
-- `maxUpdates?: number` - Android-only maximum watch updates before native cleanup, available since `v1.2`.
 - `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`.
 - `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`.
 - `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`. This only has a visible effect when the app has background location capability and permission.
@@ -700,9 +700,11 @@ const cached = await getLastKnownPositionAsync({
 });
 ```
 
-`getLastKnownPositionAsync(options?)` queries native/provider cache-only sources
-with the same filtering options as `getCurrentPosition()`, but never falls
-through to a fresh request. It resolves `undefined` when no cached location
+`getLastKnownPositionAsync(options?: LastKnownPositionOptions)` queries
+native/provider cache-only sources using `maximumAge`, `accuracy`,
+`granularity`, `waitForAccurateLocation`, and `maxUpdateAge`. Fresh/watch-only
+options are intentionally excluded, and the call never falls through to a
+fresh request. It resolves `undefined` when no cached location
 satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
 failures, such as permission denial, reject with the Modern `LocationError`
 contract.
@@ -1071,12 +1073,15 @@ All Modern API exports are fully typed:
 import type {
   PermissionStatus,
   CurrentPositionOptions,
+  LastKnownPositionOptions,
   LocationRequestOptions,
   LocationErrorCode,
   LocationError,
   GeolocationResponse,
   GeolocationCoordinates,
   LocationProviderUsed,
+  LocationAvailability,
+  LocationAvailabilityReason,
   LocationReadiness,
   LocationReadinessRemediation,
   GeolocationConfiguration

--- a/docs/docs/v2/background/activity-recognition.md
+++ b/docs/docs/v2/background/activity-recognition.md
@@ -7,7 +7,6 @@ import {
 } from 'react-native-nitro-geolocation/background';
 
 await startActivityRecognition({
-  enabled: true,
   interval: 10_000,
   stopOnStill: true,
   minimumConfidence: 70,
@@ -17,6 +16,11 @@ const sub = onActivityChange((activity) => {
   console.log(activity.type, activity.confidence);
 });
 ```
+
+Calling `startActivityRecognition()` enables the standalone activity stream, so
+its options do not include `enabled`. Use `activityRecognition.enabled` only
+inside `BackgroundLocationOptions` when activity recognition is controlled by
+background tracking configuration.
 
 Activity events are delivered through the same native event pipeline as location
 and geofence events. Android uses Activity Recognition APIs. iOS uses Core

--- a/docs/docs/v2/background/overview.md
+++ b/docs/docs/v2/background/overview.md
@@ -16,6 +16,38 @@ import {
 Prefer `react-native-nitro-geolocation/background` so foreground and background
 imports stay explicit and tree-shakable.
 
+## Type imports
+
+The `/background` entry point is self-contained. Background contracts and the
+named coordinate, accuracy, permission, provider, and error types they reference
+can all be imported from the same subpath:
+
+```ts
+import type {
+  BackgroundLocation,
+  BackgroundLocationOptions,
+  GeolocationResponse,
+  GeolocationCoordinates,
+  NullableDouble,
+  LocationAccuracyOptions,
+  AndroidAccuracyPreset,
+  AndroidGranularity,
+  IOSAccuracyPreset,
+  AccuracyAuthorization,
+  PermissionStatus,
+  LocationProviderStatus,
+  LocationProviderUsed,
+  LocationError,
+  LocationErrorCode,
+} from 'react-native-nitro-geolocation/background';
+```
+
+The background `GeolocationResponse` is the raw native background payload
+shape. The Modern root response additionally allows delivery metadata. No root
+type import is required for a background-only integration. TypeScript can
+resolve this subpath with `node`, `node16`, `nodenext`, and `bundler` module
+resolution.
+
 ## Where to go next
 
 - [Android Setup](/background/setup-android) and [iOS Setup](/background/setup-ios) - add the required native permissions and capabilities.

--- a/docs/docs/v2/guide/compat-api.md
+++ b/docs/docs/v2/guide/compat-api.md
@@ -19,6 +19,34 @@ import {
 } from 'react-native-nitro-geolocation/compat';
 ```
 
+### Type imports
+
+The `/compat` entry point is self-contained. Import the callback API contracts
+and every named supporting type from the same subpath:
+
+```ts
+import type {
+  GeolocationConfiguration,
+  GeolocationOptions,
+  GeolocationOptionsWithMetadata,
+  GeolocationResponse,
+  GeolocationResponseWithMetadata,
+  GeolocationError,
+  GeolocationCoordinates,
+  NullableDouble,
+  AuthorizationLevel,
+  LocationProvider,
+  LocationProviderUsed,
+  LocationAccuracyOptions,
+  AndroidAccuracyPreset,
+  IOSAccuracyPreset,
+  IOSActivityType,
+} from 'react-native-nitro-geolocation/compat';
+```
+
+No type import from the Modern root is required. TypeScript can resolve this
+subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
+
 ## Compatibility Scope
 
 This API is drop-in compatible with the core native

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -1082,6 +1082,7 @@ import type {
   LocationProviderUsed,
   LocationAvailability,
   LocationAvailabilityReason,
+  NullableDouble,
   LocationReadiness,
   LocationReadinessRemediation,
   GeolocationConfiguration

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -1089,6 +1089,9 @@ import type {
 } from 'react-native-nitro-geolocation';
 ```
 
+`NullableDouble` is `number | null`. It is the shared scalar used by
+`GeolocationCoordinates.altitude`, `altitudeAccuracy`, `heading`, and `speed`.
+
 The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
 `GeolocationConfiguration` for the root Modern API.
 

--- a/docs/docs/v2/guide/modern-api.md
+++ b/docs/docs/v2/guide/modern-api.md
@@ -298,11 +298,12 @@ function ProviderStatusObserver() {
 - `watchProviderStatus(callback): string` - Delivers an asynchronous initial
   provider snapshot and then only distinct readiness changes. Pass its token to
   `unwatch()` for cleanup. Available in 2.0.
-- `getLocationAvailability(): Promise<{ available: boolean; reason?: string }>` -
+- `getLocationAvailability(): Promise<LocationAvailability>` -
   Available since `v1.2`. Android reads Fused Location availability when
   `locationProvider: 'auto'` or `locationProvider: 'playServices'` is
   configured, then falls back to platform provider/service checks. iOS maps Core
-  Location service and authorization state.
+  Location service and authorization state. When unavailable, `reason` is a
+  typed `LocationAvailabilityReason` code rather than platform-specific text.
 - `getLocationReadiness(): Promise<LocationReadiness>` - Combines current
   permission, services, provider, availability, Play Services, Google Location
   Accuracy, and observed module-cache state into one read-only diagnosis. It
@@ -464,7 +465,6 @@ function LocationButton() {
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
 - `maxUpdateDelay?: number` - Android-only maximum batching delay in ms, available since `v1.2`.
-- `maxUpdates?: number` - Android-only maximum watch updates before native cleanup, available since `v1.2`.
 - `activityType?: 'other' | 'automotiveNavigation' | 'fitness' | 'otherNavigation' | 'airborne'` - iOS Core Location activity type, available since `v1.2`.
 - `pausesLocationUpdatesAutomatically?: boolean` - iOS automatic pause behavior, available since `v1.2`.
 - `showsBackgroundLocationIndicator?: boolean` - iOS background location indicator, available since `v1.2`. This only has a visible effect when the app has background location capability and permission.
@@ -700,9 +700,11 @@ const cached = await getLastKnownPositionAsync({
 });
 ```
 
-`getLastKnownPositionAsync(options?)` queries native/provider cache-only sources
-with the same filtering options as `getCurrentPosition()`, but never falls
-through to a fresh request. It resolves `undefined` when no cached location
+`getLastKnownPositionAsync(options?: LastKnownPositionOptions)` queries
+native/provider cache-only sources using `maximumAge`, `accuracy`,
+`granularity`, `waitForAccurateLocation`, and `maxUpdateAge`. Fresh/watch-only
+options are intentionally excluded, and the call never falls through to a
+fresh request. It resolves `undefined` when no cached location
 satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
 failures, such as permission denial, reject with the Modern `LocationError`
 contract.
@@ -1071,12 +1073,15 @@ All Modern API exports are fully typed:
 import type {
   PermissionStatus,
   CurrentPositionOptions,
+  LastKnownPositionOptions,
   LocationRequestOptions,
   LocationErrorCode,
   LocationError,
   GeolocationResponse,
   GeolocationCoordinates,
   LocationProviderUsed,
+  LocationAvailability,
+  LocationAvailabilityReason,
   LocationReadiness,
   LocationReadinessRemediation,
   GeolocationConfiguration

--- a/examples/v0.81.1/src/type-contracts/public-entrypoint-types.ts
+++ b/examples/v0.81.1/src/type-contracts/public-entrypoint-types.ts
@@ -1,0 +1,64 @@
+import type { NullableDouble } from "react-native-nitro-geolocation";
+import type {
+  AccuracyAuthorization as BackgroundAccuracyAuthorization,
+  AndroidAccuracyPreset as BackgroundAndroidAccuracyPreset,
+  AndroidGranularity as BackgroundAndroidGranularity,
+  GeolocationCoordinates as BackgroundGeolocationCoordinates,
+  GeolocationResponse as BackgroundGeolocationResponse,
+  IOSAccuracyPreset as BackgroundIOSAccuracyPreset,
+  LocationAccuracyOptions as BackgroundLocationAccuracyOptions,
+  LocationError as BackgroundLocationError,
+  LocationErrorCode as BackgroundLocationErrorCode,
+  LocationProviderStatus as BackgroundLocationProviderStatus,
+  LocationProviderUsed as BackgroundLocationProviderUsed,
+  NullableDouble as BackgroundNullableDouble,
+  PermissionStatus as BackgroundPermissionStatus
+} from "react-native-nitro-geolocation/background";
+import type {
+  AndroidAccuracyPreset as CompatAndroidAccuracyPreset,
+  AuthorizationLevel as CompatAuthorizationLevel,
+  GeolocationCoordinates as CompatGeolocationCoordinates,
+  IOSAccuracyPreset as CompatIOSAccuracyPreset,
+  IOSActivityType as CompatIOSActivityType,
+  LocationAccuracyOptions as CompatLocationAccuracyOptions,
+  LocationProvider as CompatLocationProvider,
+  NullableDouble as CompatNullableDouble
+} from "react-native-nitro-geolocation/compat";
+
+type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
+  Value
+>() => Value extends Right ? 1 : 2
+  ? true
+  : false;
+type Expect<Value extends true> = Value;
+
+export type RootEntrypointTypeContract = Expect<
+  Equal<NullableDouble, number | null>
+>;
+
+export type CompatEntrypointTypeContract = [
+  CompatAndroidAccuracyPreset,
+  CompatAuthorizationLevel,
+  CompatGeolocationCoordinates,
+  CompatIOSAccuracyPreset,
+  CompatIOSActivityType,
+  CompatLocationAccuracyOptions,
+  CompatLocationProvider,
+  CompatNullableDouble
+];
+
+export type BackgroundEntrypointTypeContract = [
+  BackgroundAccuracyAuthorization,
+  BackgroundAndroidAccuracyPreset,
+  BackgroundAndroidGranularity,
+  BackgroundGeolocationCoordinates,
+  BackgroundGeolocationResponse,
+  BackgroundIOSAccuracyPreset,
+  BackgroundLocationAccuracyOptions,
+  BackgroundLocationError,
+  BackgroundLocationErrorCode,
+  BackgroundLocationProviderStatus,
+  BackgroundLocationProviderUsed,
+  BackgroundNullableDouble,
+  BackgroundPermissionStatus
+];

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -692,7 +692,7 @@ class NitroGeolocation(
 
     private fun getPlatformLocationAvailability(): LocationAvailability {
         val providers = getValidProviders(resolveAndroidAccuracy(null, enableHighAccuracy = false))
-        val reason = if (providers.isEmpty()) "noLocationProvider" else null
+        val reason = if (providers.isEmpty()) "providerUnavailable" else null
         return createLocationAvailability(providers.isNotEmpty(), reason)
     }
 

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -29,6 +29,16 @@
       "default": "./src/background/index.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      "compat": [
+        "src/compat/index.tsx"
+      ],
+      "background": [
+        "src/background/index.ts"
+      ]
+    }
+  },
   "codegenConfig": {
     "name": "NitroGeolocationSpec",
     "type": "modules",

--- a/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/NitroGeolocation.nitro.ts
@@ -2,29 +2,28 @@ import type { HybridObject } from "react-native-nitro-modules";
 import type {
   AccuracyAuthorization,
   ActiveWatch,
-  AndroidGranularity,
   GeocodedLocation,
   GeocodingCoordinates,
   GeolocationResponse,
   Heading,
   HeadingOptions,
-  IOSActivityType,
-  LocationAccuracyOptions,
   LocationAvailability,
+  LocationError,
   LocationProviderStatus,
+  LocationRequestOptions,
+  LocationSettingsOptions,
   LocationSettingsResult,
+  PermissionStatus,
   ReverseGeocodedAddress
 } from "./types";
 
-/**
- * Permission status for location services.
- * Matches native permission states across iOS and Android.
- */
-export type PermissionStatus =
-  | "granted" // User has granted location permission
-  | "denied" // User has denied permission
-  | "restricted" // Permission is restricted (iOS parental controls)
-  | "undetermined"; // Permission not yet requested
+export type {
+  LocationError,
+  LocationErrorCode,
+  LocationRequestOptions,
+  LocationSettingsOptions,
+  PermissionStatus
+} from "./types";
 
 /**
  * iOS authorization level.
@@ -72,151 +71,6 @@ export interface GeolocationConfiguration {
    * - 'auto': Prefer Google Play Services (fused location), then platform fallback
    */
   locationProvider?: LocationProvider;
-}
-
-/**
- * Options for location requests.
- */
-export interface LocationRequestOptions {
-  /** Timeout in milliseconds (default: 600000 / 10 minutes) */
-  timeout?: number;
-
-  /** Maximum age of cached location in milliseconds (default: 0) */
-  maximumAge?: number;
-
-  /**
-   * Platform-specific accuracy preset.
-   */
-  accuracy?: LocationAccuracyOptions;
-
-  /** Minimum time interval between updates in milliseconds (watch only) */
-  interval?: number;
-
-  /** Fastest interval for updates in milliseconds (Android watch only) */
-  fastestInterval?: number;
-
-  /** Minimum distance change in meters for updates (watch only) */
-  distanceFilter?: number;
-
-  /**
-   * Android-only location granularity.
-   *
-   * Available since v1.2.
-   *
-   * `permission` follows the granted permission level, `coarse` prevents fine
-   * GPS-only requests from being used, and `fine` requires fine location
-   * permission.
-   */
-  granularity?: AndroidGranularity;
-
-  /**
-   * Android-only option for high-accuracy initial updates.
-   *
-   * Available since v1.2.
-   */
-  waitForAccurateLocation?: boolean;
-
-  /**
-   * Android-only maximum age for an initial update in milliseconds.
-   *
-   * Available since v1.2.
-   */
-  maxUpdateAge?: number;
-
-  /**
-   * Android-only maximum batching delay in milliseconds.
-   *
-   * Available since v1.2.
-   */
-  maxUpdateDelay?: number;
-
-  /**
-   * Android-only maximum number of updates before a watch stops itself.
-   *
-   * Available since v1.2.
-   */
-  maxUpdates?: number;
-
-  /** Use significant location changes mode (iOS watch only) */
-  useSignificantChanges?: boolean;
-
-  /**
-   * iOS-only activity type used to tune Core Location behavior.
-   *
-   * Available since v1.2.
-   */
-  activityType?: IOSActivityType;
-
-  /**
-   * iOS-only setting for automatic pausing of location updates.
-   *
-   * Available since v1.2.
-   */
-  pausesLocationUpdatesAutomatically?: boolean;
-
-  /**
-   * iOS-only setting for the background location indicator.
-   *
-   * Requires background location capability and is ignored by Android.
-   *
-   * Available since v1.2.
-   */
-  showsBackgroundLocationIndicator?: boolean;
-}
-
-/**
- * Android-only location settings request options.
- *
- * Used by `requestLocationSettings()` on Android to build the native
- * `LocationSettingsRequest`. On iOS these options are ignored because iOS does
- * not provide an equivalent system settings resolution dialog.
- */
-export interface LocationSettingsOptions {
-  /**
-   * Platform-specific accuracy preset for settings checks.
-   *
-   * Android uses `accuracy.android` to map to the native location request
-   * priority. iOS ignores this option because iOS has no equivalent settings
-   * resolution dialog.
-   */
-  accuracy?: LocationAccuracyOptions;
-
-  /** Desired update interval in milliseconds. */
-  interval?: number;
-
-  /** Fastest acceptable update interval in milliseconds. */
-  fastestInterval?: number;
-
-  /** Minimum distance change in meters. */
-  distanceFilter?: number;
-
-  /** Ask Android to always show the resolution dialog when possible. */
-  alwaysShow?: boolean;
-
-  /** Require BLE availability for the location settings request. */
-  needBle?: boolean;
-}
-
-/**
- * Stable Modern API error codes.
- *
- * These string values are intentionally separate from the numeric W3C codes
- * exposed by `/compat`.
- */
-export type LocationErrorCode =
-  | "internalError"
-  | "permissionDenied"
-  | "positionUnavailable"
-  | "timeout"
-  | "playServicesUnavailable"
-  | "settingsNotSatisfied";
-
-/**
- * Location error structure.
- */
-export interface LocationError {
-  code: LocationErrorCode;
-  message: string;
 }
 
 /**

--- a/packages/react-native-nitro-geolocation/src/api/checkPermission.ts
+++ b/packages/react-native-nitro-geolocation/src/api/checkPermission.ts
@@ -1,5 +1,5 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
+import type { PermissionStatus } from "../publicTypes";
 
 /**
  * Check current location permission status.

--- a/packages/react-native-nitro-geolocation/src/api/currentPositionOptions.ts
+++ b/packages/react-native-nitro-geolocation/src/api/currentPositionOptions.ts
@@ -1,7 +1,8 @@
-import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
+import type { LocationRequestOptions } from "../publicTypes";
 
 /** Options for a one-shot location request. */
-export interface CurrentPositionOptions extends LocationRequestOptions {
+export interface CurrentPositionOptions
+  extends Omit<LocationRequestOptions, "maxUpdates"> {
   /**
    * Cancels only this request. A pre-aborted signal does not start native or
    * browser location work. Cancellation rejects with `signal.reason`, or an

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -1,8 +1,10 @@
-import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { getDevtoolsLastKnownPosition } from "../devtools/getLastKnownPosition";
-import type { GeolocationResponse } from "../publicTypes";
+import type {
+  GeolocationResponse,
+  LastKnownPositionOptions
+} from "../publicTypes";
 import { LocationErrorCodes } from "../utils/errors";
 import { decoratePositionWithMetadata } from "./locationMetadata";
 import { readLastKnownPosition, rememberPosition } from "./positionCache";
@@ -32,7 +34,7 @@ export function getLastKnownPosition(): GeolocationResponse | undefined {
  * @throws LocationError if permission is denied or the cache query fails
  */
 export function getLastKnownPositionAsync(
-  options?: LocationRequestOptions
+  options?: LastKnownPositionOptions
 ): Promise<GeolocationResponse | undefined> {
   const requestedAt = Date.now();
   const rememberPlatformCache = (position: GeolocationResponse) =>

--- a/packages/react-native-nitro-geolocation/src/api/getLocationAvailability.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLocationAvailability.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const native = vi.hoisted(() => ({
+  getLocationAvailability: vi.fn()
+}));
+
+vi.mock("../NitroGeolocationModule", () => ({
+  NitroGeolocationHybridObject: native
+}));
+
+import { getLocationAvailability } from "./getLocationAvailability";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getLocationAvailability", () => {
+  it("preserves a known native reason", async () => {
+    native.getLocationAvailability.mockResolvedValue({
+      available: false,
+      reason: "permissionDenied"
+    });
+
+    await expect(getLocationAvailability()).resolves.toEqual({
+      available: false,
+      reason: "permissionDenied"
+    });
+  });
+
+  it("maps an unknown native reason to the public fallback", async () => {
+    native.getLocationAvailability.mockResolvedValue({
+      available: false,
+      reason: "futureNativeReason"
+    });
+
+    await expect(getLocationAvailability()).resolves.toEqual({
+      available: false,
+      reason: "unknown"
+    });
+  });
+
+  it("omits the reason when native reports availability", async () => {
+    native.getLocationAvailability.mockResolvedValue({ available: true });
+
+    await expect(getLocationAvailability()).resolves.toEqual({
+      available: true
+    });
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/api/getLocationAvailability.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLocationAvailability.ts
@@ -1,5 +1,38 @@
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
-import type { LocationAvailability } from "../publicTypes";
+import type {
+  LocationAvailability,
+  LocationAvailabilityReason
+} from "../publicTypes";
+import type { LocationAvailability as NativeLocationAvailability } from "../types";
+
+const locationAvailabilityReasons = new Set<LocationAvailabilityReason>([
+  "unsupported",
+  "permissionUndetermined",
+  "permissionDenied",
+  "permissionRestricted",
+  "locationServicesDisabled",
+  "providerUnavailable",
+  "temporarilyUnavailable",
+  "authorizationUnknown",
+  "unknown"
+]);
+
+function normalizeLocationAvailability(
+  availability: NativeLocationAvailability
+): LocationAvailability {
+  if (!availability.reason) {
+    return { available: availability.available };
+  }
+
+  return {
+    available: availability.available,
+    reason: locationAvailabilityReasons.has(
+      availability.reason as LocationAvailabilityReason
+    )
+      ? (availability.reason as LocationAvailabilityReason)
+      : "unknown"
+  };
+}
 
 /**
  * Check whether the current platform is likely to deliver location updates.
@@ -7,5 +40,7 @@ import type { LocationAvailability } from "../publicTypes";
  * @returns Promise resolving to availability state plus an optional reason.
  */
 export function getLocationAvailability(): Promise<LocationAvailability> {
-  return NitroGeolocationHybridObject.getLocationAvailability();
+  return NitroGeolocationHybridObject.getLocationAvailability().then(
+    normalizeLocationAvailability
+  );
 }

--- a/packages/react-native-nitro-geolocation/src/api/locationReadiness.ts
+++ b/packages/react-native-nitro-geolocation/src/api/locationReadiness.ts
@@ -1,4 +1,4 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
+import type { PermissionStatus } from "../publicTypes";
 import type {
   GeolocationResponse,
   LocationAvailability,

--- a/packages/react-native-nitro-geolocation/src/api/permissionDetails.ts
+++ b/packages/react-native-nitro-geolocation/src/api/permissionDetails.ts
@@ -1,5 +1,5 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
 import type { BackgroundPermissionStatus } from "../background/types";
+import type { PermissionStatus } from "../publicTypes";
 import type {
   AccuracyAuthorization,
   PermissionDetails,

--- a/packages/react-native-nitro-geolocation/src/api/requestLocationSettings.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestLocationSettings.ts
@@ -1,5 +1,5 @@
-import type { LocationSettingsOptions } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
+import type { LocationSettingsOptions } from "../publicTypes";
 import type { LocationSettingsResult } from "../publicTypes";
 
 /**

--- a/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestLocationSettingsDetailed.ts
@@ -1,4 +1,4 @@
-import type { LocationSettingsOptions } from "../NitroGeolocation.nitro";
+import type { LocationSettingsOptions } from "../publicTypes";
 import type { LocationSettingsResult } from "../publicTypes";
 import { requestLocationSettings } from "./requestLocationSettings";
 

--- a/packages/react-native-nitro-geolocation/src/api/requestPermission.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestPermission.ts
@@ -1,5 +1,5 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
+import type { PermissionStatus } from "../publicTypes";
 
 /**
  * Request location permission from the user.

--- a/packages/react-native-nitro-geolocation/src/api/requestTemporaryFullAccuracy.ts
+++ b/packages/react-native-nitro-geolocation/src/api/requestTemporaryFullAccuracy.ts
@@ -1,6 +1,6 @@
-import type { LocationError } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import type { AccuracyAuthorization } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 
 /**
  * Request temporary full location accuracy on iOS.

--- a/packages/react-native-nitro-geolocation/src/api/watchHeading.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchHeading.ts
@@ -1,6 +1,6 @@
-import type { LocationError } from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import type { Heading, HeadingOptions } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 
 /**
  * Start watching platform heading updates.

--- a/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/watchPosition.ts
@@ -1,11 +1,9 @@
-import type {
-  LocationError,
-  LocationRequestOptions
-} from "../NitroGeolocation.nitro";
 import { NitroGeolocationHybridObject } from "../NitroGeolocationModule";
 import { isDevtoolsEnabled } from "../devtools";
 import { devtoolsWatchPosition } from "../devtools/watchPosition";
+import type { LocationRequestOptions } from "../publicTypes";
 import type { GeolocationResponse } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 import { decoratePositionWithMetadata } from "./locationMetadata";
 import { rememberPosition } from "./positionCache";
 

--- a/packages/react-native-nitro-geolocation/src/background/NitroBackgroundLocation.nitro.ts
+++ b/packages/react-native-nitro-geolocation/src/background/NitroBackgroundLocation.nitro.ts
@@ -1,5 +1,5 @@
 import type { HybridObject } from "react-native-nitro-modules";
-import type { LocationError } from "../NitroGeolocation.nitro";
+import type { LocationError } from "../types";
 import type {
   ActivityRecognitionOptions,
   BackgroundEventEnvelope,

--- a/packages/react-native-nitro-geolocation/src/background/index.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.ts
@@ -1,5 +1,5 @@
 import { NitroModules } from "react-native-nitro-modules";
-import type { LocationError } from "../NitroGeolocation.nitro";
+import type { LocationError } from "../utils/errors";
 import type { NitroBackgroundLocation } from "./NitroBackgroundLocation.nitro";
 import { createLocationLifecycleSubscription } from "./locationLifecycle";
 import {
@@ -7,9 +7,7 @@ import {
   toNativeBackgroundLocationOptions
 } from "./options";
 import type {
-  ActivityRecognitionOptions,
   BackgroundEvent,
-  BackgroundEventEnvelope,
   BackgroundHttpSyncResult,
   BackgroundLocation,
   BackgroundLocationDiagnosis,
@@ -24,10 +22,14 @@ import type {
   GetStoredBackgroundEventsOptions,
   GetStoredBackgroundLocationsOptions,
   LocationLifecycleEvent,
+  StartActivityRecognitionOptions,
   StoredBackgroundEvent,
-  StoredBackgroundEventEnvelope,
   StoredBackgroundLocation
 } from "./publicTypes";
+import type {
+  BackgroundEventEnvelope,
+  StoredBackgroundEventEnvelope
+} from "./types";
 
 const NativeBackgroundLocation =
   NitroModules.createHybridObject<NitroBackgroundLocation>(
@@ -166,7 +168,7 @@ export function getRegisteredGeofences(): Promise<GeofenceRegion[]> {
 }
 
 export function startActivityRecognition(
-  options?: ActivityRecognitionOptions
+  options?: StartActivityRecognitionOptions
 ): Promise<void> {
   return NativeBackgroundLocation.startActivityRecognition(options);
 }

--- a/packages/react-native-nitro-geolocation/src/background/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.web.ts
@@ -1,6 +1,5 @@
-import type { LocationError } from "../NitroGeolocation.nitro";
+import type { LocationError } from "../utils/errors";
 import type {
-  ActivityRecognitionOptions,
   BackgroundEvent,
   BackgroundHttpSyncResult,
   BackgroundLocation,
@@ -17,6 +16,7 @@ import type {
   GetStoredBackgroundEventsOptions,
   GetStoredBackgroundLocationsOptions,
   LocationLifecycleEvent,
+  StartActivityRecognitionOptions,
   StoredBackgroundEvent,
   StoredBackgroundLocation
 } from "./publicTypes";
@@ -78,7 +78,7 @@ export const removeGeofences = (_identifiers?: string[]): Promise<void> =>
 export const getRegisteredGeofences = (): Promise<GeofenceRegion[]> =>
   rejectUnsupported();
 export const startActivityRecognition = (
-  _options?: ActivityRecognitionOptions
+  _options?: StartActivityRecognitionOptions
 ): Promise<void> => rejectUnsupported();
 export const stopActivityRecognition = (): Promise<void> => rejectUnsupported();
 export const syncStoredLocations = (): Promise<BackgroundHttpSyncResult> =>

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -5,13 +5,59 @@ import type {
 import type {
   ActivityRecognitionOptions,
   AndroidForegroundServiceOptions,
+  BackgroundErrorEvent,
+  BackgroundEventBase,
+  BackgroundHttpSyncEvent,
   BackgroundHttpSyncOptions,
+  BackgroundLifecycleEvent,
+  BackgroundLocationEvent,
+  BackgroundProviderChangeEvent,
   BackgroundTrackingMode,
+  DetectedActivity,
+  GeofenceEvent,
   GeofencingOptions,
   IOSBackgroundLocationOptions
 } from "./types";
 
-export * from "./types";
+export type {
+  ActivityRecognitionOptions,
+  AndroidBackgroundLocationStatus,
+  AndroidForegroundServiceOptions,
+  BackgroundErrorEvent,
+  BackgroundEventBase,
+  BackgroundEventType,
+  BackgroundHttpMethod,
+  BackgroundHttpSyncEvent,
+  BackgroundHttpSyncOptions,
+  BackgroundHttpSyncResult,
+  BackgroundLifecycleEvent,
+  BackgroundLocation,
+  BackgroundLocationDiagnosis,
+  BackgroundLocationEvent,
+  BackgroundLocationSource,
+  BackgroundLocationState,
+  BackgroundLocationStatus,
+  BackgroundPermissionResult,
+  BackgroundPermissionStatus,
+  BackgroundProviderChangeEvent,
+  BackgroundSubscription,
+  BackgroundTrackingMode,
+  BatterySnapshot,
+  DetectedActivity,
+  DetectedActivityType,
+  GeofenceEvent,
+  GeofenceRegion,
+  GeofenceTransition,
+  GeofencingOptions,
+  GetStoredBackgroundEventsOptions,
+  GetStoredBackgroundLocationsOptions,
+  IOSBackgroundActivityType,
+  IOSBackgroundLocationOptions,
+  IOSBackgroundLocationStatus,
+  LocationLifecycleEvent,
+  LocationLifecycleState,
+  StoredBackgroundLocation
+} from "./types";
 
 /** Android provider selection exposed by the public background API. */
 export type AndroidBackgroundProvider = "auto" | "playServices" | "android";
@@ -46,3 +92,39 @@ export interface BackgroundLocationOptions {
   activityRecognition?: ActivityRecognitionOptions;
   sync?: BackgroundHttpSyncOptions;
 }
+
+/** Options for an explicit `startActivityRecognition()` call. */
+export interface StartActivityRecognitionOptions {
+  interval?: number;
+  stopOnStill?: boolean;
+  minimumConfidence?: number;
+}
+
+export interface BackgroundGeofenceEvent extends BackgroundEventBase {
+  type: "geofence";
+  geofence: GeofenceEvent;
+}
+
+export interface BackgroundActivityEvent extends BackgroundEventBase {
+  type: "activity";
+  activity: DetectedActivity;
+}
+
+/** Discriminated event delivered by background listeners and tasks. */
+export type BackgroundEvent =
+  | BackgroundLocationEvent
+  | BackgroundGeofenceEvent
+  | BackgroundActivityEvent
+  | BackgroundProviderChangeEvent
+  | BackgroundLifecycleEvent
+  | BackgroundHttpSyncEvent
+  | BackgroundErrorEvent;
+
+export interface StoredBackgroundEvent extends BackgroundEventBase {
+  event: BackgroundEvent;
+  createdAt: number;
+}
+
+export type BackgroundTaskHandler = (
+  event: BackgroundEvent
+) => void | Promise<void>;

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -19,6 +19,26 @@ import type {
   IOSBackgroundLocationOptions
 } from "./types";
 
+// Keep the `/background` entry point self-contained: consumers should be able
+// to import every named type referenced by its public options, status, and
+// event contracts without reaching through the package root.
+export type {
+  AccuracyAuthorization,
+  AndroidAccuracyPreset,
+  AndroidGranularity,
+  IOSAccuracyPreset,
+  LocationAccuracyOptions,
+  LocationProviderStatus,
+  LocationProviderUsed,
+  PermissionStatus
+} from "../publicTypes";
+export type {
+  GeolocationCoordinates,
+  GeolocationResponse,
+  NullableDouble
+} from "../types";
+export type { LocationError, LocationErrorCode } from "../utils/errors";
+
 export type {
   ActivityRecognitionOptions,
   AndroidBackgroundLocationStatus,

--- a/packages/react-native-nitro-geolocation/src/background/task.ts
+++ b/packages/react-native-nitro-geolocation/src/background/task.ts
@@ -1,5 +1,5 @@
 import { AppRegistry } from "react-native";
-import type { BackgroundEvent, BackgroundTaskHandler } from "./types";
+import type { BackgroundEvent, BackgroundTaskHandler } from "./publicTypes";
 
 export const BACKGROUND_LOCATION_TASK_NAME = "NitroBackgroundLocationTask";
 

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -1,15 +1,13 @@
 import type {
-  LocationError,
-  PermissionStatus
-} from "../NitroGeolocation.nitro";
-import type {
   AccuracyAuthorization,
   AndroidGranularity,
   LocationAccuracyOptions,
   LocationProviderStatus,
-  LocationProviderUsed
+  LocationProviderUsed,
+  PermissionStatus
 } from "../publicTypes";
 import type { GeolocationResponse as SchemaGeolocationResponse } from "../types";
+import type { LocationError } from "../utils/errors";
 
 export type BackgroundPermissionStatus =
   | "granted"

--- a/packages/react-native-nitro-geolocation/src/compat/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/compat/index.tsx
@@ -25,13 +25,21 @@ const Geolocation = {
 
 // Export types
 export type {
+  AndroidAccuracyPreset,
+  AuthorizationLevel,
   CompatGeolocationConfiguration as GeolocationConfiguration,
   CompatGeolocationResponse as GeolocationResponse,
   CompatGeolocationResponseWithMetadata as GeolocationResponseWithMetadata,
   CompatGeolocationError as GeolocationError,
   CompatGeolocationOptions as GeolocationOptions,
   CompatGeolocationOptionsWithMetadata as GeolocationOptionsWithMetadata,
-  LocationProviderUsed
+  GeolocationCoordinates,
+  IOSAccuracyPreset,
+  IOSActivityType,
+  LocationAccuracyOptions,
+  LocationProvider,
+  LocationProviderUsed,
+  NullableDouble
 } from "../publicTypes";
 
 export default Geolocation;

--- a/packages/react-native-nitro-geolocation/src/compat/index.web.ts
+++ b/packages/react-native-nitro-geolocation/src/compat/index.web.ts
@@ -10,13 +10,21 @@ import type { BrowserPosition, BrowserPositionError } from "../web/browser";
 import { getGeolocation } from "../web/browser";
 
 export type {
+  AndroidAccuracyPreset,
+  AuthorizationLevel,
   CompatGeolocationConfiguration as GeolocationConfiguration,
   CompatGeolocationResponse as GeolocationResponse,
   CompatGeolocationResponseWithMetadata as GeolocationResponseWithMetadata,
   CompatGeolocationError as GeolocationError,
   CompatGeolocationOptions as GeolocationOptions,
   CompatGeolocationOptionsWithMetadata as GeolocationOptionsWithMetadata,
-  LocationProviderUsed
+  GeolocationCoordinates,
+  IOSAccuracyPreset,
+  IOSActivityType,
+  LocationAccuracyOptions,
+  LocationProvider,
+  LocationProviderUsed,
+  NullableDouble
 } from "../publicTypes";
 
 function mapPosition(

--- a/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/getLastKnownPosition.ts
@@ -1,10 +1,10 @@
 import { getDevtoolsState } from ".";
-import type { LocationRequestOptions } from "../NitroGeolocation.nitro";
 import { selectCachedPosition } from "../api/positionCache";
+import type { LastKnownPositionOptions } from "../publicTypes";
 import type { GeolocationResponse } from "../publicTypes";
 
 export function getDevtoolsLastKnownPosition(
-  options?: LocationRequestOptions,
+  options?: LastKnownPositionOptions,
   currentTime = Date.now()
 ): GeolocationResponse | undefined {
   const maximumAge = Math.min(

--- a/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
@@ -1,6 +1,6 @@
-import type { LocationError } from "../NitroGeolocation.nitro";
 import type { GeolocationResponse } from "../publicTypes";
 import type { ActiveWatch } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 import { LocationErrorCodes } from "../utils/errors";
 import { getDevtoolsState } from "./index";
 

--- a/packages/react-native-nitro-geolocation/src/hooks/types.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/types.ts
@@ -1,8 +1,8 @@
 import type {
-  LocationError,
+  GeolocationResponse,
   LocationRequestOptions
-} from "../NitroGeolocation.nitro";
-import type { GeolocationResponse } from "../publicTypes";
+} from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 
 /** Options for the declarative position watcher. */
 export interface UseWatchPositionOptions extends LocationRequestOptions {

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import type { LocationError } from "../NitroGeolocation.nitro";
 import { unwatch, watchPosition } from "../api";
 import type { GeolocationResponse } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 import type { UseWatchPositionOptions, UseWatchPositionResult } from "./types";
 
 /**

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -83,12 +83,6 @@ export * from "./background";
 export * from "./hooks";
 
 // Types from Nitro spec
-export type {
-  PermissionStatus,
-  LocationRequestOptions,
-  LocationSettingsOptions
-} from "./NitroGeolocation.nitro";
-
 export type { CurrentPositionOptions } from "./api/currentPositionOptions";
 
 export type {
@@ -98,6 +92,11 @@ export type {
   LocationSettingsOutcome,
   LocationSettingsResult,
   LocationAvailability,
+  LocationAvailabilityReason,
+  LastKnownPositionOptions,
+  PermissionStatus,
+  LocationRequestOptions,
+  LocationSettingsOptions,
   LocationReadiness,
   LocationCacheReadiness,
   LocationReadinessRemediation,

--- a/packages/react-native-nitro-geolocation/src/index.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.tsx
@@ -91,6 +91,7 @@ export type {
   LocationProviderStatus,
   LocationSettingsOutcome,
   LocationSettingsResult,
+  NullableDouble,
   LocationAvailability,
   LocationAvailabilityReason,
   LastKnownPositionOptions,

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -19,6 +19,7 @@ export type {
   LocationReadinessRemediation,
   LocationSettingsOutcome,
   LocationSettingsResult,
+  NullableDouble,
   LocationAvailability,
   LocationAvailabilityReason,
   LastKnownPositionOptions,

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -8,12 +8,6 @@
 export * from "./web";
 export * from "./background/index.web";
 
-export type {
-  PermissionStatus,
-  LocationRequestOptions,
-  LocationSettingsOptions
-} from "./NitroGeolocation.nitro";
-
 export type { CurrentPositionOptions } from "./api/currentPositionOptions";
 
 export type {
@@ -26,6 +20,11 @@ export type {
   LocationSettingsOutcome,
   LocationSettingsResult,
   LocationAvailability,
+  LocationAvailabilityReason,
+  LastKnownPositionOptions,
+  PermissionStatus,
+  LocationRequestOptions,
+  LocationSettingsOptions,
   PermissionDetails,
   PermissionScope,
   PermissionSettingsGuidance,

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -21,6 +21,7 @@ import type {
   LocationSettingsOptions as SchemaLocationSettingsOptions,
   LocationSettingsOutcome as SchemaLocationSettingsOutcome,
   LocationSettingsResult as SchemaLocationSettingsResult,
+  NullableDouble as SchemaNullableDouble,
   PermissionStatus as SchemaPermissionStatus,
   ReverseGeocodedAddress as SchemaReverseGeocodedAddress
 } from "./types";
@@ -59,6 +60,7 @@ export type GeolocationResponse = SchemaGeolocationResponse & {
 export type LocationProviderStatus = SchemaLocationProviderStatus;
 export type LocationSettingsOutcome = SchemaLocationSettingsOutcome;
 export type LocationSettingsResult = SchemaLocationSettingsResult;
+export type NullableDouble = SchemaNullableDouble;
 export type LocationAvailabilityReason =
   | "unsupported"
   | "permissionUndetermined"

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -1,4 +1,3 @@
-import type { PermissionStatus } from "./NitroGeolocation.nitro";
 import type {
   AccuracyAuthorization as SchemaAccuracyAuthorization,
   ActiveWatch as SchemaActiveWatch,
@@ -8,7 +7,6 @@ import type {
   CompatGeolocationError as SchemaCompatGeolocationError,
   CompatGeolocationOptions as SchemaCompatGeolocationOptions,
   CompatGeolocationResponse as SchemaCompatGeolocationResponse,
-  CompatGeolocationResponseWithMetadataInternal as SchemaCompatGeolocationResponseWithMetadataInternal,
   GeocodedLocation as SchemaGeocodedLocation,
   GeocodingCoordinates as SchemaGeocodingCoordinates,
   GeolocationResponse as SchemaGeolocationResponse,
@@ -17,11 +15,13 @@ import type {
   IOSAccuracyPreset as SchemaIOSAccuracyPreset,
   IOSActivityType as SchemaIOSActivityType,
   LocationAccuracyOptions as SchemaLocationAccuracyOptions,
-  LocationAvailability as SchemaLocationAvailability,
   LocationProviderStatus as SchemaLocationProviderStatus,
   LocationProviderUsed as SchemaLocationProviderUsed,
+  LocationRequestOptions as SchemaLocationRequestOptions,
+  LocationSettingsOptions as SchemaLocationSettingsOptions,
   LocationSettingsOutcome as SchemaLocationSettingsOutcome,
   LocationSettingsResult as SchemaLocationSettingsResult,
+  PermissionStatus as SchemaPermissionStatus,
   ReverseGeocodedAddress as SchemaReverseGeocodedAddress
 } from "./types";
 
@@ -59,7 +59,23 @@ export type GeolocationResponse = SchemaGeolocationResponse & {
 export type LocationProviderStatus = SchemaLocationProviderStatus;
 export type LocationSettingsOutcome = SchemaLocationSettingsOutcome;
 export type LocationSettingsResult = SchemaLocationSettingsResult;
-export type LocationAvailability = SchemaLocationAvailability;
+export type LocationAvailabilityReason =
+  | "unsupported"
+  | "permissionUndetermined"
+  | "permissionDenied"
+  | "permissionRestricted"
+  | "locationServicesDisabled"
+  | "providerUnavailable"
+  | "temporarilyUnavailable"
+  | "authorizationUnknown"
+  | "unknown";
+export interface LocationAvailability {
+  available: boolean;
+  reason?: LocationAvailabilityReason;
+}
+export type PermissionStatus = SchemaPermissionStatus;
+export type LocationRequestOptions = SchemaLocationRequestOptions;
+export type LocationSettingsOptions = SchemaLocationSettingsOptions;
 
 export type LocationReadinessRemediation =
   | "requestPermission"
@@ -123,6 +139,20 @@ export type HeadingOptions = SchemaHeadingOptions;
 export type ActiveWatch = SchemaActiveWatch;
 export type ActiveWatchKind = SchemaActiveWatchKind;
 
+/** Cache filters accepted by `getLastKnownPositionAsync()`. */
+export interface LastKnownPositionOptions {
+  /** Maximum age of a cached location in milliseconds. Defaults to unbounded. */
+  maximumAge?: number;
+  /** Accuracy used for Android provider and cache-quality selection. */
+  accuracy?: LocationAccuracyOptions;
+  /** Android cache/provider granularity. */
+  granularity?: AndroidGranularity;
+  /** Require an Android cached fix to satisfy the requested accuracy. */
+  waitForAccurateLocation?: boolean;
+  /** Additional Android upper bound for cached update age. */
+  maxUpdateAge?: number;
+}
+
 export type CompatGeolocationResponse = SchemaCompatGeolocationResponse;
 
 /**
@@ -130,13 +160,10 @@ export type CompatGeolocationResponse = SchemaCompatGeolocationResponse;
  * Metadata remains optional because platform/runtime support can vary.
  */
 export type CompatGeolocationResponseWithMetadata =
-  SchemaCompatGeolocationResponse &
-    Partial<
-      Pick<
-        SchemaCompatGeolocationResponseWithMetadataInternal,
-        "mocked" | "provider"
-      >
-    >;
+  SchemaCompatGeolocationResponse & {
+    mocked?: boolean;
+    provider?: LocationProviderUsed;
+  };
 
 export type GeolocationCoordinates = GeolocationResponse["coords"];
 export type LocationProviderUsed = SchemaLocationProviderUsed;

--- a/packages/react-native-nitro-geolocation/src/types.ts
+++ b/packages/react-native-nitro-geolocation/src/types.ts
@@ -1,5 +1,11 @@
-// Shared Nitro schema structs. Public entry points re-export inferred aliases
-// from the Nitro/Compat specs in publicTypes.ts.
+// Shared Nitro schema structs. Public entry points expose these through the
+// package's public type facade.
+export type PermissionStatus =
+  | "granted"
+  | "denied"
+  | "restricted"
+  | "undetermined";
+
 export type LocationProviderUsed =
   | "fused"
   | "gps"
@@ -28,6 +34,63 @@ export type IOSActivityType =
 export interface LocationAccuracyOptions {
   android?: AndroidAccuracyPreset;
   ios?: IOSAccuracyPreset;
+}
+
+/** Options shared by native current-position, cache, and watch operations. */
+export interface LocationRequestOptions {
+  /** Timeout in milliseconds (default: 600000 / 10 minutes). */
+  timeout?: number;
+  /** Maximum age of cached location in milliseconds (default: 0). */
+  maximumAge?: number;
+  /** Platform-specific accuracy preset. */
+  accuracy?: LocationAccuracyOptions;
+  /** Minimum time interval between updates in milliseconds. */
+  interval?: number;
+  /** Fastest interval for Android updates. */
+  fastestInterval?: number;
+  /** Minimum distance change in meters. */
+  distanceFilter?: number;
+  /** Android location granularity. */
+  granularity?: AndroidGranularity;
+  /** Wait for a high-accuracy initial Android update. */
+  waitForAccurateLocation?: boolean;
+  /** Android maximum age for an initial update in milliseconds. */
+  maxUpdateAge?: number;
+  /** Android maximum batching delay in milliseconds. */
+  maxUpdateDelay?: number;
+  /** Android maximum number of updates before a watch stops itself. */
+  maxUpdates?: number;
+  /** Use significant location changes mode on iOS. */
+  useSignificantChanges?: boolean;
+  /** iOS activity type used to tune Core Location behavior. */
+  activityType?: IOSActivityType;
+  /** Allow iOS to pause location updates automatically. */
+  pausesLocationUpdatesAutomatically?: boolean;
+  /** Show the iOS background location indicator. */
+  showsBackgroundLocationIndicator?: boolean;
+}
+
+/** Android location-settings resolution options. */
+export interface LocationSettingsOptions {
+  accuracy?: LocationAccuracyOptions;
+  interval?: number;
+  fastestInterval?: number;
+  distanceFilter?: number;
+  alwaysShow?: boolean;
+  needBle?: boolean;
+}
+
+export type LocationErrorCode =
+  | "internalError"
+  | "permissionDenied"
+  | "positionUnavailable"
+  | "timeout"
+  | "playServicesUnavailable"
+  | "settingsNotSatisfied";
+
+export interface LocationError {
+  code: LocationErrorCode;
+  message: string;
 }
 
 export interface GeolocationCoordinates {

--- a/packages/react-native-nitro-geolocation/src/utils/errors.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/errors.ts
@@ -1,10 +1,9 @@
-export type LocationErrorCode =
-  | "internalError"
-  | "permissionDenied"
-  | "positionUnavailable"
-  | "timeout"
-  | "playServicesUnavailable"
-  | "settingsNotSatisfied";
+import type {
+  LocationError as SchemaLocationError,
+  LocationErrorCode as SchemaLocationErrorCode
+} from "../types";
+
+export type LocationErrorCode = SchemaLocationErrorCode;
 
 /**
  * Readable Modern API error codes.
@@ -31,10 +30,7 @@ export const LocationErrorCodes = {
 /**
  * Geolocation error object.
  */
-export interface LocationError {
-  code: LocationErrorCode;
-  message: string;
-}
+export type LocationError = SchemaLocationError;
 
 const locationErrorCodes = new Set<LocationErrorCode>(
   Object.values(LocationErrorCodes)

--- a/packages/react-native-nitro-geolocation/src/web/browser.ts
+++ b/packages/react-native-nitro-geolocation/src/web/browser.ts
@@ -1,9 +1,12 @@
 import type {
-  LocationError,
+  GeolocationResponse,
   LocationRequestOptions
-} from "../NitroGeolocation.nitro";
-import type { GeolocationResponse } from "../publicTypes";
-import { LocationErrorCodes, createLocationError } from "../utils/errors";
+} from "../publicTypes";
+import {
+  type LocationError,
+  LocationErrorCodes,
+  createLocationError
+} from "../utils/errors";
 
 type BrowserPermissionState = "granted" | "denied" | "prompt";
 

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -64,6 +64,15 @@ afterEach(() => {
 });
 
 describe("web Modern API", () => {
+  it("uses a stable availability reason when browser geolocation is unsupported", async () => {
+    setNavigator(undefined);
+
+    await expect(getLocationAvailability()).resolves.toEqual({
+      available: false,
+      reason: "unsupported"
+    });
+  });
+
   it("returns an unavailable detailed settings result without browser geolocation", async () => {
     setNavigator(undefined);
 
@@ -599,7 +608,7 @@ describe("web Modern API", () => {
 
     await expect(getLocationAvailability()).resolves.toEqual({
       available: false,
-      reason: "Browser geolocation permission is denied."
+      reason: "permissionDenied"
     });
   });
 

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -1,9 +1,3 @@
-import type {
-  LocationError,
-  LocationRequestOptions,
-  LocationSettingsOptions,
-  PermissionStatus
-} from "../NitroGeolocation.nitro";
 import {
   type CurrentPositionOptions,
   getAbortReason
@@ -23,16 +17,18 @@ import type {
   GeolocationConfiguration,
   GeolocationResponse,
   Heading,
+  LastKnownPositionOptions,
   LocationAvailability,
   LocationProviderStatus,
   LocationReadiness,
+  LocationSettingsOptions,
   LocationSettingsResult,
   PermissionDetails,
+  PermissionStatus,
   ReverseGeocodedAddress
 } from "../publicTypes";
-import { LocationErrorCodes } from "../utils/errors";
+import { type LocationError, LocationErrorCodes } from "../utils/errors";
 import {
-  createUnsupportedError,
   getGeolocation,
   getNavigator,
   mapBrowserError,
@@ -179,7 +175,7 @@ export async function getLocationAvailability(): Promise<LocationAvailability> {
   if (!getGeolocation()) {
     return {
       available: false,
-      reason: createUnsupportedError().message
+      reason: "unsupported"
     };
   }
 
@@ -190,7 +186,7 @@ export async function getLocationAvailability(): Promise<LocationAvailability> {
   if (permission === "denied" || permission === "restricted") {
     return {
       available: false,
-      reason: "Browser geolocation permission is denied."
+      reason: "permissionDenied"
     };
   }
 
@@ -340,7 +336,7 @@ export function getLastKnownPosition(): GeolocationResponse | undefined {
 }
 
 export function getLastKnownPositionAsync(
-  options?: LocationRequestOptions
+  options?: LastKnownPositionOptions
 ): Promise<GeolocationResponse | undefined> {
   const maximumAge = options?.maximumAge ?? Number.POSITIVE_INFINITY;
   return Promise.resolve(

--- a/packages/react-native-nitro-geolocation/src/web/permissionDetailsEvidence.ts
+++ b/packages/react-native-nitro-geolocation/src/web/permissionDetailsEvidence.ts
@@ -1,4 +1,4 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
+import type { PermissionStatus } from "../publicTypes";
 
 type ObservedPermissionStatus = Extract<PermissionStatus, "granted" | "denied">;
 

--- a/packages/react-native-nitro-geolocation/src/web/permissionEvidence.ts
+++ b/packages/react-native-nitro-geolocation/src/web/permissionEvidence.ts
@@ -1,4 +1,4 @@
-import type { PermissionStatus } from "../NitroGeolocation.nitro";
+import type { PermissionStatus } from "../publicTypes";
 
 type ObservedPermissionStatus = Extract<PermissionStatus, "granted" | "denied">;
 

--- a/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import type { LocationError } from "../NitroGeolocation.nitro";
 import type {
   UseWatchPositionOptions,
   UseWatchPositionResult
 } from "../hooks/types";
 import type { GeolocationResponse } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
 import { unwatch, watchPosition } from "./watch";
 
 export function useWatchPosition(

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -1,7 +1,3 @@
-import type {
-  LocationError,
-  LocationRequestOptions
-} from "../NitroGeolocation.nitro";
 import { decoratePositionWithMetadata } from "../api/locationMetadata";
 import { rememberPosition } from "../api/positionCache";
 import type {
@@ -9,9 +5,10 @@ import type {
   GeolocationResponse,
   Heading,
   HeadingOptions,
-  LocationProviderStatus
+  LocationProviderStatus,
+  LocationRequestOptions
 } from "../publicTypes";
-import { LocationErrorCodes } from "../utils/errors";
+import { type LocationError, LocationErrorCodes } from "../utils/errors";
 import {
   createUnsupportedError,
   distanceMeters,

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -9,6 +9,7 @@ import type {
   LocationErrorCode as LocationErrorCodeType,
   LocationRequestOptions,
   LocationSettingsOptions,
+  NullableDouble,
   PermissionStatus,
   UseWatchPositionResult
 } from "../src";
@@ -26,15 +27,38 @@ import type {
 } from "../src/NitroGeolocationCompat.nitro";
 import type {
   AndroidBackgroundProvider,
+  AccuracyAuthorization as BackgroundAccuracyAuthorization,
   BackgroundActivityEvent,
+  AndroidAccuracyPreset as BackgroundAndroidAccuracyPreset,
+  AndroidGranularity as BackgroundAndroidGranularity,
   BackgroundGeofenceEvent,
+  GeolocationCoordinates as BackgroundGeolocationCoordinates,
+  GeolocationResponse as BackgroundGeolocationResponse,
+  IOSAccuracyPreset as BackgroundIOSAccuracyPreset,
+  LocationAccuracyOptions as BackgroundLocationAccuracyOptions,
   BackgroundLocationDiagnosis,
+  LocationError as BackgroundLocationError,
+  LocationErrorCode as BackgroundLocationErrorCode,
+  LocationProviderStatus as BackgroundLocationProviderStatus,
+  LocationProviderUsed as BackgroundLocationProviderUsed,
+  NullableDouble as BackgroundNullableDouble,
+  PermissionStatus as BackgroundPermissionStatus,
   StartActivityRecognitionOptions
 } from "../src/background";
 import type {
   BackgroundActivityEventEnvelope as NativeBackgroundActivityEvent,
   BackgroundGeofenceEventEnvelope as NativeBackgroundGeofenceEvent
 } from "../src/background/types";
+import type {
+  AndroidAccuracyPreset as CompatAndroidAccuracyPreset,
+  AuthorizationLevel as CompatAuthorizationLevel,
+  GeolocationCoordinates as CompatGeolocationCoordinates,
+  IOSAccuracyPreset as CompatIOSAccuracyPreset,
+  IOSActivityType as CompatIOSActivityType,
+  LocationAccuracyOptions as CompatLocationAccuracyOptions,
+  LocationProvider as CompatLocationProvider,
+  NullableDouble as CompatNullableDouble
+} from "../src/compat";
 import type { CompatGeolocationConfiguration } from "../src/publicTypes";
 import type { LocationAvailability as NativeLocationAvailability } from "../src/types";
 
@@ -86,6 +110,7 @@ type _LocationAvailabilityReasonIsExact = Expect<
     | "unknown"
   >
 >;
+type _NullableDoubleIsExact = Expect<Equal<NullableDouble, number | null>>;
 type _LocationAvailabilityUsesPublicReason = Expect<
   Equal<LocationAvailability["reason"], LocationAvailabilityReason | undefined>
 >;
@@ -137,6 +162,64 @@ type _StartActivityOptionsAreActionSpecific = Expect<
       stopOnStill?: boolean;
       minimumConfidence?: number;
     }
+  >
+>;
+type _BackgroundEntrypointExportsRelatedRootTypes = Expect<
+  Equal<
+    [
+      BackgroundAccuracyAuthorization,
+      BackgroundAndroidAccuracyPreset,
+      BackgroundAndroidGranularity,
+      BackgroundGeolocationCoordinates,
+      BackgroundGeolocationResponse,
+      BackgroundIOSAccuracyPreset,
+      BackgroundLocationAccuracyOptions,
+      BackgroundLocationError,
+      BackgroundLocationErrorCode,
+      BackgroundLocationProviderStatus,
+      BackgroundLocationProviderUsed,
+      BackgroundNullableDouble,
+      BackgroundPermissionStatus
+    ],
+    [
+      import("../src").AccuracyAuthorization,
+      import("../src").AndroidAccuracyPreset,
+      import("../src").AndroidGranularity,
+      import("../src/types").GeolocationCoordinates,
+      import("../src/types").GeolocationResponse,
+      import("../src").IOSAccuracyPreset,
+      import("../src").LocationAccuracyOptions,
+      import("../src").LocationError,
+      import("../src").LocationErrorCode,
+      import("../src").LocationProviderStatus,
+      import("../src").LocationProviderUsed,
+      import("../src").NullableDouble,
+      import("../src").PermissionStatus
+    ]
+  >
+>;
+type _CompatEntrypointExportsRelatedRootTypes = Expect<
+  Equal<
+    [
+      CompatAndroidAccuracyPreset,
+      CompatAuthorizationLevel,
+      CompatGeolocationCoordinates,
+      CompatIOSAccuracyPreset,
+      CompatIOSActivityType,
+      CompatLocationAccuracyOptions,
+      CompatLocationProvider,
+      CompatNullableDouble
+    ],
+    [
+      import("../src").AndroidAccuracyPreset,
+      import("../src").AuthorizationLevel,
+      import("../src").GeolocationCoordinates,
+      import("../src").IOSAccuracyPreset,
+      import("../src").IOSActivityType,
+      import("../src").LocationAccuracyOptions,
+      import("../src").LocationProvider,
+      import("../src").NullableDouble
+    ]
   >
 >;
 type _RootConfigurationMatchesNativeContract = Expect<

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -1,14 +1,24 @@
 import { LocationErrorCodes } from "../src";
 import type {
+  CurrentPositionOptions,
   GeolocationConfiguration,
+  LastKnownPositionOptions,
+  LocationAvailability,
+  LocationAvailabilityReason,
   LocationError,
   LocationErrorCode as LocationErrorCodeType,
+  LocationRequestOptions,
+  LocationSettingsOptions,
+  PermissionStatus,
   UseWatchPositionResult
 } from "../src";
 import type {
   GeolocationConfiguration as NativeGeolocationConfiguration,
   LocationError as NativeLocationError,
-  LocationProvider as NativeLocationProvider
+  LocationProvider as NativeLocationProvider,
+  LocationRequestOptions as NativeLocationRequestOptions,
+  LocationSettingsOptions as NativeLocationSettingsOptions,
+  PermissionStatus as NativePermissionStatus
 } from "../src/NitroGeolocation.nitro";
 import type {
   CompatGeolocationConfigurationInternal,
@@ -16,9 +26,26 @@ import type {
 } from "../src/NitroGeolocationCompat.nitro";
 import type {
   AndroidBackgroundProvider,
-  BackgroundLocationDiagnosis
+  BackgroundActivityEvent,
+  BackgroundGeofenceEvent,
+  BackgroundLocationDiagnosis,
+  StartActivityRecognitionOptions
 } from "../src/background";
+import type {
+  BackgroundActivityEventEnvelope as NativeBackgroundActivityEvent,
+  BackgroundGeofenceEventEnvelope as NativeBackgroundGeofenceEvent
+} from "../src/background/types";
 import type { CompatGeolocationConfiguration } from "../src/publicTypes";
+import type { LocationAvailability as NativeLocationAvailability } from "../src/types";
+
+// @ts-expect-error Nitro's nullable bridge envelope is not a public API type.
+import type { BackgroundEventEnvelope } from "../src/background";
+// @ts-expect-error Nitro's stored bridge envelope is not a public API type.
+import type { StoredBackgroundEventEnvelope } from "../src/background";
+
+type _BackgroundEventEnvelopeMustStayPrivate = BackgroundEventEnvelope;
+type _StoredBackgroundEventEnvelopeMustStayPrivate =
+  StoredBackgroundEventEnvelope;
 
 type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
   Value
@@ -45,6 +72,48 @@ type _LocationErrorCodeIsExact = Expect<
     | "settingsNotSatisfied"
   >
 >;
+type _LocationAvailabilityReasonIsExact = Expect<
+  Equal<
+    LocationAvailabilityReason,
+    | "unsupported"
+    | "permissionUndetermined"
+    | "permissionDenied"
+    | "permissionRestricted"
+    | "locationServicesDisabled"
+    | "providerUnavailable"
+    | "temporarilyUnavailable"
+    | "authorizationUnknown"
+    | "unknown"
+  >
+>;
+type _LocationAvailabilityUsesPublicReason = Expect<
+  Equal<LocationAvailability["reason"], LocationAvailabilityReason | undefined>
+>;
+type _NativeAvailabilityWireShapeIsUnchanged = Expect<
+  Equal<NativeLocationAvailability["reason"], string | undefined>
+>;
+type _PermissionStatusMatchesNativeContract = Expect<
+  Equal<PermissionStatus, NativePermissionStatus>
+>;
+type _RequestOptionsMatchNativeContract = Expect<
+  Equal<LocationRequestOptions, NativeLocationRequestOptions>
+>;
+type _SettingsOptionsMatchNativeContract = Expect<
+  Equal<LocationSettingsOptions, NativeLocationSettingsOptions>
+>;
+type _LastKnownPositionOptionsAreCacheSpecific = Expect<
+  Equal<
+    keyof LastKnownPositionOptions,
+    | "maximumAge"
+    | "accuracy"
+    | "granularity"
+    | "waitForAccurateLocation"
+    | "maxUpdateAge"
+  >
+>;
+type _CurrentPositionOptionsExcludeWatchLimit = Expect<
+  Equal<Extract<"maxUpdates", keyof CurrentPositionOptions>, never>
+>;
 type _HookResultIsNamed = Expect<
   Equal<UseWatchPositionResult["error"], LocationError | null>
 >;
@@ -53,6 +122,22 @@ type _BackgroundDiagnosisIsNamed = Expect<
 >;
 type _BackgroundProviderIsPublic = Expect<
   Equal<AndroidBackgroundProvider, "auto" | "playServices" | "android">
+>;
+type _BackgroundGeofenceEventHasPublicName = Expect<
+  Equal<BackgroundGeofenceEvent, NativeBackgroundGeofenceEvent>
+>;
+type _BackgroundActivityEventHasPublicName = Expect<
+  Equal<BackgroundActivityEvent, NativeBackgroundActivityEvent>
+>;
+type _StartActivityOptionsAreActionSpecific = Expect<
+  Equal<
+    StartActivityRecognitionOptions,
+    {
+      interval?: number;
+      stopOnStill?: boolean;
+      minimumConfidence?: number;
+    }
+  >
 >;
 type _RootConfigurationMatchesNativeContract = Expect<
   Equal<


### PR DESCRIPTION
## Description

Completes the critical public-API audit for the RoadMap in #98 and follows up on the first boundary fix in #184.

The RoadMap features were already implemented by their linked issues and PRs. This PR verifies that those checked items are actually usable through the published package entry points, then fixes the cross-cutting declaration, type-export, native/web parity, and package-resolution gaps found by that audit.

### RoadMap audit result

| RoadMap area | What was verified | Result |
| --- | --- | --- |
| v1.5 selected work (#157–#175) | Root, compat, and background APIs; docs and consumer contracts; doctor/config-plugin packaging; privacy and release documentation | Pass |
| Existing v2 items (#150, #151, #154) | Removed Modern alias, Modern-only removal of enableHighAccuracy, and sync/async last-known-position split | Pass |
| Additional v2 items (#155, #156, #176, #177) | Deterministic settings results, Watch Manager contracts, unified background events, and migrated error taxonomy | Pass |
| Release preparation (#153, #160, #178) | RC package metadata, optional SPM guidance, and 1.x/2.x documentation snapshots | Pass |

### Findings fixed

- Move shared public schemas out of Nitro spec declarations so emitted public types do not originate from codegen contracts.
- Replace inferred background declarations with explicit public contracts.
- Keep nullable bridge envelopes private while exposing named discriminated background event types.
- Restore native/web parity for background diagnosis, task registration, availability reasons, and all published entry points.
- Keep the public provider spelling as `"android"` and confine `"android_platform"` to the Nitro bridge conversion boundary.
- Separate the `LocationErrorCode` annotation type from the `LocationErrorCodes` runtime constants.
- Add action-specific `StartActivityRecognitionOptions` and `LastKnownPositionOptions`.
- Remove watch-only `maxUpdates` from one-shot `CurrentPositionOptions`.
- Export the missing root `NullableDouble` coordinate type.
- Make `/compat` self-contained by exporting all eight supporting types used by its public configuration, options, and response contracts.
- Make `/background` self-contained by exporting all thirteen root/raw-schema types reachable from its public contracts.
- Add `typesVersions` fallbacks so legacy TypeScript `moduleResolution: node` can resolve `/compat` and `/background`.
- Add source-level and package-name consumer contracts that fail compilation if these exports regress.

Closes #98.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Checklist

- [x] My code follows the project style
- [x] I've tested my changes locally
- [x] Documentation updated (if needed)

## E2E Test Results

Native Maestro E2E was not run for this PR. The changes are public TypeScript/declaration boundaries and bridge spelling conversion, with no new native location behavior. Native contract coverage was exercised by CI through Android unit tests, Android prebuilt checksum verification, and the iOS lifecycle contract test.

**Platform tested:**
- [ ] iOS
- [ ] Android
- [ ] N/A (docs only)

**Test artifacts:**

No screenshots or videos; no E2E failures to report.

---

## Additional Notes

### Compatibility guarantees

- Default `/compat` responses remain exactly `{ coords, timestamp }`; metadata remains opt-in.
- `enableHighAccuracy` remains available in `/compat` and remains absent from the Modern v2 API.
- The Nitro ABI and native wire shapes are unchanged.
- Internal background event envelopes remain unexported and package deep imports remain blocked.
- `/background` exports the raw background `GeolocationResponse` schema intentionally; it does not alias the Modern root facade that adds optional delivery metadata.
- `LocationErrorCodes` is not duplicated into `/background`: it is a runtime convenience value, not a named type required by a background signature.

### Audit evidence

- Three independent audits covered the Modern root, `/compat`, and `/background`, followed by a second post-fix audit.
- Native/web compiler-symbol parity:
  - root: 161 / 161
  - compat: 22 / 22
  - background: 90 / 90
- Recursive background type graph: 59 reachable repository-owned named symbols, 0 missing exports.
- Legacy and modern TypeScript resolution passed for `node`, `node16`, `nodenext`, and `bundler`.
- Packed-package checks confirmed all public entry files and supporting type sources are published.

### Validation

- `yarn format:check`
- `yarn lint`
- package TypeScript check
- React Native example TypeScript check using package-name imports
- legacy `moduleResolution: node` consumer compile
- `yarn test:unit` — 24 files, 195 tests
- background unit tests — 3 files, 8 tests
- `yarn build:all`
- `yarn pack:check`
- `yarn deadcode`
- `yarn source-lines:check`
- all PR checks green, including TypeScript, Android unit tests, iOS lifecycle contract, package guardrails, docs, Changeset, and Cloudflare Pages
