### PR TITLE
perf: remove work from location hot paths

### DIFF
--- a/.changeset/fast-location-hot-paths.md
+++ b/.changeset/fast-location-hot-paths.md
@@ -2,7 +2,8 @@
 "react-native-nitro-geolocation": patch
 ---
 
-Reduce location and heading hot-path work across Android, iOS, and Web by
-deferring response conversion until delivery, reusing sensor buffers, avoiding
-unchanged native configuration writes, and limiting iOS background persistence
-to the collections that changed.
+Reduce location, heading, and background-processing hot-path work across
+Android, iOS, and Web. Response conversion and metadata allocation are deferred
+until delivery, sensor buffers and shared polling are reused, unchanged native
+configuration and persistence writes are skipped, and batched background work
+avoids repeated serialization, sync admission, and unindexed queue scans.

--- a/.changeset/fast-location-hot-paths.md
+++ b/.changeset/fast-location-hot-paths.md
@@ -1,0 +1,8 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Reduce location and heading hot-path work across Android, iOS, and Web by
+deferring response conversion until delivery, reusing sensor buffers, avoiding
+unchanged native configuration writes, and limiting iOS background persistence
+to the collections that changed.

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidHeadingManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidHeadingManager.kt
@@ -50,8 +50,18 @@ internal class AndroidHeadingManager(
 
     private var isListening = false
     private var sensorAccuracy: Int? = null
-    private var gravityValues: FloatArray? = null
-    private var magneticValues: FloatArray? = null
+    private val gravityValues = FloatArray(3)
+    private val magneticValues = FloatArray(3)
+    private val rotationMatrix = FloatArray(9)
+    private val inclinationMatrix = FloatArray(9)
+    private val orientation = FloatArray(3)
+    private var hasGravityValues = false
+    private var hasMagneticValues = false
+    private var declinationLatitude = Double.NaN
+    private var declinationLongitude = Double.NaN
+    private var declinationAltitude = Double.NaN
+    private var declinationTime = Long.MIN_VALUE
+    private var cachedDeclination = 0.0
 
     private val sensorListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
@@ -61,17 +71,19 @@ internal class AndroidHeadingManager(
                     headingFromRotationVector(event.values)
                 }
                 Sensor.TYPE_ACCELEROMETER -> {
-                    gravityValues = event.values.clone()
+                    event.values.copyInto(gravityValues, endIndex = gravityValues.size)
+                    hasGravityValues = true
                     headingFromAccelerationAndMagnetometer()
                 }
                 Sensor.TYPE_MAGNETIC_FIELD -> {
-                    magneticValues = event.values.clone()
+                    event.values.copyInto(magneticValues, endIndex = magneticValues.size)
+                    hasMagneticValues = true
                     headingFromAccelerationAndMagnetometer()
                 }
                 else -> null
             } ?: return
 
-            emitHeading(createHeading(magneticHeading))
+            emitHeading(magneticHeading)
         }
 
         override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
@@ -220,29 +232,28 @@ internal class AndroidHeadingManager(
             // Ignore unregister races.
         }
         isListening = false
-        gravityValues = null
-        magneticValues = null
+        hasGravityValues = false
+        hasMagneticValues = false
     }
 
     private fun headingFromRotationVector(values: FloatArray): Double? {
-        val rotationMatrix = FloatArray(9)
-        val orientation = FloatArray(3)
         SensorManager.getRotationMatrixFromVector(rotationMatrix, values)
         SensorManager.getOrientation(rotationMatrix, orientation)
         return normalizeHeading(Math.toDegrees(orientation[0].toDouble()))
     }
 
     private fun headingFromAccelerationAndMagnetometer(): Double? {
-        val gravity = gravityValues ?: return null
-        val magnetic = magneticValues ?: return null
-        val rotationMatrix = FloatArray(9)
-        val inclinationMatrix = FloatArray(9)
+        if (!hasGravityValues || !hasMagneticValues) return null
 
-        if (!SensorManager.getRotationMatrix(rotationMatrix, inclinationMatrix, gravity, magnetic)) {
+        if (!SensorManager.getRotationMatrix(
+                rotationMatrix,
+                inclinationMatrix,
+                gravityValues,
+                magneticValues
+            )) {
             return null
         }
 
-        val orientation = FloatArray(3)
         SensorManager.getOrientation(rotationMatrix, orientation)
         return normalizeHeading(Math.toDegrees(orientation[0].toDouble()))
     }
@@ -250,13 +261,7 @@ internal class AndroidHeadingManager(
     private fun createHeading(magneticHeading: Double): Heading {
         val referenceLocation = getReferenceLocation()
         val trueHeading = referenceLocation?.let { location ->
-            val field = GeomagneticField(
-                location.latitude.toFloat(),
-                location.longitude.toFloat(),
-                if (location.hasAltitude()) location.altitude.toFloat() else 0f,
-                location.time
-            )
-            normalizeHeading(magneticHeading + field.declination)
+            normalizeHeading(magneticHeading + declination(location))
         }
 
         return Heading(
@@ -269,12 +274,38 @@ internal class AndroidHeadingManager(
         )
     }
 
-    private fun emitHeading(heading: Heading) {
+    private fun declination(location: Location): Double {
+        val altitude = if (location.hasAltitude()) location.altitude else 0.0
+        if (
+            location.latitude != declinationLatitude ||
+            location.longitude != declinationLongitude ||
+            altitude != declinationAltitude ||
+            location.time != declinationTime
+        ) {
+            cachedDeclination = GeomagneticField(
+                location.latitude.toFloat(),
+                location.longitude.toFloat(),
+                altitude.toFloat(),
+                location.time
+            ).declination.toDouble()
+            declinationLatitude = location.latitude
+            declinationLongitude = location.longitude
+            declinationAltitude = altitude
+            declinationTime = location.time
+        }
+        return cachedDeclination
+    }
+
+    private fun emitHeading(magneticHeading: Double) {
+        var heading: Heading? = null
         val pendingSnapshot = pendingRequests.values.toList()
         pendingSnapshot.forEach { request ->
             mainHandler.removeCallbacks(request.timeoutRunnable)
             if (pendingRequests.remove(request.id) != null) {
-                request.success(heading)
+                val deliveredHeading = heading ?: createHeading(magneticHeading).also {
+                    heading = it
+                }
+                request.success(deliveredHeading)
             }
         }
 
@@ -282,10 +313,13 @@ internal class AndroidHeadingManager(
             val lastHeading = subscription.lastDeliveredHeading
             if (
                 lastHeading == null ||
-                angularDistance(lastHeading, heading.magneticHeading) >= subscription.headingFilter
+                angularDistance(lastHeading, magneticHeading) >= subscription.headingFilter
             ) {
-                subscription.lastDeliveredHeading = heading.magneticHeading
-                subscription.success(heading)
+                subscription.lastDeliveredHeading = magneticHeading
+                val deliveredHeading = heading ?: createHeading(magneticHeading).also {
+                    heading = it
+                }
+                subscription.success(deliveredHeading)
             }
         }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidHeadingManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidHeadingManager.kt
@@ -298,14 +298,16 @@ internal class AndroidHeadingManager(
 
     private fun emitHeading(magneticHeading: Double) {
         var heading: Heading? = null
-        val pendingSnapshot = pendingRequests.values.toList()
-        pendingSnapshot.forEach { request ->
-            mainHandler.removeCallbacks(request.timeoutRunnable)
-            if (pendingRequests.remove(request.id) != null) {
-                val deliveredHeading = heading ?: createHeading(magneticHeading).also {
-                    heading = it
+        if (pendingRequests.isNotEmpty()) {
+            val pendingSnapshot = pendingRequests.values.toList()
+            pendingSnapshot.forEach { request ->
+                mainHandler.removeCallbacks(request.timeoutRunnable)
+                if (pendingRequests.remove(request.id) != null) {
+                    val deliveredHeading = heading ?: createHeading(magneticHeading).also {
+                        heading = it
+                    }
+                    request.success(deliveredHeading)
                 }
-                request.success(deliveredHeading)
             }
         }
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
@@ -24,6 +24,7 @@ internal class AndroidPositionWatchManager(
     private val subscriptions = AndroidWatchCollection<WatchSubscription>()
     private var platformListener: LocationListener? = null
     private var fusedCallback: LocationCallback? = null
+    private var activeRequestOptions: ParsedOptions? = null
     private var generation = 0L
 
     fun watch(
@@ -50,7 +51,6 @@ internal class AndroidPositionWatchManager(
     fun activeWatches(): Array<ActiveWatch> = dispatcher.sync {
         subscriptions.tokens()
             .map { ActiveWatch(token = it, kind = ActiveWatchKind.POSITION) }
-            .sortedBy { it.token }
             .toTypedArray()
     }
 
@@ -58,23 +58,27 @@ internal class AndroidPositionWatchManager(
         dispatcher.sync { applyTransition(subscriptions.clear()) }
     }
 
-    private fun start() {
+    private fun start(options: ParsedOptions = mergeOptions()) {
         val activeGeneration = generation
+        activeRequestOptions = options
         if (providerRoute() == AndroidProviderRoute.FUSED) {
-            startFused(activeGeneration)
+            startFused(activeGeneration, options)
         } else {
-            startPlatform(activeGeneration)
+            startPlatform(activeGeneration, options)
         }
     }
 
     private fun isActive(activeGeneration: Long): Boolean =
         !subscriptions.isEmpty() && generation == activeGeneration
 
-    private fun startPlatform(activeGeneration: Long) {
+    private fun startPlatform(
+        activeGeneration: Long,
+        options: ParsedOptions = mergeOptions()
+    ) {
         if (!isActive(activeGeneration)) return
-        val options = mergeOptions()
         val provider = getValidProvider(options)
         if (provider == null) {
+            activeRequestOptions = null
             notifyProviderUnavailable()
             return
         }
@@ -90,6 +94,7 @@ internal class AndroidPositionWatchManager(
             override fun onProviderDisabled(provider: String) {
                 dispatcher.sync {
                     if (!isActive(activeGeneration)) return@sync
+                    activeRequestOptions = null
                     notifyError(LocationError(
                         code = SETTINGS_NOT_SATISFIED,
                         message = "Provider disabled: $provider"
@@ -118,6 +123,7 @@ internal class AndroidPositionWatchManager(
                 Looper.getMainLooper()
             )
         } catch (error: SecurityException) {
+            activeRequestOptions = null
             notifyError(LocationError(
                 code = PERMISSION_DENIED,
                 message = "Permission denied: ${error.message}"
@@ -125,9 +131,8 @@ internal class AndroidPositionWatchManager(
         }
     }
 
-    private fun startFused(activeGeneration: Long) {
+    private fun startFused(activeGeneration: Long, options: ParsedOptions) {
         if (!isActive(activeGeneration)) return
-        val options = mergeOptions()
         val callback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
                 val location = result.lastLocation ?: return
@@ -147,8 +152,9 @@ internal class AndroidPositionWatchManager(
                 removeFusedCallback()
                 runAndroidWatchPositionFallbackAfterFusedFailure(
                     locationProvider = configuredProvider(),
-                    runPlatformFallback = { startPlatform(activeGeneration) },
+                    runPlatformFallback = { startPlatform(activeGeneration, options) },
                     failWithoutFallback = {
+                        activeRequestOptions = null
                         if (error != null) notifyError(error) else notifyProviderUnavailable()
                     }
                 )
@@ -270,6 +276,7 @@ internal class AndroidPositionWatchManager(
 
     private fun stop() {
         generation += 1
+        activeRequestOptions = null
         removePlatformListener()
         removeFusedCallback()
     }
@@ -288,16 +295,19 @@ internal class AndroidPositionWatchManager(
         fusedCallback = null
     }
 
-    private fun restart() {
+    private fun restart(options: ParsedOptions) {
         stop()
-        start()
+        start(options)
     }
 
     private fun applyTransition(transition: AndroidWatchTransition) {
         when (transition) {
             AndroidWatchTransition.NONE -> Unit
             AndroidWatchTransition.START -> start()
-            AndroidWatchTransition.RESTART -> restart()
+            AndroidWatchTransition.RESTART -> {
+                val options = mergeOptions()
+                if (options != activeRequestOptions) restart(options)
+            }
             AndroidWatchTransition.STOP -> stop()
         }
     }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidPositionWatchManager.kt
@@ -83,7 +83,7 @@ internal class AndroidPositionWatchManager(
             override fun onLocationChanged(location: Location) {
                 dispatcher.sync {
                     if (!isActive(activeGeneration)) return@sync
-                    deliver(locationToPosition(location, null))
+                    deliver(location, null)
                 }
             }
 
@@ -133,7 +133,7 @@ internal class AndroidPositionWatchManager(
                 val location = result.lastLocation ?: return
                 dispatcher.sync {
                     if (!isActive(activeGeneration)) return@sync
-                    deliver(locationToPosition(location, LocationProviderUsed.FUSED))
+                    deliver(location, LocationProviderUsed.FUSED)
                 }
             }
         }
@@ -210,14 +210,15 @@ internal class AndroidPositionWatchManager(
         )
     }
 
-    private fun deliver(position: GeolocationResponse) {
+    private fun deliver(location: Location, provider: LocationProviderUsed?) {
         var removedFinishedWatch = false
+        var position: GeolocationResponse? = null
         val elapsedRealtimeMillis = SystemClock.elapsedRealtime()
         subscriptions.forEachCurrent { token, subscription ->
             val decision = evaluateAndroidWatchDelivery(
                 previous = subscription.deliveryState,
-                latitude = position.coords.latitude,
-                longitude = position.coords.longitude,
+                latitude = location.latitude,
+                longitude = location.longitude,
                 elapsedRealtimeMillis = elapsedRealtimeMillis,
                 minimumIntervalMillis = subscription.options.interval,
                 distanceFilterMeters = subscription.options.distanceFilter
@@ -226,7 +227,10 @@ internal class AndroidPositionWatchManager(
 
             subscription.deliveryState = decision.nextState
             subscription.deliveredUpdates += 1
-            subscription.success(position)
+            val deliveredPosition = position ?: locationToPosition(location, provider).also {
+                position = it
+            }
+            subscription.success(deliveredPosition)
             val maxUpdates = subscription.options.maxUpdates
             if (maxUpdates != null && subscription.deliveredUpdates >= maxUpdates) {
                 removedFinishedWatch = subscriptions.removeCurrent(token, subscription) ||

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntime.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidWatchRuntime.kt
@@ -47,7 +47,7 @@ internal class AndroidWatchCollection<T> {
     fun tokens(): List<String> = entries.keys.toList()
 
     fun forEachCurrent(deliver: (String, T) -> Unit) {
-        val snapshot = entries.toList()
+        val snapshot = entries.entries.toList()
         for ((token, value) in snapshot) {
             if (entries[token] === value) deliver(token, value)
         }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/GetCurrentPosition.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/GetCurrentPosition.kt
@@ -111,24 +111,20 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
             locationManager: LocationManager,
             accuracy: AndroidAccuracyResolution
     ): String? {
+        val fineGranted = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+        val coarseGranted = fineGranted || hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
         return accuracy.providerOrder().firstOrNull { provider ->
-            isProviderValid(locationManager, provider)
+            isProviderValid(locationManager, provider, fineGranted, coarseGranted)
         }
     }
 
-    private fun isProviderValid(locationManager: LocationManager, provider: String): Boolean {
+    private fun isProviderValid(
+            locationManager: LocationManager,
+            provider: String,
+            fineGranted: Boolean,
+            coarseGranted: Boolean
+    ): Boolean {
         if (!locationManager.isProviderEnabled(provider)) return false
-
-        val fineGranted =
-                ContextCompat.checkSelfPermission(
-                        reactContext,
-                        Manifest.permission.ACCESS_FINE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
-        val coarseGranted =
-                ContextCompat.checkSelfPermission(
-                        reactContext,
-                        Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
 
         return if (provider == LocationManager.GPS_PROVIDER) {
             fineGranted
@@ -136,6 +132,10 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
             coarseGranted || fineGranted
         }
     }
+
+    private fun hasPermission(permission: String): Boolean =
+            ContextCompat.checkSelfPermission(reactContext, permission) ==
+                    PackageManager.PERMISSION_GRANTED
 
     private fun requestFreshLocation(
             locationManager: LocationManager,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -505,12 +505,11 @@ class NitroGeolocation(
         options: LocationRequestOptions,
         error: ((LocationError) -> Unit)?
     ): String {
-        val token = UUID.randomUUID().toString()
         val parsedOptions = ParsedOptions.parse(options)
         val validationError = validateParsedOptions(parsedOptions)
         if (validationError != null) {
             error?.invoke(validationError)
-            return token
+            return UUID.randomUUID().toString()
         }
         val permissionError = if (!hasLocationPermission()) {
             createLocationError(
@@ -522,7 +521,7 @@ class NitroGeolocation(
         }
         if (permissionError != null) {
             error?.invoke(permissionError)
-            return token
+            return UUID.randomUUID().toString()
         }
 
         return positionWatchManager.watch(success, error, parsedOptions)
@@ -702,25 +701,35 @@ class NitroGeolocation(
     }
 
     private fun getValidProviders(options: ParsedOptions): List<String> {
-        return getValidProviders(options.androidAccuracy)
-            .filter { provider -> options.granularity.allowsProvider(provider) }
+        return getValidProviders(options.androidAccuracy, options.granularity)
     }
 
-    private fun getValidProviders(accuracy: AndroidAccuracyResolution): List<String> {
+    private fun getValidProviders(
+        accuracy: AndroidAccuracyResolution,
+        granularity: AndroidGranularity? = null
+    ): List<String> {
+        val fineGranted = hasFineLocationPermission()
+        val coarseGranted = fineGranted || hasCoarseLocationPermission()
         return accuracy.providerOrder()
-            .distinct()
-            .filter { provider -> isProviderValid(provider) }
+            .filter { provider ->
+                granularity.allowsProvider(provider) &&
+                    isProviderValid(provider, fineGranted, coarseGranted)
+            }
     }
 
-    private fun isProviderValid(provider: String): Boolean {
+    private fun isProviderValid(
+        provider: String,
+        fineGranted: Boolean,
+        coarseGranted: Boolean
+    ): Boolean {
         return try {
             if (!locationManager.isProviderEnabled(provider)) return false
 
             when (provider) {
-                AndroidLocationManager.GPS_PROVIDER -> hasFineLocationPermission()
-                AndroidLocationManager.NETWORK_PROVIDER -> hasCoarseLocationPermission() || hasFineLocationPermission()
-                AndroidLocationManager.PASSIVE_PROVIDER -> hasLocationPermission()
-                else -> hasLocationPermission()
+                AndroidLocationManager.GPS_PROVIDER -> fineGranted
+                AndroidLocationManager.NETWORK_PROVIDER -> coarseGranted
+                AndroidLocationManager.PASSIVE_PROVIDER -> coarseGranted
+                else -> coarseGranted
             }
         } catch (e: Exception) {
             false

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -89,16 +89,13 @@ class NitroGeolocation(
         AndroidHeadingManager(
             context = reactContext,
             createLocationError = ::createLocationError,
-            getReferenceLocation = {
-                lastLocation ?: getBestCachedLocation(
-                    getValidProviders(resolveAndroidAccuracy(null, enableHighAccuracy = false)),
-                    ParsedOptions.parseLastKnown(null)
-                )
-            }
+            getReferenceLocation = ::getHeadingReferenceLocation
         )
     }
     private val geocoder by lazy { AndroidGeocoder(reactContext) }
     private var lastLocation: Location? = null
+    private var cachedHeadingReferenceLocation: Location? = null
+    private var didResolveHeadingReferenceLocation = false
 
     // Permission callbacks
     private val pendingPermissionResolvers = mutableListOf<(PermissionStatus) -> Unit>()
@@ -805,6 +802,18 @@ class NitroGeolocation(
         }
 
         return bestLocation
+    }
+
+    private fun getHeadingReferenceLocation(): Location? {
+        lastLocation?.let { return it }
+        if (!didResolveHeadingReferenceLocation) {
+            cachedHeadingReferenceLocation = getBestCachedLocation(
+                getValidProviders(resolveAndroidAccuracy(null, enableHighAccuracy = false)),
+                ParsedOptions.parseLastKnown(null)
+            )
+            didResolveHeadingReferenceLocation = true
+        }
+        return cachedHeadingReferenceLocation
     }
 
     // MARK: - Helper Functions - Conversion

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/WatchPosition.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/WatchPosition.kt
@@ -20,24 +20,30 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
     private val watchIdGenerator = AtomicInteger(0)
     private var locationListener: LocationListener? = null
     private var watchedProvider: String? = null
-    private var currentOptions: CompatGeolocationOptions? = null
 
-    data class WatchCallback(
-            val success: (Location) -> Unit,
-            val error: ((CompatGeolocationError) -> Unit)?,
-            val options: CompatGeolocationOptions?
-    )
+    private sealed interface WatchCallback {
+        val error: ((CompatGeolocationError) -> Unit)?
+        val options: CompatGeolocationOptions?
+    }
+
+    private data class PositionWatchCallback(
+            val success: (CompatGeolocationResponse) -> Unit,
+            override val error: ((CompatGeolocationError) -> Unit)?,
+            override val options: CompatGeolocationOptions?
+    ) : WatchCallback
+
+    private data class MetadataWatchCallback(
+            val success: (CompatGeolocationResponseWithMetadataInternal) -> Unit,
+            override val error: ((CompatGeolocationError) -> Unit)?,
+            override val options: CompatGeolocationOptions?
+    ) : WatchCallback
 
     fun watch(
             success: (CompatGeolocationResponse) -> Unit,
             error: ((CompatGeolocationError) -> Unit)?,
             options: CompatGeolocationOptions?
     ): Int {
-        return watchLocation(
-                success = { location -> success(location.toCompatGeolocationResponse()) },
-                error = error,
-                options = options
-        )
+        return addWatch(PositionWatchCallback(success, error, options))
     }
 
     fun watchWithMetadata(
@@ -45,26 +51,16 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
             error: ((CompatGeolocationError) -> Unit)?,
             options: CompatGeolocationOptions?
     ): Int {
-        return watchLocation(
-                success = { location ->
-                    success(location.toCompatGeolocationResponseWithMetadata())
-                },
-                error = error,
-                options = options
-        )
+        return addWatch(MetadataWatchCallback(success, error, options))
     }
 
-    private fun watchLocation(
-            success: (Location) -> Unit,
-            error: ((CompatGeolocationError) -> Unit)?,
-            options: CompatGeolocationOptions?
-    ): Int {
+    private fun addWatch(callback: WatchCallback): Int {
         val watchId = watchIdGenerator.incrementAndGet()
-        watchCallbacks[watchId] = WatchCallback(success, error, options)
+        watchCallbacks[watchId] = callback
 
         // Start observing if this is the first watch
         if (watchCallbacks.size == 1) {
-            startObserving(options)
+            startObserving(callback.options)
         }
 
         return watchId
@@ -87,7 +83,6 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
 
         locationListener = null
         watchedProvider = null
-        currentOptions = null
         watchCallbacks.clear()
     }
 
@@ -133,8 +128,26 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
             val listener =
                     object : LocationListener {
                         override fun onLocationChanged(location: Location) {
-                            // Call all watch callbacks
-                            watchCallbacks.values.forEach { callback -> callback.success(location) }
+                            var position: CompatGeolocationResponse? = null
+                            var positionWithMetadata: CompatGeolocationResponseWithMetadataInternal? = null
+                            watchCallbacks.values.forEach { callback ->
+                                when (callback) {
+                                    is PositionWatchCallback -> {
+                                        val response = position
+                                            ?: location.toCompatGeolocationResponse().also {
+                                                position = it
+                                            }
+                                        callback.success(response)
+                                    }
+                                    is MetadataWatchCallback -> {
+                                        val response = positionWithMetadata
+                                            ?: location.toCompatGeolocationResponseWithMetadata().also {
+                                                positionWithMetadata = it
+                                            }
+                                        callback.success(response)
+                                    }
+                                }
+                            }
                         }
 
                         override fun onStatusChanged(
@@ -156,7 +169,6 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
 
             locationListener = listener
             watchedProvider = provider
-            currentOptions = options
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException: ${e.message}")
             emitErrorToAll(
@@ -188,24 +200,20 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
             locationManager: LocationManager,
             accuracy: AndroidAccuracyResolution
     ): String? {
+        val fineGranted = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+        val coarseGranted = fineGranted || hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
         return accuracy.providerOrder().firstOrNull { provider ->
-            isProviderValid(locationManager, provider)
+            isProviderValid(locationManager, provider, fineGranted, coarseGranted)
         }
     }
 
-    private fun isProviderValid(locationManager: LocationManager, provider: String): Boolean {
+    private fun isProviderValid(
+            locationManager: LocationManager,
+            provider: String,
+            fineGranted: Boolean,
+            coarseGranted: Boolean
+    ): Boolean {
         if (!locationManager.isProviderEnabled(provider)) return false
-
-        val fineGranted =
-                ContextCompat.checkSelfPermission(
-                        reactContext,
-                        Manifest.permission.ACCESS_FINE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
-        val coarseGranted =
-                ContextCompat.checkSelfPermission(
-                        reactContext,
-                        Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
 
         return if (provider == LocationManager.GPS_PROVIDER) {
             fineGranted
@@ -213,6 +221,10 @@ class WatchPosition(private val reactContext: ReactApplicationContext) {
             coarseGranted || fineGranted
         }
     }
+
+    private fun hasPermission(permission: String): Boolean =
+            ContextCompat.checkSelfPermission(reactContext, permission) ==
+                    PackageManager.PERMISSION_GRANTED
 
     private fun createError(code: Int, message: String): CompatGeolocationError {
         return CompatGeolocationError(

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundHttpSync.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundHttpSync.kt
@@ -13,7 +13,6 @@ internal class AndroidBackgroundHttpSync {
         sync: BackgroundHttpSyncOptions,
         locations: Array<StoredBackgroundLocation>
     ): BackgroundHttpSyncResult {
-        val ids = locations.map { it.id }
         val maxAttempts = if (sync.retry == true) {
             (sync.maxRetries?.toInt()?.takeIf { it >= 0 } ?: 3) + 1
         } else {
@@ -25,6 +24,7 @@ internal class AndroidBackgroundHttpSync {
         if (sync.batch == false) {
             return uploadSingleLocationsWithRetry(sync, locations, maxAttempts)
         }
+        val ids = Array(locations.size) { index -> locations[index].id }
 
         repeat(maxAttempts) { attempt ->
             try {
@@ -34,7 +34,7 @@ internal class AndroidBackgroundHttpSync {
                     return BackgroundHttpSyncResult(
                         true,
                         response.toDouble(),
-                        ids.toTypedArray(),
+                        ids,
                         emptyArray(),
                         null
                     )
@@ -52,7 +52,7 @@ internal class AndroidBackgroundHttpSync {
             false,
             lastStatus?.toDouble(),
             emptyArray(),
-            ids.toTypedArray(),
+            ids,
             lastError ?: "HTTP sync failed"
         )
     }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundSerialization.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundSerialization.kt
@@ -56,8 +56,8 @@ internal fun BackgroundHttpSyncResult.toJson(): JSONObject {
     return JSONObject()
         .put("success", success)
         .put("statusCode", statusCode)
-        .put("syncedLocationIds", JSONArray(syncedLocationIds.toList()))
-        .put("failedLocationIds", JSONArray(failedLocationIds.toList()))
+        .put("syncedLocationIds", syncedLocationIds.toJsonArray())
+        .put("failedLocationIds", failedLocationIds.toJsonArray())
         .put("error", error)
 }
 
@@ -183,8 +183,16 @@ internal fun jsonToVariantMap(payload: String): Map<String, Variant_NullType_Boo
 
 internal fun BackgroundHttpSyncOptions.batchBody(locations: Array<StoredBackgroundLocation>): JSONObject {
     val body = metadataToJsonObject(bodyTemplate) ?: JSONObject()
-    body.put("locations", JSONArray(locations.map { it.toJson() }))
+    val serializedLocations = JSONArray()
+    for (location in locations) serializedLocations.put(location.toJson())
+    body.put("locations", serializedLocations)
     return body
+}
+
+internal fun Array<String>.toJsonArray(): JSONArray {
+    val json = JSONArray()
+    for (value in this) json.put(value)
+    return json
 }
 
 internal fun BackgroundHttpSyncOptions.singleBody(location: StoredBackgroundLocation): JSONObject {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -447,17 +447,39 @@ class NitroBackgroundLocationController private constructor(
         callbackGeneration: Long,
         registrationGeneration: Long
     ) {
-        if (!isActiveLocationRegistration(callbackGeneration, registrationGeneration)) return
-        val serviceGeneration = activeServiceGeneration() ?: return
-        NitroGeoLog.d("handleNativeLocation(): src=$source lat=${location.latitude} lng=${location.longitude}")
+        val serviceGeneration = handleNativeLocationWithoutSync(
+            location,
+            source,
+            callbackGeneration,
+            registrationGeneration
+        ) ?: return
+        scheduleSyncIfNeeded(
+            callbackGeneration,
+            registrationGeneration,
+            serviceGeneration
+        )
+    }
+
+    internal fun handleNativeLocationWithoutSync(
+        location: Location,
+        source: BackgroundLocationSource,
+        callbackGeneration: Long,
+        registrationGeneration: Long
+    ): Long? {
+        if (!isActiveLocationRegistration(callbackGeneration, registrationGeneration)) return null
+        val serviceGeneration = activeServiceGeneration() ?: return null
+        NitroGeoLog.d {
+            "handleNativeLocation(): src=$source lat=${location.latitude} lng=${location.longitude}"
+        }
         val id = UUID.randomUUID().toString()
+        val recordedAt = System.currentTimeMillis().toDouble()
         val backgroundLocation = BackgroundLocation(
             id,
             source,
             true,
             backgroundProviderFrom(location.provider),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) location.isMock else location.isFromMockProvider,
-            System.currentTimeMillis().toDouble(),
+            recordedAt,
             null,
             null,
             GeolocationCoordinates(
@@ -481,7 +503,7 @@ class NitroBackgroundLocationController private constructor(
             null,
             UUID.randomUUID().toString(),
             BackgroundEventType.LOCATION,
-            System.currentTimeMillis().toDouble(),
+            recordedAt,
             false
         )
         val current = configForGeneration(callbackGeneration)
@@ -492,18 +514,16 @@ class NitroBackgroundLocationController private constructor(
             ) {
                 synchronized(storageLock) {
                     if (!shouldPersist(current, callbackGeneration)) return@synchronized
-                store.insertLocation(backgroundLocation)
-                store.pruneLocations(maxStoredLocations(current))
-                store.insertEvent(event)
-                store.pruneEvents(maxStoredEvents(current))
+                    store.insertLocationEventAndPrune(
+                        backgroundLocation,
+                        event,
+                        maxStoredLocations(current),
+                        maxStoredEvents(current)
+                    )
                 }
             }
-        ) return
-        scheduleSyncIfNeeded(
-            callbackGeneration,
-            registrationGeneration,
-            serviceGeneration
-        )
+        ) return null
+        return serviceGeneration
     }
 
     fun handleGeofenceEvent(geofencingEvent: GeofencingEvent, callbackGeneration: Long) {
@@ -650,7 +670,7 @@ class NitroBackgroundLocationController private constructor(
         return syncCoordinator.syncManual(callbackGeneration)
     }
 
-    private fun scheduleSyncIfNeeded(
+    internal fun scheduleSyncIfNeeded(
         callbackGeneration: Long,
         registrationGeneration: Long,
         serviceGeneration: Long
@@ -658,15 +678,7 @@ class NitroBackgroundLocationController private constructor(
         if (!isActiveLocationRegistration(callbackGeneration, registrationGeneration)) return
         val sync = configForGeneration(callbackGeneration)?.sync ?: return
         val threshold = sync.syncThreshold?.toInt()?.takeIf { it > 0 } ?: 1
-        val unsynced = store.getLocations(
-            GetStoredBackgroundLocationsOptions(
-                threshold.toDouble(),
-                null,
-                true,
-                false
-            )
-        )
-        if (unsynced.size < threshold) return
+        if (!store.hasUnsyncedLocations(threshold)) return
 
         syncCoordinator.scheduleAutomatic(
             callbackGeneration,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStore.kt
@@ -38,7 +38,7 @@ internal data class NitroBackgroundStoreSnapshot(
 )
 
 class NitroBackgroundStore(context: Context) :
-    SQLiteOpenHelper(context, "nitro_background_location.db", null, 3) {
+    SQLiteOpenHelper(context, "nitro_background_location.db", null, 4) {
 
     init {
         // WAL lets the broadcast-receiver writer and concurrent readers (JS Promise threads and the
@@ -99,6 +99,7 @@ class NitroBackgroundStore(context: Context) :
             )
             """.trimIndent()
         )
+        createIndexes(db)
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
@@ -108,6 +109,32 @@ class NitroBackgroundStore(context: Context) :
         if (oldVersion < 3) {
             runCatching { db.execSQL("ALTER TABLE geofences ADD COLUMN metadata TEXT") }
         }
+        if (oldVersion < 4) {
+            createIndexes(db)
+        }
+    }
+
+    private fun createIndexes(db: SQLiteDatabase) {
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_background_locations_created_at " +
+                "ON background_locations(created_at DESC)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_background_locations_sync_queue " +
+                "ON background_locations(synced, created_at DESC)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_background_locations_pending " +
+                "ON background_locations(delivered_to_js, synced, created_at DESC)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_background_events_created_at " +
+                "ON background_events(created_at DESC)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_background_events_pending " +
+                "ON background_events(delivered_to_js, created_at DESC)"
+        )
     }
 
     fun insertLocation(location: BackgroundLocation): StoredBackgroundLocation {
@@ -175,6 +202,36 @@ class NitroBackgroundStore(context: Context) :
             },
             SQLiteDatabase.CONFLICT_REPLACE
         )
+    }
+
+    fun insertLocationEventAndPrune(
+        location: BackgroundLocation,
+        event: BackgroundEventEnvelope,
+        maxLocations: Int?,
+        maxEvents: Int?
+    ) {
+        val database = writableDatabase
+        database.beginTransaction()
+        try {
+            insertLocation(location)
+            pruneLocations(maxLocations)
+            insertEvent(event)
+            pruneEvents(maxEvents)
+            database.setTransactionSuccessful()
+        } finally {
+            database.endTransaction()
+        }
+    }
+
+    fun hasUnsyncedLocations(minimumCount: Int): Boolean {
+        if (minimumCount <= 0) return true
+        val cursor = readableDatabase.rawQuery(
+            "SELECT count(*) FROM (" +
+                "SELECT 1 FROM background_locations WHERE synced = 0 LIMIT ?" +
+                ")",
+            arrayOf(minimumCount.toString())
+        )
+        return cursor.use { it.moveToFirst() && it.getInt(0) >= minimumCount }
     }
 
     fun getLocations(options: GetStoredBackgroundLocationsOptions?): Array<StoredBackgroundLocation> {
@@ -383,12 +440,12 @@ class NitroBackgroundStore(context: Context) :
         }
     }
 
-    fun markSynced(ids: List<String>) {
+    fun markSynced(ids: Array<String>) {
         if (ids.isEmpty()) return
         val placeholders = ids.joinToString(",") { "?" }
         writableDatabase.execSQL(
             "UPDATE background_locations SET synced = 1 WHERE id IN ($placeholders)",
-            ids.toTypedArray()
+            ids
         )
     }
 
@@ -400,8 +457,10 @@ class NitroBackgroundStore(context: Context) :
         writableDatabase.execSQL(
             """
             DELETE FROM $table
-            WHERE id NOT IN (
-              SELECT id FROM $table ORDER BY created_at DESC LIMIT ?
+            WHERE id IN (
+              SELECT id FROM $table
+              ORDER BY created_at ASC
+              LIMIT max((SELECT count(*) FROM $table) - ?, 0)
             )
             """.trimIndent(),
             arrayOf(limit.toString())
@@ -667,8 +726,8 @@ class NitroBackgroundStore(context: Context) :
         return JSONObject()
             .put("success", result.success)
             .put("statusCode", result.statusCode)
-            .put("syncedLocationIds", JSONArray(result.syncedLocationIds.toList()))
-            .put("failedLocationIds", JSONArray(result.failedLocationIds.toList()))
+            .put("syncedLocationIds", result.syncedLocationIds.toJsonArray())
+            .put("failedLocationIds", result.failedLocationIds.toJsonArray())
             .put("error", result.error)
             .toString()
     }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncCoordinator.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundSyncCoordinator.kt
@@ -88,7 +88,7 @@ internal class NitroBackgroundSyncCoordinator(
                         false,
                         null,
                         emptyArray(),
-                        batch.locations.map { it.id }.toTypedArray(),
+                        Array(batch.locations.size) { index -> batch.locations[index].id },
                         error.message ?: "HTTP sync failed"
                     )
                 }
@@ -148,11 +148,16 @@ internal class NitroBackgroundSyncCoordinator(
                     if (candidates.size < threshold) {
                         null
                     } else {
+                        val batch = if (candidates.size <= batchSize) {
+                            candidates
+                        } else {
+                            candidates.copyOfRange(0, batchSize)
+                        }
                         NitroBackgroundSyncBatch(
                             callbackGeneration,
                             configRevision,
                             sync,
-                            candidates.take(batchSize).toTypedArray()
+                            batch
                         )
                     }
                 }
@@ -194,7 +199,7 @@ internal class NitroBackgroundSyncCoordinator(
         val result = httpSync.uploadLocationsWithRetry(batch.sync, batch.locations)
         synchronized(storageLock) {
             if (currentRunGeneration() == batch.runGeneration) {
-                store.markSynced(result.syncedLocationIds.toList())
+                store.markSynced(result.syncedLocationIds)
                 if (batch.sync.autoClear == true) {
                     store.clearLocations(result.syncedLocationIds)
                 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroGeoLog.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroGeoLog.kt
@@ -14,13 +14,18 @@ import com.margelo.nitro.nitrogeolocation.BuildConfig
  * quiet, while [w] and [e] always emit because they mark real delivery or registration failures.
  */
 internal object NitroGeoLog {
-    private const val TAG = "NitroGeolocation"
+    @PublishedApi
+    internal const val TAG = "NitroGeolocation"
 
     @Volatile
     var verbose: Boolean = BuildConfig.DEBUG
 
     fun d(message: String) {
         if (verbose) Log.d(TAG, message)
+    }
+
+    inline fun d(message: () -> String) {
+        if (verbose) Log.d(TAG, message())
     }
 
     fun w(message: String, error: Throwable? = null) {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroLocationUpdateReceiver.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroLocationUpdateReceiver.kt
@@ -11,7 +11,7 @@ import com.margelo.nitro.nitrogeolocation.BackgroundLocationSource
 
 class NitroLocationUpdateReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        NitroGeoLog.d("LocationUpdateReceiver.onReceive(): action=${intent.action}")
+        NitroGeoLog.d { "LocationUpdateReceiver.onReceive(): action=${intent.action}" }
         val controller = NitroBackgroundLocationController.getInstance(context)
         val generation = intent.getLongExtra(
             EXTRA_RUN_GENERATION,
@@ -47,13 +47,17 @@ class NitroLocationUpdateReceiver : BroadcastReceiver() {
             )
             return
         }
+        var serviceGeneration: Long? = null
         for (location in result.locations) {
-            controller.handleNativeLocation(
+            controller.handleNativeLocationWithoutSync(
                 location,
                 BackgroundLocationSource.FOREGROUNDSERVICE,
                 generation,
                 registrationGeneration
-            )
+            )?.let { serviceGeneration = it }
+        }
+        serviceGeneration?.let {
+            controller.scheduleSyncIfNeeded(generation, registrationGeneration, it)
         }
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStoreTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundStoreTest.kt
@@ -1,0 +1,128 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import androidx.test.core.app.ApplicationProvider
+import com.margelo.nitro.nitrogeolocation.BackgroundEventEnvelope
+import com.margelo.nitro.nitrogeolocation.BackgroundEventType
+import com.margelo.nitro.nitrogeolocation.BackgroundLocation
+import com.margelo.nitro.nitrogeolocation.BackgroundLocationSource
+import com.margelo.nitro.nitrogeolocation.GeolocationCoordinates
+import com.margelo.nitro.nitrogeolocation.GetStoredBackgroundEventsOptions
+import com.margelo.nitro.nitrogeolocation.GetStoredBackgroundLocationsOptions
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundStoreTest {
+    private lateinit var store: NitroBackgroundStore
+
+    @Before
+    fun setUp() {
+        store = NitroBackgroundStore(ApplicationProvider.getApplicationContext())
+        store.clearEvents(null)
+        store.clearLocations(null)
+    }
+
+    @After
+    fun tearDown() {
+        store.clearEvents(null)
+        store.clearLocations(null)
+        store.close()
+    }
+
+    @Test
+    fun `background queue queries have covering order indexes`() {
+        val indexes = mutableSetOf<String>()
+        store.readableDatabase.rawQuery(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_background_%'",
+            null
+        ).use { cursor ->
+            while (cursor.moveToNext()) indexes += cursor.getString(0)
+        }
+
+        assertTrue("idx_background_locations_created_at" in indexes)
+        assertTrue("idx_background_locations_sync_queue" in indexes)
+        assertTrue("idx_background_locations_pending" in indexes)
+        assertTrue("idx_background_events_created_at" in indexes)
+        assertTrue("idx_background_events_pending" in indexes)
+    }
+
+    @Test
+    fun `unsynced threshold check stops at the requested count`() {
+        store.insertLocation(location("first", 1.0))
+        store.insertLocation(location("second", 2.0))
+
+        assertTrue(store.hasUnsyncedLocations(1))
+        assertTrue(store.hasUnsyncedLocations(2))
+        assertFalse(store.hasUnsyncedLocations(3))
+
+        store.markSynced(arrayOf("first"))
+        assertTrue(store.hasUnsyncedLocations(1))
+        assertFalse(store.hasUnsyncedLocations(2))
+    }
+
+    @Test
+    fun `location and event write shares one prune boundary`() {
+        repeat(3) { index ->
+            val location = location("location-$index", index.toDouble())
+            store.insertLocationEventAndPrune(
+                location,
+                event("event-$index", location),
+                maxLocations = 2,
+                maxEvents = 2
+            )
+        }
+
+        val locations = store.getLocations(
+            GetStoredBackgroundLocationsOptions(10.0, null, true, true)
+        )
+        val events = store.getEvents(
+            GetStoredBackgroundEventsOptions(null, 10.0, null, true)
+        )
+
+        assertEquals(2, locations.size)
+        assertEquals(2, events.size)
+    }
+
+    private fun location(id: String, timestamp: Double) = BackgroundLocation(
+        id,
+        BackgroundLocationSource.BACKGROUND,
+        true,
+        null,
+        false,
+        timestamp,
+        null,
+        null,
+        GeolocationCoordinates(
+            37.5665,
+            126.9780,
+            null,
+            5.0,
+            null,
+            null,
+            null
+        ),
+        timestamp
+    )
+
+    private fun event(id: String, location: BackgroundLocation) = BackgroundEventEnvelope(
+        location,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        id,
+        BackgroundEventType.LOCATION,
+        location.timestamp,
+        false
+    )
+}

--- a/packages/react-native-nitro-geolocation/ios/ActiveWatchRegistry.swift
+++ b/packages/react-native-nitro-geolocation/ios/ActiveWatchRegistry.swift
@@ -31,6 +31,10 @@ final class ActiveWatchRegistry<Value> {
         }
     }
 
+    func entriesSnapshot() -> [String: Value] {
+        return withLock { subscriptions }
+    }
+
     func updateIfPresent(token: String, value: Value) -> Bool {
         return withLock {
             guard subscriptions[token] != nil else { return false }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundLocationDelegate.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundLocationDelegate.swift
@@ -23,11 +23,6 @@ final class NitroBackgroundLocationDelegate: NSObject, CLLocationManagerDelegate
             runGeneration: runGeneration,
             locationSessionGeneration: locationSessionGeneration
         )
-        owner?.applyDeferredUpdatesIfNeeded(
-            manager,
-            runGeneration: runGeneration,
-            locationSessionGeneration: locationSessionGeneration
-        )
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
@@ -151,6 +151,7 @@ extension NitroBackgroundLocation {
             confidence: motionConfidence(activity.confidence),
             timestamp: activity.startDate.timeIntervalSince1970 * 1000
         )
+        let timestamp = Date().timeIntervalSince1970 * 1000
         let event = BackgroundEventEnvelope(
             location: nil,
             geofence: nil,
@@ -161,7 +162,7 @@ extension NitroBackgroundLocation {
             error: nil,
             id: UUID().uuidString,
             type: .activity,
-            timestamp: Date().timeIntervalSince1970 * 1000,
+            timestamp: timestamp,
             deliveredToJS: false
         )
         let storedForRun: Bool = withStoreLock {
@@ -172,7 +173,7 @@ extension NitroBackgroundLocation {
             appendStoredEvent(
                 StoredBackgroundEventEnvelope(
                     event: event,
-                    createdAt: Date().timeIntervalSince1970 * 1000,
+                    createdAt: timestamp,
                     id: event.id,
                     type: event.type,
                     timestamp: event.timestamp,

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundMotion.swift
@@ -44,10 +44,7 @@ internal func mapActivityType(_ activityType: IOSBackgroundActivityType?) -> CLA
     case .othernavigation:
         return .otherNavigation
     case .airborne:
-        if #available(iOS 12.0, *) {
-            return .airborne
-        }
-        return .other
+        return .airborne
     case .other, nil:
         return .other
     @unknown default:
@@ -183,7 +180,7 @@ extension NitroBackgroundLocation {
                 ),
                 allowUnconfigured: true
             )
-            persistStore()
+            persistEvents()
             return true
         }
         guard storedForRun else { return }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
@@ -143,7 +143,6 @@ extension NitroBackgroundLocation {
             let stopOnStill = activityOptions?.stopOnStill ?? (options.trackingMode == .activityaware)
             if activity.type == .still && stopOnStill {
                 runOnMainSync {
-                    self.manager?.disallowDeferredLocationUpdates()
                     self.manager?.stopUpdatingLocation()
                     self.manager?.stopMonitoringSignificantLocationChanges()
                 }
@@ -182,29 +181,6 @@ extension NitroBackgroundLocation {
         self.delegate = delegate
     }
 
-    func applyDeferredUpdatesIfNeeded(
-        _ manager: CLLocationManager,
-        runGeneration: UInt64,
-        locationSessionGeneration: UInt64
-    ) {
-        guard let options = withStoreLock({ () -> BackgroundLocationOptions? in
-            guard isCurrentLocationSession(
-                runGeneration,
-                locationSessionGeneration
-            ) else { return nil }
-            return self.options
-        }),
-            let distance = options.ios?.deferredUpdatesDistance,
-            let interval = options.ios?.deferredUpdatesInterval
-        else {
-            return
-        }
-        manager.allowDeferredLocationUpdates(
-            untilTraveled: distance,
-            timeout: interval / 1000
-        )
-    }
-
     func replaceLocationSession() -> UInt64 {
         let generations = withStoreLock {
             locationSessionGeneration &+= 1
@@ -212,7 +188,6 @@ extension NitroBackgroundLocation {
             return (storeGeneration, locationSessionGeneration)
         }
         runOnMainSync {
-            self.manager?.disallowDeferredLocationUpdates()
             self.manager?.stopUpdatingLocation()
             self.manager?.stopMonitoringSignificantLocationChanges()
             let delegate = NitroBackgroundLocationDelegate(
@@ -238,7 +213,6 @@ extension NitroBackgroundLocation {
         }
         guard shouldStop else { return }
         runOnMainSync {
-            self.manager?.disallowDeferredLocationUpdates()
             self.manager?.stopUpdatingLocation()
             self.manager?.stopMonitoringSignificantLocationChanges()
         }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundRuntime.swift
@@ -87,9 +87,13 @@ extension NitroBackgroundLocation {
         )
         withListenerLock {
             guard withStoreLock({
-                isCurrentLocationSession(runGeneration, locationSessionGeneration)
+                runGeneration == storeGeneration &&
+                    self.locationSessionGeneration == locationSessionGeneration &&
+                    locationSessionActive
             }) else { return }
-            Array(errorListeners.keys).forEach { errorListeners[$0]?(locationError) }
+            for listener in Array(errorListeners.values) {
+                listener(locationError)
+            }
         }
     }
 
@@ -104,22 +108,24 @@ extension NitroBackgroundLocation {
             guard withStoreLock({
                 guard runGeneration == storeGeneration else { return false }
                 if let locationSessionGeneration {
-                    guard isCurrentLocationSession(
-                        runGeneration,
-                        locationSessionGeneration
-                    ) else { return false }
+                    guard self.locationSessionGeneration == locationSessionGeneration,
+                        locationSessionActive
+                    else { return false }
                 }
                 if let motionRegistrationGeneration {
-                    guard isCurrentMotionRegistration(
-                        runGeneration,
-                        motionRegistrationGeneration
-                    ) else { return false }
+                    guard self.motionRegistrationGeneration == motionRegistrationGeneration,
+                        motionRegistrationActive
+                    else { return false }
                 }
                 return true
             }) else { return }
-            Array(eventListeners.keys).forEach { eventListeners[$0]?(event) }
+            for listener in Array(eventListeners.values) {
+                listener(event)
+            }
             if let location {
-                Array(locationListeners.keys).forEach { locationListeners[$0]?(location) }
+                for listener in Array(locationListeners.values) {
+                    listener(location)
+                }
             }
         }
     }
@@ -142,13 +148,17 @@ extension NitroBackgroundLocation {
             guard activity.confidence >= (activityOptions?.minimumConfidence ?? 0) else { return }
             let stopOnStill = activityOptions?.stopOnStill ?? (options.trackingMode == .activityaware)
             if activity.type == .still && stopOnStill {
+                guard !activityPausedLocationUpdates else { return }
+                activityPausedLocationUpdates = true
                 runOnMainSync {
                     self.manager?.stopUpdatingLocation()
                     self.manager?.stopMonitoringSignificantLocationChanges()
                 }
                 return
             }
-            if activity.type != .still && activity.type != .unknown && snapshot.1 {
+            if activity.type != .still && activity.type != .unknown && snapshot.1 &&
+                activityPausedLocationUpdates {
+                activityPausedLocationUpdates = false
                 runOnMainSync {
                     if options.trackingMode == .significantchanges ||
                         options.ios?.useSignificantChanges == true {

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSerialization.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSerialization.swift
@@ -33,7 +33,7 @@ internal func makeStoredLocation(_ dictionary: [String: Any]) -> StoredBackgroun
 
 internal func makeStoredEvent(
     _ dictionary: [String: Any],
-    storedLocations: [StoredBackgroundLocation] = []
+    storedLocationsById: [String: StoredBackgroundLocation] = [:]
 ) -> StoredBackgroundEventEnvelope? {
     guard
         let id = dictionary["id"] as? String,
@@ -44,12 +44,16 @@ internal func makeStoredEvent(
     else {
         return nil
     }
-    let persistedLocation = (dictionary["location"] as? [String: Any])
-        .flatMap(makeBackgroundLocation)
-    let referencedLocation = (dictionary["locationId"] as? String)
-        .flatMap { locationId in storedLocations.first { $0.id == locationId } }
-        .map(backgroundLocation)
-    let location = persistedLocation ?? referencedLocation
+    let location: BackgroundLocation?
+    if let persistedLocation = (dictionary["location"] as? [String: Any])
+        .flatMap(makeBackgroundLocation) {
+        location = persistedLocation
+    } else if let locationId = dictionary["locationId"] as? String,
+        let storedLocation = storedLocationsById[locationId] {
+        location = backgroundLocation(storedLocation)
+    } else {
+        location = nil
+    }
     let geofence = (dictionary["geofence"] as? [String: Any]).flatMap(makeGeofenceEvent)
     let activity = (dictionary["activity"] as? [String: Any]).flatMap(makeActivity)
     let providerStatus = (dictionary["providerStatus"] as? [String: Any])

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
@@ -38,6 +38,7 @@ extension NitroBackgroundLocation {
                 continuationConfigRevision: continuationConfigRevision
             ) else { return nil }
             let result = self.performSyncBatch(batch, runGeneration: runGeneration)
+            let timestamp = Date().timeIntervalSince1970 * 1000
             let event = BackgroundEventEnvelope(
                 location: nil,
                 geofence: nil,
@@ -48,7 +49,7 @@ extension NitroBackgroundLocation {
                 error: nil,
                 id: UUID().uuidString,
                 type: .httpsync,
-                timestamp: Date().timeIntervalSince1970 * 1000,
+                timestamp: timestamp,
                 deliveredToJS: false
             )
             let storedForRun: Bool = self.withStoreLock {
@@ -60,7 +61,7 @@ extension NitroBackgroundLocation {
                 self.appendStoredEvent(
                     StoredBackgroundEventEnvelope(
                         event: event,
-                        createdAt: Date().timeIntervalSince1970 * 1000,
+                        createdAt: timestamp,
                         id: event.id,
                         type: event.type,
                         timestamp: event.timestamp,
@@ -107,9 +108,9 @@ extension NitroBackgroundLocation {
                 locationSessionActive,
                 let sync = options?.sync
             else { return nil }
-            let allUnsynced = storedLocations.filter { !$0.synced }
+            let unsyncedLocations = storedLocations.lazy.filter { !$0.synced }
             let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
-            guard allUnsynced.count >= threshold else { return nil }
+            guard unsyncedLocations.prefix(threshold).count >= threshold else { return nil }
             let now = Date().timeIntervalSince1970 * 1000
             let interval = sync.syncInterval ?? 0
             let sameConfigContinuation = continuationConfigRevision == syncConfigRevision
@@ -119,12 +120,13 @@ extension NitroBackgroundLocation {
             let count = safePrefixCount(
                 sync.batchSize,
                 defaultValue: 50,
-                upperBound: allUnsynced.count
+                upperBound: storedLocations.count
             )
-            guard count > 0 else { return nil }
+            let locations = Array(unsyncedLocations.prefix(count))
+            guard !locations.isEmpty else { return nil }
             lastSyncAt = now
             return IOSBackgroundSyncBatch(
-                locations: Array(allUnsynced.prefix(count)),
+                locations: locations,
                 sync: sync,
                 configRevision: syncConfigRevision
             )
@@ -133,15 +135,15 @@ extension NitroBackgroundLocation {
 
     private func syncBatch(runGeneration: UInt64) -> IOSBackgroundSyncBatch? {
         guard runGeneration == storeGeneration, let sync = options?.sync else { return nil }
-        let allUnsynced = storedLocations.filter { !$0.synced }
         let count = safePrefixCount(
             sync.batchSize,
             defaultValue: 50,
-            upperBound: allUnsynced.count
+            upperBound: storedLocations.count
         )
-        guard count > 0 else { return nil }
+        let locations = Array(storedLocations.lazy.filter { !$0.synced }.prefix(count))
+        guard !locations.isEmpty else { return nil }
         return IOSBackgroundSyncBatch(
-            locations: Array(allUnsynced.prefix(count)),
+            locations: locations,
             sync: sync,
             configRevision: syncConfigRevision
         )
@@ -158,28 +160,37 @@ extension NitroBackgroundLocation {
         let syncedIds = Set(result.syncedLocationIds)
         withStoreLock {
             guard runGeneration == storeGeneration else { return }
-            for index in storedLocations.indices where syncedIds.contains(storedLocations[index].id) {
-                let location = storedLocations[index]
-                storedLocations[index] = StoredBackgroundLocation(
-                    id: location.id,
-                    deliveredToJS: location.deliveredToJS,
-                    synced: true,
-                    createdAt: location.createdAt,
-                    source: location.source,
-                    isFromBackground: location.isFromBackground,
-                    provider: location.provider,
-                    mocked: location.mocked,
-                    recordedAt: location.recordedAt,
-                    activity: location.activity,
-                    battery: location.battery,
-                    coords: location.coords,
-                    timestamp: location.timestamp
-                )
-            }
+            var changed = false
             if batch.sync.autoClear == true {
+                let previousCount = storedLocations.count
                 storedLocations.removeAll { syncedIds.contains($0.id) }
+                changed = storedLocations.count != previousCount
+            } else {
+                for index in storedLocations.indices
+                where syncedIds.contains(storedLocations[index].id) &&
+                    !storedLocations[index].synced {
+                    let location = storedLocations[index]
+                    storedLocations[index] = StoredBackgroundLocation(
+                        id: location.id,
+                        deliveredToJS: location.deliveredToJS,
+                        synced: true,
+                        createdAt: location.createdAt,
+                        source: location.source,
+                        isFromBackground: location.isFromBackground,
+                        provider: location.provider,
+                        mocked: location.mocked,
+                        recordedAt: location.recordedAt,
+                        activity: location.activity,
+                        battery: location.battery,
+                        coords: location.coords,
+                        timestamp: location.timestamp
+                    )
+                    changed = true
+                }
             }
-            persistLocations()
+            if changed {
+                persistLocations()
+            }
         }
         return result
     }

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSync.swift
@@ -18,7 +18,8 @@ extension NitroBackgroundLocation {
                 let sync = options?.sync
             else { return nil }
             let threshold = positiveFiniteInt(sync.syncThreshold, defaultValue: 1)
-            guard storedLocations.filter({ !$0.synced }).count >= threshold else { return nil }
+            guard storedLocations.lazy.filter({ !$0.synced }).prefix(threshold).count >= threshold
+            else { return nil }
             return syncConfigRevision
         }
         guard let scheduledConfigRevision else { return }
@@ -66,7 +67,7 @@ extension NitroBackgroundLocation {
                         deliveredToJS: false
                     )
                 )
-                self.persistStore()
+                self.persistEvents()
                 return true
             }
             guard storedForRun else { return nil }
@@ -154,32 +155,31 @@ extension NitroBackgroundLocation {
         if !result.success && result.syncedLocationIds.isEmpty {
             return result
         }
-        let syncedIds = result.syncedLocationIds
+        let syncedIds = Set(result.syncedLocationIds)
         withStoreLock {
             guard runGeneration == storeGeneration else { return }
-            storedLocations = storedLocations.map { location in
-                syncedIds.contains(location.id)
-                    ? StoredBackgroundLocation(
-                        id: location.id,
-                        deliveredToJS: location.deliveredToJS,
-                        synced: true,
-                        createdAt: location.createdAt,
-                        source: location.source,
-                        isFromBackground: location.isFromBackground,
-                        provider: location.provider,
-                        mocked: location.mocked,
-                        recordedAt: location.recordedAt,
-                        activity: location.activity,
-                        battery: location.battery,
-                        coords: location.coords,
-                        timestamp: location.timestamp
-                    )
-                    : location
+            for index in storedLocations.indices where syncedIds.contains(storedLocations[index].id) {
+                let location = storedLocations[index]
+                storedLocations[index] = StoredBackgroundLocation(
+                    id: location.id,
+                    deliveredToJS: location.deliveredToJS,
+                    synced: true,
+                    createdAt: location.createdAt,
+                    source: location.source,
+                    isFromBackground: location.isFromBackground,
+                    provider: location.provider,
+                    mocked: location.mocked,
+                    recordedAt: location.recordedAt,
+                    activity: location.activity,
+                    battery: location.battery,
+                    coords: location.coords,
+                    timestamp: location.timestamp
+                )
             }
             if batch.sync.autoClear == true {
                 storedLocations.removeAll { syncedIds.contains($0.id) }
             }
-            persistStore()
+            persistLocations()
         }
         return result
     }

--- a/packages/react-native-nitro-geolocation/ios/IOSWatchDeliveryPolicy.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSWatchDeliveryPolicy.swift
@@ -42,8 +42,10 @@ private func distanceMeters(
     let longitudeDelta = (toLongitude - fromLongitude) * .pi / 180
     let fromLatitudeRadians = fromLatitude * .pi / 180
     let toLatitudeRadians = toLatitude * .pi / 180
-    let haversine = pow(sin(latitudeDelta / 2), 2) +
+    let latitudeSine = sin(latitudeDelta / 2)
+    let longitudeSine = sin(longitudeDelta / 2)
+    let haversine = latitudeSine * latitudeSine +
         cos(fromLatitudeRadians) * cos(toLatitudeRadians) *
-        pow(sin(longitudeDelta / 2), 2)
+        longitudeSine * longitudeSine
     return 2 * 6_371_000 * asin(sqrt(min(max(haversine, 0), 1)))
 }

--- a/packages/react-native-nitro-geolocation/ios/LocationManager.swift
+++ b/packages/react-native-nitro-geolocation/ios/LocationManager.swift
@@ -374,11 +374,12 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         lastLocation = location
 
         // 1. Fire all pending getCurrentPosition requests
-        for request in pendingRequests {
+        let requests = pendingRequests
+        pendingRequests.removeAll()
+        for request in requests {
             request.timer?.cancel()
             request.success(location)
         }
-        pendingRequests.removeAll()
 
         // 2. Fire all active watchPosition subscriptions
         for (_, watch) in activeWatches {
@@ -386,10 +387,12 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         }
 
         // 3. Stop monitoring if no more watches or pending requests
-        if activeWatches.isEmpty && pendingRequests.isEmpty {
-            stopMonitoring()
-        } else {
-            updateLocationManagerConfiguration()
+        if !requests.isEmpty {
+            if activeWatches.isEmpty && pendingRequests.isEmpty {
+                stopMonitoring()
+            } else {
+                updateLocationManagerConfiguration()
+            }
         }
     }
 
@@ -497,9 +500,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         manager.activityType = activityType ?? .other
         manager.pausesLocationUpdatesAutomatically = pausesLocationUpdatesAutomatically ?? true
 
-        if #available(iOS 11.0, *) {
-            manager.showsBackgroundLocationIndicator = showsBackgroundLocationIndicator
-        }
+        manager.showsBackgroundLocationIndicator = showsBackgroundLocationIndicator
 
         // Update significant changes mode if changed
         if shouldUseSignificantChanges != usingSignificantChanges {

--- a/packages/react-native-nitro-geolocation/ios/LocationManager.swift
+++ b/packages/react-native-nitro-geolocation/ios/LocationManager.swift
@@ -386,13 +386,12 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
             watch.success(location)
         }
 
-        // 3. Stop monitoring if no more watches or pending requests
-        if !requests.isEmpty {
-            if activeWatches.isEmpty && pendingRequests.isEmpty {
-                stopMonitoring()
-            } else {
-                updateLocationManagerConfiguration()
-            }
+        // 3. Stop authorization-triggered monitoring once there is no active work.
+        // Only recompute the configuration when completing requests can change it.
+        if activeWatches.isEmpty && pendingRequests.isEmpty {
+            stopMonitoring()
+        } else if !requests.isEmpty {
+            updateLocationManagerConfiguration()
         }
     }
 

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -37,6 +37,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     var motionRegistrationActive = false
     var backgroundMotionRequested = false
     var standaloneMotionRequested = false
+    var activityPausedLocationUpdates = false
     let syncScheduler = IOSBackgroundSyncScheduler()
     let httpSync = IOSBackgroundHttpSync()
     var permissionRequest: IOSBackgroundPermissionRequest?
@@ -127,6 +128,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     self.state = .starting
                 }
                 _ = self.replaceLocationSession()
+                self.activityPausedLocationUpdates = false
                 self.apply(current)
                 self.backgroundMotionRequested = motionRequested
                 self.updateMotionUpdates()
@@ -143,6 +145,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             self.withLifecycleLock {
                 self.withStoreLock { self.state = .stopping }
                 self.stopLocationSession()
+                self.activityPausedLocationUpdates = false
                 self.backgroundMotionRequested = false
                 self.updateMotionUpdates()
                 self.withStoreLock {
@@ -180,6 +183,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 }
                 self.backgroundMotionRequested = false
                 self.standaloneMotionRequested = false
+                self.activityPausedLocationUpdates = false
                 self.updateMotionUpdates()
             }
             // Do not overlap listenerLock with lifecycleLock: callbacks may re-enter lifecycle APIs.
@@ -301,8 +305,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     return
                 }
                 let idSet = Set(ids)
+                let previousCount = self.storedLocations.count
                 self.storedLocations.removeAll { idSet.contains($0.id) }
-                self.persistLocations()
+                if self.storedLocations.count != previousCount {
+                    self.persistLocations()
+                }
             }
         }
     }
@@ -311,8 +318,10 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return Promise.async {
             self.withStoreLock {
                 let idSet = Set(ids)
+                var changed = false
                 for index in self.storedLocations.indices
-                where idSet.contains(self.storedLocations[index].id) {
+                where idSet.contains(self.storedLocations[index].id) &&
+                    !self.storedLocations[index].deliveredToJS {
                     let location = self.storedLocations[index]
                     self.storedLocations[index] = StoredBackgroundLocation(
                         id: location.id,
@@ -329,8 +338,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                         coords: location.coords,
                         timestamp: location.timestamp
                     )
+                    changed = true
                 }
-                self.persistLocations()
+                if changed {
+                    self.persistLocations()
+                }
             }
         }
     }
@@ -367,8 +379,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     return
                 }
                 let idSet = Set(ids)
+                let previousCount = self.storedEvents.count
                 self.storedEvents.removeAll { idSet.contains($0.id) }
-                self.persistEvents()
+                if self.storedEvents.count != previousCount {
+                    self.persistEvents()
+                }
             }
         }
     }
@@ -377,8 +392,10 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return Promise.async {
             self.withStoreLock {
                 let idSet = Set(ids)
+                var changed = false
                 for index in self.storedEvents.indices
-                where idSet.contains(self.storedEvents[index].id) {
+                where idSet.contains(self.storedEvents[index].id) &&
+                    !self.storedEvents[index].deliveredToJS {
                     let event = self.storedEvents[index]
                     self.storedEvents[index] = StoredBackgroundEventEnvelope(
                         event: event.event,
@@ -388,8 +405,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                         timestamp: event.timestamp,
                         deliveredToJS: true
                     )
+                    changed = true
                 }
-                self.persistEvents()
+                if changed {
+                    self.persistEvents()
+                }
             }
         }
     }
@@ -498,9 +518,20 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         runGeneration: UInt64,
         locationSessionGeneration: UInt64
     ) {
-        guard isCurrentLocationSession(runGeneration, locationSessionGeneration) else { return }
+        guard !locations.isEmpty,
+            isCurrentLocationSession(runGeneration, locationSessionGeneration)
+        else { return }
+        var deliveries: [(
+            id: String,
+            createdAt: Double,
+            location: BackgroundLocation,
+            event: BackgroundEventEnvelope
+        )] = []
+        deliveries.reserveCapacity(locations.count)
+
         for location in locations {
             let id = UUID().uuidString
+            let createdAt = Date().timeIntervalSince1970 * 1000
             let coords = GeolocationCoordinates(
                 latitude: location.coordinate.latitude,
                 longitude: location.coordinate.longitude,
@@ -516,26 +547,11 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 isFromBackground: true,
                 provider: .unknown,
                 mocked: location.sourceInformation?.isSimulatedBySoftware,
-                recordedAt: Date().timeIntervalSince1970 * 1000,
+                recordedAt: createdAt,
                 activity: nil,
                 battery: nil,
                 coords: coords,
                 timestamp: location.timestamp.timeIntervalSince1970 * 1000
-            )
-            let stored = StoredBackgroundLocation(
-                id: id,
-                deliveredToJS: false,
-                synced: false,
-                createdAt: Date().timeIntervalSince1970 * 1000,
-                source: backgroundLocation.source,
-                isFromBackground: true,
-                provider: backgroundLocation.provider,
-                mocked: backgroundLocation.mocked,
-                recordedAt: backgroundLocation.recordedAt,
-                activity: nil,
-                battery: nil,
-                coords: coords,
-                timestamp: backgroundLocation.timestamp
             )
             let event = BackgroundEventEnvelope(
                 location: backgroundLocation,
@@ -547,41 +563,75 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 error: nil,
                 id: UUID().uuidString,
                 type: .location,
-                timestamp: Date().timeIntervalSince1970 * 1000,
+                timestamp: createdAt,
                 deliveredToJS: false
             )
-            let storedForRun: Bool = withStoreLock {
-                guard runGeneration == storeGeneration,
-                    self.locationSessionGeneration == locationSessionGeneration,
-                    locationSessionActive,
-                    options != nil
-                else { return false }
-                appendStoredLocation(stored)
-                appendStoredEvent(
-                    StoredBackgroundEventEnvelope(
-                        event: event,
-                        createdAt: Date().timeIntervalSince1970 * 1000,
-                        id: event.id,
-                        type: event.type,
-                        timestamp: event.timestamp,
-                        deliveredToJS: false
-                    )
-                )
-                persistLocationsAndEvents()
-                return true
-            }
-            guard storedForRun else { return }
-            dispatchInProcess(
-                event: event,
+            deliveries.append((
+                id: id,
+                createdAt: createdAt,
                 location: backgroundLocation,
-                runGeneration: runGeneration,
-                locationSessionGeneration: locationSessionGeneration
-            )
-            scheduleSyncIfNeeded(
+                event: event
+            ))
+        }
+
+        let acceptedForRun: Bool = withStoreLock {
+            guard runGeneration == storeGeneration,
+                self.locationSessionGeneration == locationSessionGeneration,
+                locationSessionActive,
+                options != nil
+            else { return false }
+
+            if shouldPersist() {
+                storedLocations.reserveCapacity(storedLocations.count + deliveries.count)
+                storedEvents.reserveCapacity(storedEvents.count + deliveries.count)
+                for delivery in deliveries {
+                    let location = delivery.location
+                    storedLocations.append(StoredBackgroundLocation(
+                        id: delivery.id,
+                        deliveredToJS: false,
+                        synced: false,
+                        createdAt: delivery.createdAt,
+                        source: location.source,
+                        isFromBackground: true,
+                        provider: location.provider,
+                        mocked: location.mocked,
+                        recordedAt: location.recordedAt,
+                        activity: nil,
+                        battery: nil,
+                        coords: location.coords,
+                        timestamp: location.timestamp
+                    ))
+                    storedEvents.append(
+                        StoredBackgroundEventEnvelope(
+                            event: delivery.event,
+                            createdAt: delivery.createdAt,
+                            id: delivery.event.id,
+                            type: delivery.event.type,
+                            timestamp: delivery.event.timestamp,
+                            deliveredToJS: false
+                        )
+                    )
+                }
+                trimStoredLocationsIfNeeded()
+                trimStoredEventsIfNeeded()
+                persistLocationsAndEvents()
+            }
+            return true
+        }
+        guard acceptedForRun else { return }
+
+        for delivery in deliveries {
+            dispatchInProcess(
+                event: delivery.event,
+                location: delivery.location,
                 runGeneration: runGeneration,
                 locationSessionGeneration: locationSessionGeneration
             )
         }
+        scheduleSyncIfNeeded(
+            runGeneration: runGeneration,
+            locationSessionGeneration: locationSessionGeneration
+        )
     }
 
     func handleRegion(
@@ -595,13 +645,14 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         }) else {
             return
         }
+        let timestamp = Date().timeIntervalSince1970 * 1000
         let event = BackgroundEventEnvelope(
             location: nil,
             geofence: GeofenceEvent(
                 region: geofence,
                 transition: transition,
                 location: nil,
-                timestamp: Date().timeIntervalSince1970 * 1000
+                timestamp: timestamp
             ),
             activity: nil,
             providerStatus: nil,
@@ -610,7 +661,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             error: nil,
             id: UUID().uuidString,
             type: .geofence,
-            timestamp: Date().timeIntervalSince1970 * 1000,
+            timestamp: timestamp,
             deliveredToJS: false
         )
         let storedForRun: Bool = withStoreLock {
@@ -618,7 +669,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             appendStoredEvent(
                 StoredBackgroundEventEnvelope(
                     event: event,
-                    createdAt: Date().timeIntervalSince1970 * 1000,
+                    createdAt: timestamp,
                     id: event.id,
                     type: event.type,
                     timestamp: event.timestamp,
@@ -697,10 +748,19 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         withStoreLock {
             storedLocations = (defaults.array(forKey: locationsKey) as? [[String: Any]] ?? [])
                 .compactMap(makeStoredLocation)
+            let eventDictionaries = defaults.array(forKey: eventsKey) as? [[String: Any]] ?? []
+            let needsLocationIndex = eventDictionaries.contains {
+                $0["location"] == nil && $0["locationId"] != nil
+            }
+            let storedLocationsById = needsLocationIndex
+                ? storedLocations.reduce(into: [String: StoredBackgroundLocation]()) { index, location in
+                    index[location.id] = location
+                }
+                : [:]
             geofences = (defaults.array(forKey: geofencesKey) as? [[String: Any]] ?? [])
                 .compactMap(makeGeofenceRegion)
-            storedEvents = (defaults.array(forKey: eventsKey) as? [[String: Any]] ?? [])
-                .compactMap { makeStoredEvent($0, storedLocations: storedLocations) }
+            storedEvents = eventDictionaries
+                .compactMap { makeStoredEvent($0, storedLocationsById: storedLocationsById) }
             options = defaults.dictionary(forKey: optionsKey).flatMap(makeBackgroundOptions)
         }
     }
@@ -753,17 +813,6 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         return Int(configured)
     }
 
-    private func appendStoredLocation(_ location: StoredBackgroundLocation) {
-        withStoreLock {
-            guard shouldPersist() else { return }
-            storedLocations.append(location)
-            if let max = resolveMaxStored(options?.maxStoredLocations, default: Self.defaultMaxStoredRows),
-               storedLocations.count > max {
-                storedLocations = Array(storedLocations.suffix(max))
-            }
-        }
-    }
-
     func appendStoredEvent(
         _ event: StoredBackgroundEventEnvelope,
         allowUnconfigured: Bool = false
@@ -771,10 +820,25 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         withStoreLock {
             guard shouldPersist(allowUnconfigured: allowUnconfigured) else { return }
             storedEvents.append(event)
-            if let max = resolveMaxStored(options?.maxStoredEvents, default: Self.defaultMaxStoredRows),
-               storedEvents.count > max {
-                storedEvents = Array(storedEvents.suffix(max))
-            }
+            trimStoredEventsIfNeeded()
+        }
+    }
+
+    private func trimStoredLocationsIfNeeded() {
+        if let max = resolveMaxStored(
+            options?.maxStoredLocations,
+            default: Self.defaultMaxStoredRows
+        ), storedLocations.count > max {
+            storedLocations = Array(storedLocations.suffix(max))
+        }
+    }
+
+    private func trimStoredEventsIfNeeded() {
+        if let max = resolveMaxStored(
+            options?.maxStoredEvents,
+            default: Self.defaultMaxStoredRows
+        ), storedEvents.count > max {
+            storedEvents = Array(storedEvents.suffix(max))
         }
     }
 

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -171,7 +171,6 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     self.persistStore()
                 }
                 self.runOnMainSync {
-                    self.manager?.disallowDeferredLocationUpdates()
                     self.manager?.stopUpdatingLocation()
                     self.manager?.stopMonitoringSignificantLocationChanges()
                     self.manager?.monitoredRegions.forEach { self.manager?.stopMonitoring(for: $0) }
@@ -201,8 +200,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                             self.options?.ios?.useSignificantChanges == true,
                         locationCount: Double(self.storedLocations.count),
                         eventCount: Double(self.storedEvents.count),
-                        lastLocationAt: self.storedLocations.map(\.recordedAt).max(),
-                        lastEventAt: self.storedEvents.map(\.timestamp).max(),
+                        lastLocationAt: self.storedLocations.max {
+                            $0.recordedAt < $1.recordedAt
+                        }?.recordedAt,
+                        lastEventAt: self.storedEvents.max {
+                            $0.timestamp < $1.timestamp
+                        }?.timestamp,
                         geofenceCount: Double(self.geofences.count)
                     )
                 }
@@ -254,7 +257,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             )
             if let storedEvent = plan.storedEvent {
                 appendStoredEvent(storedEvent)
-                persistStore()
+                persistEvents()
             }
             return plan
         }
@@ -270,22 +273,22 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         options: GetStoredBackgroundLocationsOptions?
     ) throws -> Promise<[StoredBackgroundLocation]> {
         return Promise.async {
-            var rows = self.withStoreLock { self.storedLocations }
-            if options?.includeDelivered != true {
-                rows = rows.filter { !$0.deliveredToJS }
+            return self.withStoreLock {
+                let includeDelivered = options?.includeDelivered == true
+                let includeSynced = options?.includeSynced == true
+                let since = options?.since
+                let limit = self.safePrefixCount(
+                    options?.limit,
+                    defaultValue: 100,
+                    upperBound: self.storedLocations.count
+                )
+                return Array(self.storedLocations.lazy.filter { location in
+                    if !includeDelivered && location.deliveredToJS { return false }
+                    if !includeSynced && location.synced { return false }
+                    if let since, location.createdAt < since { return false }
+                    return true
+                }.prefix(limit))
             }
-            if options?.includeSynced != true {
-                rows = rows.filter { !$0.synced }
-            }
-            if let since = options?.since {
-                rows = rows.filter { $0.createdAt >= since }
-            }
-            let limit = self.safePrefixCount(
-                options?.limit,
-                defaultValue: 100,
-                upperBound: rows.count
-            )
-            return Array(rows.prefix(limit))
         }
     }
 
@@ -294,11 +297,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             self.withStoreLock {
                 guard let ids else {
                     self.storedLocations.removeAll()
-                    self.persistStore()
+                    self.persistLocations()
                     return
                 }
-                self.storedLocations.removeAll { ids.contains($0.id) }
-                self.persistStore()
+                let idSet = Set(ids)
+                self.storedLocations.removeAll { idSet.contains($0.id) }
+                self.persistLocations()
             }
         }
     }
@@ -306,26 +310,27 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     func markStoredBackgroundLocationsDelivered(ids: [String]) throws -> Promise<Void> {
         return Promise.async {
             self.withStoreLock {
-                self.storedLocations = self.storedLocations.map { location in
-                    ids.contains(location.id)
-                        ? StoredBackgroundLocation(
-                            id: location.id,
-                            deliveredToJS: true,
-                            synced: location.synced,
-                            createdAt: location.createdAt,
-                            source: location.source,
-                            isFromBackground: location.isFromBackground,
-                            provider: location.provider,
-                            mocked: location.mocked,
-                            recordedAt: location.recordedAt,
-                            activity: location.activity,
-                            battery: location.battery,
-                            coords: location.coords,
-                            timestamp: location.timestamp
-                        )
-                        : location
+                let idSet = Set(ids)
+                for index in self.storedLocations.indices
+                where idSet.contains(self.storedLocations[index].id) {
+                    let location = self.storedLocations[index]
+                    self.storedLocations[index] = StoredBackgroundLocation(
+                        id: location.id,
+                        deliveredToJS: true,
+                        synced: location.synced,
+                        createdAt: location.createdAt,
+                        source: location.source,
+                        isFromBackground: location.isFromBackground,
+                        provider: location.provider,
+                        mocked: location.mocked,
+                        recordedAt: location.recordedAt,
+                        activity: location.activity,
+                        battery: location.battery,
+                        coords: location.coords,
+                        timestamp: location.timestamp
+                    )
                 }
-                self.persistStore()
+                self.persistLocations()
             }
         }
     }
@@ -334,22 +339,22 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
         options: GetStoredBackgroundEventsOptions?
     ) throws -> Promise<[StoredBackgroundEventEnvelope]> {
         return Promise.async {
-            var rows = self.withStoreLock { self.storedEvents }
-            if options?.includeDelivered != true {
-                rows = rows.filter { !$0.deliveredToJS }
+            return self.withStoreLock {
+                let includeDelivered = options?.includeDelivered == true
+                let since = options?.since
+                let types = options?.types
+                let limit = self.safePrefixCount(
+                    options?.limit,
+                    defaultValue: 100,
+                    upperBound: self.storedEvents.count
+                )
+                return Array(self.storedEvents.lazy.filter { event in
+                    if !includeDelivered && event.deliveredToJS { return false }
+                    if let since, event.createdAt < since { return false }
+                    if let types, !types.isEmpty, !types.contains(event.type) { return false }
+                    return true
+                }.prefix(limit))
             }
-            if let since = options?.since {
-                rows = rows.filter { $0.createdAt >= since }
-            }
-            if let types = options?.types, !types.isEmpty {
-                rows = rows.filter { types.contains($0.type) }
-            }
-            let limit = self.safePrefixCount(
-                options?.limit,
-                defaultValue: 100,
-                upperBound: rows.count
-            )
-            return Array(rows.prefix(limit))
         }
     }
 
@@ -358,11 +363,12 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             self.withStoreLock {
                 guard let ids else {
                     self.storedEvents.removeAll()
-                    self.persistStore()
+                    self.persistEvents()
                     return
                 }
-                self.storedEvents.removeAll { ids.contains($0.id) }
-                self.persistStore()
+                let idSet = Set(ids)
+                self.storedEvents.removeAll { idSet.contains($0.id) }
+                self.persistEvents()
             }
         }
     }
@@ -370,19 +376,20 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     func markStoredBackgroundEventsDelivered(ids: [String]) throws -> Promise<Void> {
         return Promise.async {
             self.withStoreLock {
-                self.storedEvents = self.storedEvents.map { event in
-                    ids.contains(event.id)
-                        ? StoredBackgroundEventEnvelope(
-                            event: event.event,
-                            createdAt: event.createdAt,
-                            id: event.id,
-                            type: event.type,
-                            timestamp: event.timestamp,
-                            deliveredToJS: true
-                        )
-                        : event
+                let idSet = Set(ids)
+                for index in self.storedEvents.indices
+                where idSet.contains(self.storedEvents[index].id) {
+                    let event = self.storedEvents[index]
+                    self.storedEvents[index] = StoredBackgroundEventEnvelope(
+                        event: event.event,
+                        createdAt: event.createdAt,
+                        id: event.id,
+                        type: event.type,
+                        timestamp: event.timestamp,
+                        deliveredToJS: true
+                    )
                 }
-                self.persistStore()
+                self.persistEvents()
             }
         }
     }
@@ -410,12 +417,13 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                         self.manager?.startMonitoring(for: circular)
                     }
                 }
+                let sanitizedIdentifiers = Set(sanitized.map(\.identifier))
                 self.withStoreLock {
-                    self.geofences.removeAll { existing in
-                        sanitized.contains { $0.identifier == existing.identifier }
+                    self.geofences.removeAll {
+                        sanitizedIdentifiers.contains($0.identifier)
                     }
                     self.geofences.append(contentsOf: sanitized)
-                    self.persistStore()
+                    self.persistGeofences()
                 }
             }
         }
@@ -430,18 +438,19 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                     }
                     self.withStoreLock {
                         self.geofences.removeAll()
-                        self.persistStore()
+                        self.persistGeofences()
                     }
                     return
                 }
+                let identifierSet = Set(identifiers)
                 self.runOnMainSync {
                     self.manager?.monitoredRegions
-                        .filter { identifiers.contains($0.identifier) }
+                        .filter { identifierSet.contains($0.identifier) }
                         .forEach { self.manager?.stopMonitoring(for: $0) }
                 }
                 self.withStoreLock {
-                    self.geofences.removeAll { identifiers.contains($0.identifier) }
-                    self.persistStore()
+                    self.geofences.removeAll { identifierSet.contains($0.identifier) }
+                    self.persistGeofences()
                 }
             }
         }
@@ -558,7 +567,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                         deliveredToJS: false
                     )
                 )
-                persistStore()
+                persistLocationsAndEvents()
                 return true
             }
             guard storedForRun else { return }
@@ -617,7 +626,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 ),
                 allowUnconfigured: true
             )
-            persistStore()
+            persistEvents()
             return true
         }
         guard storedForRun else { return }
@@ -639,10 +648,8 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
             manager.allowsBackgroundLocationUpdates = true
             manager.pausesLocationUpdatesAutomatically =
                 options.ios?.pausesLocationUpdatesAutomatically ?? false
-            if #available(iOS 11.0, *) {
-                manager.showsBackgroundLocationIndicator =
-                    options.ios?.showsBackgroundLocationIndicator ?? false
-            }
+            manager.showsBackgroundLocationIndicator =
+                options.ios?.showsBackgroundLocationIndicator ?? false
             manager.desiredAccuracy = kCLLocationAccuracyBest
             manager.distanceFilter = options.distanceFilter ?? kCLDistanceFilterNone
             manager.activityType = mapActivityType(options.ios?.activityType)
@@ -700,9 +707,34 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
 
     func persistStore() {
         withStoreLock {
+            persistLocations()
+            persistEvents()
+            persistGeofences()
+        }
+    }
+
+    func persistLocations() {
+        withStoreLock {
             defaults.set(storedLocations.map(storedLocationDictionary), forKey: locationsKey)
+        }
+    }
+
+    func persistEvents() {
+        withStoreLock {
             defaults.set(storedEvents.map(storedEventDictionary), forKey: eventsKey)
+        }
+    }
+
+    private func persistGeofences() {
+        withStoreLock {
             defaults.set(geofences.map(geofenceDictionary), forKey: geofencesKey)
+        }
+    }
+
+    private func persistLocationsAndEvents() {
+        withStoreLock {
+            persistLocations()
+            persistEvents()
         }
     }
 

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+WatchDelivery.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+WatchDelivery.swift
@@ -3,21 +3,25 @@ import CoreLocation
 extension NitroGeolocation {
     func deliverPositionToWatches(
         location: CLLocation,
-        position: GeolocationResponse
+        cachedPosition: GeolocationResponse?
     ) {
-        for (token, subscription) in Array(watchSubscriptions) {
+        var position = cachedPosition
+        for (token, subscription) in $watchSubscriptions.entriesSnapshot() {
             let decision = evaluateIOSWatchDelivery(
                 previous: subscription.deliveryState,
                 latitude: location.coordinate.latitude,
                 longitude: location.coordinate.longitude,
                 distanceFilterMeters: subscription.options.distanceFilter
             )
-            guard decision.shouldDeliver, watchSubscriptions[token] != nil else { continue }
+            guard decision.shouldDeliver else { continue }
 
             var updatedSubscription = subscription
             updatedSubscription.deliveryState = decision.nextState
-            watchSubscriptions[token] = updatedSubscription
-            subscription.success(position)
+            if $watchSubscriptions.updateIfPresent(token: token, value: updatedSubscription) {
+                let deliveredPosition = position ?? location.toGeolocationResponse()
+                position = deliveredPosition
+                subscription.success(deliveredPosition)
+            }
         }
     }
 }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -435,13 +435,12 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
         lastLocation = location
         var position: GeolocationResponse?
-        let removedPositionRequests = !pendingPositionRequests.isEmpty
-        let positionRequests = Array(pendingPositionRequests.values)
+        let positionRequests = pendingPositionRequests
         pendingPositionRequests.removeAll()
-        if removedPositionRequests {
+        if !positionRequests.isEmpty {
             let currentPosition = location.toGeolocationResponse()
             position = currentPosition
-            for request in positionRequests {
+            for request in positionRequests.values {
                 request.timer?.cancel()
                 request.success(currentPosition)
             }
@@ -449,7 +448,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
         deliverPositionToWatches(location: location, cachedPosition: position)
 
-        if removedPositionRequests {
+        if !positionRequests.isEmpty {
             updateMonitoringAfterPositionRequestRemoval()
         }
     }
@@ -480,15 +479,14 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             )
         }
 
-        let positionRequests = Array(pendingPositionRequests.values)
+        let positionRequests = pendingPositionRequests
         pendingPositionRequests.removeAll()
-        for request in positionRequests {
+        for request in positionRequests.values {
             request.timer?.cancel()
             request.error(locationError)
         }
 
-        let subscriptions = Array(watchSubscriptions.values)
-        for subscription in subscriptions {
+        for subscription in $watchSubscriptions.entriesSnapshot().values {
             subscription.error?(locationError)
         }
 
@@ -497,20 +495,25 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     }
 
     func handleHeadingUpdate(_ clHeading: CLHeading) {
-        let heading = headingToResponse(clHeading)
-
-        for (id, request) in Array(pendingHeadingRequests) {
-            request.timer?.cancel()
-            request.success(heading)
-            pendingHeadingRequests.removeValue(forKey: id)
+        var heading: Heading?
+        let headingRequests = pendingHeadingRequests
+        pendingHeadingRequests.removeAll()
+        if !headingRequests.isEmpty {
+            let currentHeading = headingToResponse(clHeading)
+            heading = currentHeading
+            for request in headingRequests.values {
+                request.timer?.cancel()
+                request.success(currentHeading)
+            }
         }
 
-        for (token, subscription) in Array(headingSubscriptions) {
+        let magneticHeading = normalizeHeading(clHeading.magneticHeading)
+        for (token, subscription) in $headingSubscriptions.entriesSnapshot() {
             let shouldDeliver: Bool
             if let lastDeliveredHeading = subscription.lastDeliveredHeading {
                 shouldDeliver = angularDistance(
                     lastDeliveredHeading,
-                    heading.magneticHeading
+                    magneticHeading
                 ) >= subscription.options.headingFilter
             } else {
                 shouldDeliver = true
@@ -518,9 +521,11 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
             if shouldDeliver {
                 var nextSubscription = subscription
-                nextSubscription.lastDeliveredHeading = heading.magneticHeading
+                nextSubscription.lastDeliveredHeading = magneticHeading
                 if $headingSubscriptions.updateIfPresent(token: token, value: nextSubscription) {
-                    nextSubscription.success(heading)
+                    let deliveredHeading = heading ?? headingToResponse(clHeading)
+                    heading = deliveredHeading
+                    nextSubscription.success(deliveredHeading)
                 }
             }
         }
@@ -647,16 +652,14 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
             return
         }
 
-        let headingRequests = Array(pendingHeadingRequests.values)
+        let headingRequests = pendingHeadingRequests
         pendingHeadingRequests.removeAll()
-        for request in headingRequests {
+        for request in headingRequests.values {
             request.timer?.cancel()
             request.error(locationError)
         }
 
-        let subscriptions = Array(headingSubscriptions.values)
-        headingSubscriptions.removeAll()
-        for subscription in subscriptions {
+        for subscription in $headingSubscriptions.drain().values {
             subscription.error?(locationError)
         }
         stopHeadingMonitoring()

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -434,21 +434,23 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         guard let location = locations.last else { return }
 
         lastLocation = location
-        let position = location.toGeolocationResponse()
-
+        var position: GeolocationResponse?
+        let removedPositionRequests = !pendingPositionRequests.isEmpty
         let positionRequests = Array(pendingPositionRequests.values)
         pendingPositionRequests.removeAll()
-        for request in positionRequests {
-            request.timer?.cancel()
-            request.success(position)
+        if removedPositionRequests {
+            let currentPosition = location.toGeolocationResponse()
+            position = currentPosition
+            for request in positionRequests {
+                request.timer?.cancel()
+                request.success(currentPosition)
+            }
         }
 
-        deliverPositionToWatches(location: location, position: position)
+        deliverPositionToWatches(location: location, cachedPosition: position)
 
-        if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
-            stopMonitoring()
-        } else {
-            updateLocationManagerConfiguration()
+        if removedPositionRequests {
+            updateMonitoringAfterPositionRequestRemoval()
         }
     }
 
@@ -525,8 +527,6 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
         if pendingHeadingRequests.isEmpty && headingSubscriptions.isEmpty {
             stopHeadingMonitoring()
-        } else {
-            updateHeadingConfiguration()
         }
     }
 
@@ -659,13 +659,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         for subscription in subscriptions {
             subscription.error?(locationError)
         }
-
-        if pendingHeadingRequests.isEmpty && headingSubscriptions.isEmpty {
-            stopHeadingMonitoring()
-        } else {
-            updateHeadingConfiguration()
-            startHeadingMonitoring()
-        }
+        stopHeadingMonitoring()
     }
 
     internal func updateLocationManagerConfiguration() {
@@ -716,9 +710,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         manager.activityType = activityType ?? .other
         manager.pausesLocationUpdatesAutomatically = pausesLocationUpdatesAutomatically ?? true
 
-        if #available(iOS 11.0, *) {
-            manager.showsBackgroundLocationIndicator = showsBackgroundLocationIndicator
-        }
+        manager.showsBackgroundLocationIndicator = showsBackgroundLocationIndicator
 
         // Update significant changes mode if changed
         if shouldUseSignificantChanges != usingSignificantChanges {
@@ -819,11 +811,18 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
 
     private func getBestCachedLocation(options: ParsedOptions) -> CLLocation? {
         initializeLocationManagerIfNeeded()
-
-        return [lastLocation, locationManager?.location]
-            .compactMap { $0 }
-            .filter { isCachedLocationValid($0, options: options) }
-            .max { $0.timestamp < $1.timestamp }
+        let validLastLocation = lastLocation.flatMap {
+            isCachedLocationValid($0, options: options) ? $0 : nil
+        }
+        guard let managerLocation = locationManager?.location,
+              isCachedLocationValid(managerLocation, options: options)
+        else {
+            return validLastLocation
+        }
+        guard let validLastLocation else { return managerLocation }
+        return managerLocation.timestamp > validLastLocation.timestamp
+            ? managerLocation
+            : validLastLocation
     }
 
     private func handlePositionTimeout(requestId: String) {

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -87,16 +87,14 @@ export function getCurrentPosition(
 
   if (isDevtoolsEnabled()) {
     const devtoolsResult = getDevtoolsCurrentPosition();
-    if (devtoolsResult) {
-      if (signal) {
-        return raceDevtoolsRequestWithSignal(
-          devtoolsResult,
-          signal,
-          rememberCurrentPosition
-        );
-      }
-      return devtoolsResult.then(rememberCurrentPosition);
+    if (signal) {
+      return raceDevtoolsRequestWithSignal(
+        devtoolsResult,
+        signal,
+        rememberCurrentPosition
+      );
     }
+    return devtoolsResult.then(rememberCurrentPosition);
   }
 
   const nativeOptions = getNativeCurrentPositionOptions(options);

--- a/packages/react-native-nitro-geolocation/src/api/getLocationReadiness.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLocationReadiness.ts
@@ -20,6 +20,7 @@ export async function getLocationReadiness(): Promise<LocationReadiness> {
     getProviderStatus(),
     getLocationAvailability()
   ]);
+  const now = Date.now();
 
   return buildLocationReadiness({
     permission,
@@ -29,7 +30,7 @@ export async function getLocationReadiness(): Promise<LocationReadiness> {
       getConfiguredLocationProvider() === "playServices",
     providerStatus,
     availability,
-    cachedPosition: readLastKnownPosition(),
-    now: Date.now()
+    cachedPosition: readLastKnownPosition(now),
+    now
   });
 }

--- a/packages/react-native-nitro-geolocation/src/api/locationMetadata.ts
+++ b/packages/react-native-nitro-geolocation/src/api/locationMetadata.ts
@@ -58,15 +58,13 @@ function getStaleReason(
     : undefined;
 }
 
-/** Add descriptive metadata without changing whether a position is accepted. */
-export function decoratePositionWithMetadata(
+/** @internal Build descriptive metadata without changing position acceptance. */
+export function buildLocationMetadata(
   position: GeolocationResponse,
   context: LocationMetadataContext
-): GeolocationResponse {
+): LocationMetadata {
   const observedAt = context.observedAt ?? Date.now();
   const requestedAt = context.requestedAt ?? observedAt;
-  const basePosition = { ...position };
-  basePosition.metadata = undefined;
   const staleReason = getStaleReason(
     position.timestamp,
     context.maximumAge,
@@ -85,5 +83,16 @@ export function decoratePositionWithMetadata(
     metadata.staleReason = staleReason;
   }
 
-  return { ...basePosition, metadata };
+  return metadata;
+}
+
+/** Add descriptive metadata without changing whether a position is accepted. */
+export function decoratePositionWithMetadata(
+  position: GeolocationResponse,
+  context: LocationMetadataContext
+): GeolocationResponse {
+  return {
+    ...position,
+    metadata: buildLocationMetadata(position, context)
+  };
 }

--- a/packages/react-native-nitro-geolocation/src/api/locationReadiness.ts
+++ b/packages/react-native-nitro-geolocation/src/api/locationReadiness.ts
@@ -74,15 +74,15 @@ export function buildLocationReadiness({
   if (!providerStatus.locationServicesEnabled) {
     remediations.push("enableLocationServices");
   } else if (permission === "granted" && !availability.available) {
-    const androidProviders = [
-      providerStatus.gpsAvailable,
-      providerStatus.networkAvailable,
-      providerStatus.passiveAvailable
-    ].filter((value): value is boolean => typeof value === "boolean");
-
+    const hasKnownAndroidProvider =
+      typeof providerStatus.gpsAvailable === "boolean" ||
+      typeof providerStatus.networkAvailable === "boolean" ||
+      typeof providerStatus.passiveAvailable === "boolean";
     if (
-      androidProviders.length > 0 &&
-      androidProviders.every((providerAvailable) => !providerAvailable)
+      hasKnownAndroidProvider &&
+      providerStatus.gpsAvailable !== true &&
+      providerStatus.networkAvailable !== true &&
+      providerStatus.passiveAvailable !== true
     ) {
       remediations.push("enableLocationProvider");
     }

--- a/packages/react-native-nitro-geolocation/src/background/index.ts
+++ b/packages/react-native-nitro-geolocation/src/background/index.ts
@@ -26,44 +26,12 @@ import type {
   StoredBackgroundEvent,
   StoredBackgroundLocation
 } from "./publicTypes";
-import type {
-  BackgroundEventEnvelope,
-  StoredBackgroundEventEnvelope
-} from "./types";
+import type { BackgroundEventEnvelope } from "./types";
 
 const NativeBackgroundLocation =
   NitroModules.createHybridObject<NitroBackgroundLocation>(
     "NitroBackgroundLocation"
   );
-
-function narrowBackgroundEvent(
-  event: BackgroundEventEnvelope
-): BackgroundEvent {
-  switch (event.type) {
-    case "location":
-      return { ...event, type: "location", location: event.location! };
-    case "geofence":
-      return { ...event, type: "geofence", geofence: event.geofence! };
-    case "activity":
-      return { ...event, type: "activity", activity: event.activity! };
-    case "providerChange":
-      return {
-        ...event,
-        type: "providerChange",
-        providerStatus: event.providerStatus!
-      };
-    case "lifecycle":
-      return {
-        ...event,
-        type: "lifecycle",
-        lifecycle: event.lifecycle!
-      };
-    case "httpSync":
-      return { ...event, type: "httpSync", result: event.result! };
-    case "error":
-      return { ...event, type: "error", error: event.error! };
-  }
-}
 
 export * from "./publicTypes";
 export { BACKGROUND_LOCATION_TASK_NAME, registerBackgroundTask } from "./task";
@@ -131,15 +99,15 @@ export function markStoredBackgroundLocationsDelivered(
   return NativeBackgroundLocation.markStoredBackgroundLocationsDelivered(ids);
 }
 
-export async function getStoredBackgroundEvents(
+export function getStoredBackgroundEvents(
   options?: GetStoredBackgroundEventsOptions
 ): Promise<StoredBackgroundEvent[]> {
-  const events =
-    await NativeBackgroundLocation.getStoredBackgroundEvents(options);
-  return events.map((event: StoredBackgroundEventEnvelope) => ({
-    ...event,
-    event: narrowBackgroundEvent(event.event)
-  }));
+  // Nitro codegen exposes discriminated native unions as envelopes. The
+  // bridged payload already has the public runtime shape, so keep the native
+  // promise and its event objects intact.
+  return NativeBackgroundLocation.getStoredBackgroundEvents(
+    options
+  ) as unknown as Promise<StoredBackgroundEvent[]>;
 }
 
 export function clearStoredBackgroundEvents(ids?: string[]): Promise<void> {
@@ -248,9 +216,11 @@ export async function diagnoseBackgroundLocation(): Promise<BackgroundLocationDi
 export function onBackgroundEvent(
   listener: (event: BackgroundEvent) => void
 ): BackgroundSubscription {
-  const token = NativeBackgroundLocation.addBackgroundEventListener((event) => {
-    listener(narrowBackgroundEvent(event));
-  });
+  // See getStoredBackgroundEvents: this cast narrows only the codegen type and
+  // avoids a passthrough closure on every native event delivery.
+  const token = NativeBackgroundLocation.addBackgroundEventListener(
+    listener as (event: BackgroundEventEnvelope) => void
+  );
   return {
     remove: () => NativeBackgroundLocation.removeBackgroundEventListener(token)
   };

--- a/packages/react-native-nitro-geolocation/src/devtools/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/getCurrentPosition.ts
@@ -2,7 +2,7 @@ import type { GeolocationResponse } from "../publicTypes";
 import { LocationErrorCodes, createLocationError } from "../utils/errors";
 import { getDevtoolsState } from "./index";
 
-export function getDevtoolsCurrentPosition(): Promise<GeolocationResponse> | null {
+export function getDevtoolsCurrentPosition(): Promise<GeolocationResponse> {
   const devtools = getDevtoolsState();
   if (devtools.position) {
     return Promise.resolve(devtools.position);

--- a/packages/react-native-nitro-geolocation/src/devtools/watchPosition.test.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/watchPosition.test.ts
@@ -42,6 +42,7 @@ describe("devtools watch observability", () => {
       { token: firstToken, kind: "position" },
       { token: secondToken, kind: "position" }
     ]);
+    expect(vi.getTimerCount()).toBe(1);
 
     devtoolsStopObserving();
 

--- a/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/devtools/watchPosition.ts
@@ -4,10 +4,57 @@ import type { LocationError } from "../utils/errors";
 import { LocationErrorCodes } from "../utils/errors";
 import { getDevtoolsState } from "./index";
 
-function nextDevtoolsWatchToken(): string {
-  const globals = globalThis as any;
+type DevtoolsWatchRegistration = {
+  previousPosition: GeolocationResponse;
+  success: (position: GeolocationResponse) => void;
+};
+
+type DevtoolsWatchGlobals = typeof globalThis & {
+  __devtoolsWatchInterval?: ReturnType<typeof setInterval>;
+  __devtoolsWatchers?: Map<string, DevtoolsWatchRegistration>;
+  __devtoolsWatchSequence?: number;
+};
+
+function getDevtoolsGlobals(): DevtoolsWatchGlobals {
+  return globalThis as DevtoolsWatchGlobals;
+}
+
+function nextDevtoolsWatchSequence(): number {
+  const globals = getDevtoolsGlobals();
   globals.__devtoolsWatchSequence = (globals.__devtoolsWatchSequence ?? 0) + 1;
-  return `devtools-${globals.__devtoolsWatchSequence}`;
+  return globals.__devtoolsWatchSequence;
+}
+
+function getDevtoolsWatchers(): Map<string, DevtoolsWatchRegistration> {
+  const globals = getDevtoolsGlobals();
+  if (!(globals.__devtoolsWatchers instanceof Map)) {
+    globals.__devtoolsWatchers = new Map();
+  }
+  return globals.__devtoolsWatchers;
+}
+
+function pollDevtoolsPosition(): void {
+  const position = getDevtoolsState().position;
+  if (!position) return;
+
+  for (const registration of getDevtoolsWatchers().values()) {
+    if (position === registration.previousPosition) continue;
+    registration.previousPosition = position;
+    registration.success(position);
+  }
+}
+
+function startDevtoolsPolling(): void {
+  const globals = getDevtoolsGlobals();
+  if (globals.__devtoolsWatchInterval !== undefined) return;
+  globals.__devtoolsWatchInterval = setInterval(pollDevtoolsPosition, 100);
+}
+
+function stopDevtoolsPolling(): void {
+  const globals = getDevtoolsGlobals();
+  if (globals.__devtoolsWatchInterval === undefined) return;
+  clearInterval(globals.__devtoolsWatchInterval);
+  globals.__devtoolsWatchInterval = undefined;
 }
 
 export function devtoolsWatchPosition(
@@ -27,26 +74,18 @@ export function devtoolsWatchPosition(
       });
     }
     // Return a dummy token that does nothing
-    return `devtools-error-${Date.now()}`;
+    return `devtools-error-${nextDevtoolsWatchSequence()}`;
   }
-
-  let previousPosition = devtools.position;
 
   // Send initial position immediately if available
   success(devtools.position);
 
-  const interval = setInterval(() => {
-    if (devtools.position && devtools.position !== previousPosition) {
-      previousPosition = devtools.position;
-      success(devtools.position);
-    }
-  }, 100);
-
-  // Return a cleanup token
-  const token = nextDevtoolsWatchToken();
-  (globalThis as any).__devtoolsWatchers =
-    (globalThis as any).__devtoolsWatchers || {};
-  (globalThis as any).__devtoolsWatchers[token] = interval;
+  const token = `devtools-${nextDevtoolsWatchSequence()}`;
+  getDevtoolsWatchers().set(token, {
+    previousPosition: devtools.position,
+    success
+  });
+  startDevtoolsPolling();
 
   return token;
 }
@@ -61,26 +100,24 @@ export function devtoolsUnwatch(token: string): boolean {
     return true;
   }
 
-  const watchers = (globalThis as any).__devtoolsWatchers;
-  if (watchers?.[token]) {
-    clearInterval(watchers[token]);
-    delete watchers[token];
-    return true;
-  }
+  const watchers = getDevtoolsGlobals().__devtoolsWatchers;
+  if (!(watchers instanceof Map) || !watchers.delete(token)) return false;
+  if (watchers.size === 0) stopDevtoolsPolling();
 
-  return false;
+  return true;
 }
 
 export function getDevtoolsActiveWatches(): ActiveWatch[] {
-  const watchers = (globalThis as any).__devtoolsWatchers;
-  return Object.keys(watchers ?? {}).map((token) => ({
+  const watchers = getDevtoolsGlobals().__devtoolsWatchers;
+  if (!(watchers instanceof Map)) return [];
+  return Array.from(watchers.keys(), (token) => ({
     token,
     kind: "position"
   }));
 }
 
 export function devtoolsStopObserving(): void {
-  for (const { token } of getDevtoolsActiveWatches()) {
-    devtoolsUnwatch(token);
-  }
+  const watchers = getDevtoolsGlobals().__devtoolsWatchers;
+  if (watchers instanceof Map) watchers.clear();
+  stopDevtoolsPolling();
 }

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
@@ -62,11 +62,6 @@ export function useWatchPosition(
 
   useEffect(() => {
     if (!enabled) {
-      // Not enabled, ensure cleanup
-      if (tokenRef.current) {
-        unwatch(tokenRef.current);
-        tokenRef.current = null;
-      }
       setIsWatching(false);
       return;
     }
@@ -94,8 +89,9 @@ export function useWatchPosition(
 
     // Cleanup function
     return () => {
-      if (token) {
-        unwatch(token);
+      unwatch(token);
+      if (tokenRef.current === token) {
+        tokenRef.current = null;
       }
     };
   }, [enabled]); // Only re-subscribe when enabled changes

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
@@ -43,11 +43,9 @@ export function useWatchPosition(
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);
 
-  // Store subscription token (hidden from user!)
-  const tokenRef = useRef<string | null>(null);
-
   // Track if component is mounted to prevent state updates after unmount
   const isMountedRef = useRef(true);
+  const hasErrorRef = useRef(false);
 
   // Store latest options in ref to avoid unnecessary re-subscriptions
   const optionsRef = useRef(options);
@@ -68,6 +66,7 @@ export function useWatchPosition(
 
     // Start watching with latest options
     setIsWatching(true);
+    hasErrorRef.current = false;
     setError(null);
 
     const token = watchPosition(
@@ -75,24 +74,23 @@ export function useWatchPosition(
         // Success callback
         if (!isMountedRef.current) return;
         setPosition(result);
-        setError(null);
+        if (hasErrorRef.current) {
+          hasErrorRef.current = false;
+          setError(null);
+        }
       },
       (err: LocationError) => {
         // Error callback
         if (!isMountedRef.current) return;
+        hasErrorRef.current = true;
         setError(err);
       },
       optionsRef.current
     );
 
-    tokenRef.current = token;
-
     // Cleanup function
     return () => {
       unwatch(token);
-      if (tokenRef.current === token) {
-        tokenRef.current = null;
-      }
     };
   }, [enabled]); // Only re-subscribe when enabled changes
 

--- a/packages/react-native-nitro-geolocation/src/web/browser.ts
+++ b/packages/react-native-nitro-geolocation/src/web/browser.ts
@@ -150,16 +150,16 @@ export function rejectUnsupported<T>(): Promise<T> {
 }
 
 export function distanceMeters(
-  first: GeolocationResponse,
-  second: GeolocationResponse
+  firstLatitude: number,
+  firstLongitude: number,
+  secondLatitude: number,
+  secondLongitude: number
 ): number {
   const earthRadiusMeters = 6371000;
-  const lat1 = (first.coords.latitude * Math.PI) / 180;
-  const lat2 = (second.coords.latitude * Math.PI) / 180;
-  const deltaLat =
-    ((second.coords.latitude - first.coords.latitude) * Math.PI) / 180;
-  const deltaLon =
-    ((second.coords.longitude - first.coords.longitude) * Math.PI) / 180;
+  const lat1 = (firstLatitude * Math.PI) / 180;
+  const lat2 = (secondLatitude * Math.PI) / 180;
+  const deltaLat = ((secondLatitude - firstLatitude) * Math.PI) / 180;
+  const deltaLon = ((secondLongitude - firstLongitude) * Math.PI) / 180;
 
   const a =
     Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -952,6 +952,35 @@ describe("web Modern API", () => {
     expect(getActiveWatches()).toEqual([]);
   });
 
+  it("rejects distance-filtered browser updates before normalizing them", () => {
+    let observePosition:
+      | ((position: ReturnType<typeof createPosition>) => void)
+      | undefined;
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn((success) => {
+          observePosition = success;
+          return 12;
+        }),
+        clearWatch: vi.fn()
+      }
+    });
+    const success = vi.fn();
+    watchPosition(success, undefined, { distanceFilter: 100 });
+    observePosition?.(createPosition());
+
+    const filteredPosition = createPosition(37.56651, 126.97801);
+    Object.defineProperty(filteredPosition.coords, "accuracy", {
+      get: () => {
+        throw new Error("filtered positions must not be normalized");
+      }
+    });
+
+    expect(() => observePosition?.(filteredPosition)).not.toThrow();
+    expect(success).toHaveBeenCalledTimes(1);
+  });
+
   it("observes distinct provider status changes and stops by token", async () => {
     const windowListeners = new Map<string, EventListener>();
     const documentListeners = new Map<string, EventListener>();

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -614,6 +614,7 @@ describe("web Modern API", () => {
 
   it("diagnoses a ready browser without starting location acquisition", async () => {
     const getCurrentPositionMock = vi.fn();
+    const query = vi.fn(async () => ({ state: "granted" as const }));
     setNavigator({
       geolocation: {
         getCurrentPosition: getCurrentPositionMock,
@@ -621,7 +622,7 @@ describe("web Modern API", () => {
         clearWatch: vi.fn()
       },
       permissions: {
-        query: vi.fn(async () => ({ state: "granted" }))
+        query
       }
     });
 
@@ -634,6 +635,7 @@ describe("web Modern API", () => {
       remediations: ["acquirePosition"]
     });
     expect(getCurrentPositionMock).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it("uses a recent successful observation as bounded permission evidence", async () => {

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -2,7 +2,7 @@ import {
   type CurrentPositionOptions,
   getAbortReason
 } from "../api/currentPositionOptions";
-import { decoratePositionWithMetadata } from "../api/locationMetadata";
+import { buildLocationMetadata } from "../api/locationMetadata";
 import { buildLocationReadiness } from "../api/locationReadiness";
 import { buildPermissionDetails } from "../api/permissionDetails";
 import {
@@ -171,18 +171,16 @@ export function getProviderStatus(): Promise<LocationProviderStatus> {
   });
 }
 
-export async function getLocationAvailability(): Promise<LocationAvailability> {
-  if (!getGeolocation()) {
+function buildWebLocationAvailability(
+  environmentSupported: boolean,
+  permission: PermissionStatus
+): LocationAvailability {
+  if (!environmentSupported) {
     return {
       available: false,
       reason: "unsupported"
     };
   }
-
-  const permission = applyRecentWebPermissionEvidence(
-    await checkPermission(),
-    Date.now()
-  );
   if (permission === "denied" || permission === "restricted") {
     return {
       available: false,
@@ -193,21 +191,39 @@ export async function getLocationAvailability(): Promise<LocationAvailability> {
   return { available: true };
 }
 
+export async function getLocationAvailability(): Promise<LocationAvailability> {
+  const environmentSupported = Boolean(getGeolocation());
+  if (!environmentSupported) {
+    return buildWebLocationAvailability(false, "denied");
+  }
+
+  const permission = applyRecentWebPermissionEvidence(
+    await checkPermission(),
+    Date.now()
+  );
+  return buildWebLocationAvailability(true, permission);
+}
+
 export async function getLocationReadiness(): Promise<LocationReadiness> {
-  const [permission, providerStatus, availability] = await Promise.all([
-    checkPermission(),
-    getProviderStatus(),
-    getLocationAvailability()
-  ]);
-  const cachedPosition = readLastKnownPosition();
+  const environmentSupported = Boolean(getGeolocation());
+  const permission = await checkPermission();
   const now = Date.now();
   const observedPermission = applyRecentWebPermissionEvidence(permission, now);
+  const providerStatus: LocationProviderStatus = {
+    locationServicesEnabled: environmentSupported,
+    backgroundModeEnabled: false
+  };
+  const availability = buildWebLocationAvailability(
+    environmentSupported,
+    observedPermission
+  );
+  const cachedPosition = readLastKnownPosition(now);
 
   return buildLocationReadiness({
     permission: observedPermission,
     deniedPermissionIsAmbiguous:
       permission === "undetermined" && observedPermission === "denied",
-    environmentSupported: Boolean(getGeolocation()),
+    environmentSupported,
     providerStatus,
     availability,
     cachedPosition,
@@ -261,26 +277,30 @@ export function getCurrentPosition(
   }
 
   const requestedAt = Date.now();
+  const maximumAge = options?.maximumAge ?? 0;
   const observePosition = (
     position: Parameters<typeof normalizePosition>[0]
   ): GeolocationResponse => {
-    rememberWebPermissionGrant();
-    rememberWebPermissionDetailsEvidence("granted");
-    return rememberPosition(
-      decoratePositionWithMetadata(normalizePosition(position), {
-        source: "currentPosition",
-        maximumAge: options?.maximumAge ?? 0,
-        requestedAt
-      })
-    );
+    const observedAt = Date.now();
+    rememberWebPermissionGrant(observedAt);
+    rememberWebPermissionDetailsEvidence("granted", observedAt);
+    const normalizedPosition = normalizePosition(position);
+    normalizedPosition.metadata = buildLocationMetadata(normalizedPosition, {
+      source: "currentPosition",
+      maximumAge,
+      requestedAt,
+      observedAt
+    });
+    return rememberPosition(normalizedPosition);
   };
   const observeError = (
     error: Parameters<typeof mapBrowserError>[0]
   ): LocationError => {
     const mappedError = mapBrowserError(error);
     if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
-      rememberWebPermissionDenial();
-      rememberWebPermissionDetailsEvidence("denied");
+      const observedAt = Date.now();
+      rememberWebPermissionDenial(observedAt);
+      rememberWebPermissionDetailsEvidence("denied", observedAt);
     }
     return mappedError;
   };

--- a/packages/react-native-nitro-geolocation/src/web/permissionDetailsEvidence.ts
+++ b/packages/react-native-nitro-geolocation/src/web/permissionDetailsEvidence.ts
@@ -3,33 +3,34 @@ import type { PermissionStatus } from "../publicTypes";
 type ObservedPermissionStatus = Extract<PermissionStatus, "granted" | "denied">;
 
 const permissionEvidenceMaxAgeMs = 30_000;
-let evidence:
-  | { status: ObservedPermissionStatus; observedAt: number }
-  | undefined;
+let evidenceStatus: ObservedPermissionStatus | undefined;
+let evidenceObservedAt: number | undefined;
 
 export function rememberWebPermissionDetailsEvidence(
   status: ObservedPermissionStatus,
   now = Date.now()
 ): void {
-  evidence = { status, observedAt: now };
+  evidenceStatus = status;
+  evidenceObservedAt = now;
 }
 
 export function clearWebPermissionDetailsEvidence(): void {
-  evidence = undefined;
+  evidenceStatus = undefined;
+  evidenceObservedAt = undefined;
 }
 
 export function readRecentWebPermissionDetailsEvidence(
   now = Date.now()
 ): ObservedPermissionStatus | undefined {
-  if (!evidence) {
+  if (evidenceObservedAt === undefined) {
     return undefined;
   }
 
-  const ageMs = now - evidence.observedAt;
+  const ageMs = now - evidenceObservedAt;
   if (ageMs < 0 || ageMs > permissionEvidenceMaxAgeMs) {
     clearWebPermissionDetailsEvidence();
     return undefined;
   }
 
-  return evidence.status;
+  return evidenceStatus;
 }

--- a/packages/react-native-nitro-geolocation/src/web/permissionEvidence.ts
+++ b/packages/react-native-nitro-geolocation/src/web/permissionEvidence.ts
@@ -3,27 +3,30 @@ import type { PermissionStatus } from "../publicTypes";
 type ObservedPermissionStatus = Extract<PermissionStatus, "granted" | "denied">;
 
 const permissionEvidenceMaxAgeMs = 30_000;
-let evidence:
-  | { status: ObservedPermissionStatus; observedAt: number }
-  | undefined;
+let evidenceStatus: ObservedPermissionStatus | undefined;
+let evidenceObservedAt: number | undefined;
 
 export function rememberWebPermissionGrant(now = Date.now()): void {
-  evidence = { status: "granted", observedAt: now };
+  evidenceStatus = "granted";
+  evidenceObservedAt = now;
 }
 
 export function rememberWebPermissionDenial(now = Date.now()): void {
-  evidence = { status: "denied", observedAt: now };
+  evidenceStatus = "denied";
+  evidenceObservedAt = now;
 }
 
 export function clearWebPermissionEvidence(): void {
-  evidence = undefined;
+  evidenceStatus = undefined;
+  evidenceObservedAt = undefined;
 }
 
 export function applyRecentWebPermissionEvidence(
   permission: PermissionStatus,
   now: number
 ): PermissionStatus {
-  const evidenceAgeMs = evidence ? now - evidence.observedAt : undefined;
+  const evidenceAgeMs =
+    evidenceObservedAt === undefined ? undefined : now - evidenceObservedAt;
 
   if (
     evidenceAgeMs !== undefined &&
@@ -34,7 +37,7 @@ export function applyRecentWebPermissionEvidence(
   }
 
   if (permission === "undetermined" && evidenceAgeMs !== undefined) {
-    return evidence?.status ?? permission;
+    return evidenceStatus ?? permission;
   }
 
   return permission;

--- a/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
@@ -13,8 +13,8 @@ export function useWatchPosition(
   const [position, setPosition] = useState<GeolocationResponse | null>(null);
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);
-  const tokenRef = useRef<string | null>(null);
   const isMountedRef = useRef(true);
+  const hasErrorRef = useRef(false);
   const optionsRef = useRef(options);
   const enabled = options?.enabled ?? false;
 
@@ -31,15 +31,12 @@ export function useWatchPosition(
 
   useEffect(() => {
     if (!enabled) {
-      if (tokenRef.current) {
-        unwatch(tokenRef.current);
-        tokenRef.current = null;
-      }
       setIsWatching(false);
       return;
     }
 
     setIsWatching(true);
+    hasErrorRef.current = false;
     setError(null);
     const token = watchPosition(
       (nextPosition) => {
@@ -47,23 +44,22 @@ export function useWatchPosition(
           return;
         }
         setPosition(nextPosition);
-        setError(null);
+        if (hasErrorRef.current) {
+          hasErrorRef.current = false;
+          setError(null);
+        }
       },
       (nextError) => {
         if (!isMountedRef.current) {
           return;
         }
+        hasErrorRef.current = true;
         setError(nextError);
       },
       optionsRef.current
     );
-    tokenRef.current = token;
-
     return () => {
       unwatch(token);
-      if (tokenRef.current === token) {
-        tokenRef.current = null;
-      }
     };
   }, [enabled]);
 

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -1,4 +1,4 @@
-import { decoratePositionWithMetadata } from "../api/locationMetadata";
+import { buildLocationMetadata } from "../api/locationMetadata";
 import { rememberPosition } from "../api/positionCache";
 import type {
   ActiveWatch,
@@ -135,10 +135,12 @@ export function watchPosition(
   let lastEmittedLongitude: number | undefined;
   const requestedAt = Date.now();
   const distanceFilter = options?.distanceFilter ?? 0;
+  const maximumAge = options?.maximumAge ?? 0;
   const watchId = geolocation.watchPosition(
     (position) => {
-      rememberWebPermissionGrant();
-      rememberWebPermissionDetailsEvidence("granted");
+      const observedAt = Date.now();
+      rememberWebPermissionGrant(observedAt);
+      rememberWebPermissionDetailsEvidence("granted", observedAt);
       if (
         distanceFilter > 0 &&
         lastEmittedLatitude !== undefined &&
@@ -152,14 +154,13 @@ export function watchPosition(
       ) {
         return;
       }
-      const normalizedPosition = decoratePositionWithMetadata(
-        normalizePosition(position),
-        {
-          source: "watchPosition",
-          maximumAge: options?.maximumAge ?? 0,
-          requestedAt
-        }
-      );
+      const normalizedPosition = normalizePosition(position);
+      normalizedPosition.metadata = buildLocationMetadata(normalizedPosition, {
+        source: "watchPosition",
+        maximumAge,
+        requestedAt,
+        observedAt
+      });
       lastEmittedLatitude = position.coords.latitude;
       lastEmittedLongitude = position.coords.longitude;
       success(rememberPosition(normalizedPosition));
@@ -167,8 +168,9 @@ export function watchPosition(
     (browserError) => {
       const mappedError = mapBrowserError(browserError);
       if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
-        rememberWebPermissionDenial();
-        rememberWebPermissionDetailsEvidence("denied");
+        const observedAt = Date.now();
+        rememberWebPermissionDenial(observedAt);
+        rememberWebPermissionDetailsEvidence("denied", observedAt);
       }
       error?.(mappedError);
     },

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -131,12 +131,27 @@ export function watchPosition(
     return token;
   }
 
-  let lastEmitted: GeolocationResponse | null = null;
+  let lastEmittedLatitude: number | undefined;
+  let lastEmittedLongitude: number | undefined;
   const requestedAt = Date.now();
+  const distanceFilter = options?.distanceFilter ?? 0;
   const watchId = geolocation.watchPosition(
     (position) => {
       rememberWebPermissionGrant();
       rememberWebPermissionDetailsEvidence("granted");
+      if (
+        distanceFilter > 0 &&
+        lastEmittedLatitude !== undefined &&
+        lastEmittedLongitude !== undefined &&
+        distanceMeters(
+          lastEmittedLatitude,
+          lastEmittedLongitude,
+          position.coords.latitude,
+          position.coords.longitude
+        ) < distanceFilter
+      ) {
+        return;
+      }
       const normalizedPosition = decoratePositionWithMetadata(
         normalizePosition(position),
         {
@@ -145,15 +160,9 @@ export function watchPosition(
           requestedAt
         }
       );
-      const filter = options?.distanceFilter ?? 0;
-      if (
-        filter <= 0 ||
-        !lastEmitted ||
-        distanceMeters(lastEmitted, normalizedPosition) >= filter
-      ) {
-        lastEmitted = rememberPosition(normalizedPosition);
-        success(lastEmitted);
-      }
+      lastEmittedLatitude = position.coords.latitude;
+      lastEmittedLongitude = position.coords.longitude;
+      success(rememberPosition(normalizedPosition));
     },
     (browserError) => {
       const mappedError = mapBrowserError(browserError);

--- a/tests/ios/IOSBackgroundLocationDelegateContract.swift
+++ b/tests/ios/IOSBackgroundLocationDelegateContract.swift
@@ -85,12 +85,6 @@ final class NitroBackgroundLocation {
         locationSessionGeneration: UInt64
     ) {}
 
-    func applyDeferredUpdatesIfNeeded(
-        _ manager: CLLocationManager,
-        runGeneration: UInt64,
-        locationSessionGeneration: UInt64
-    ) {}
-
     func handleError(
         _ error: Error,
         runGeneration: UInt64,


### PR DESCRIPTION
## Summary

- defer Android, iOS, and Web response/metadata creation until an update passes delivery filters, and share converted responses across subscribers
- reuse Android heading buffers and declination data, skip unchanged native watch re-registration, and remove duplicate permission checks, UUIDs, sorting, snapshots, and collection allocations
- batch iOS Core Location persistence, trimming, and sync admission; avoid unchanged UserDefaults rewrites; replace legacy event O(E×L) restore scans with indexed lookup
- transact Android location/event persistence, add queue indexes, delete only excess rows during pruning, and check sync thresholds without materializing stored locations
- collapse Web readiness permission queries, remove per-update evidence allocations, share one DevTools polling timer, and avoid background-event passthrough copies
- remove obsolete iOS deferred APIs/deployment guards and redundant React/native cleanup guards
- add Android store regressions, Web hot-path regressions, and a patch changeset

## Why

The full audit found repeated work on high-frequency paths: conversion before filter decisions, subscriber-specific response creation, sensor allocation, redundant provider reconfiguration, per-sample background serialization and sync admission, unindexed queue scans, repeated Permissions API calls, and one polling timer per DevTools watcher. The changes move work behind actual delivery/state transitions and preserve generation, persistence-before-delivery, and bounded-storage contracts.

## Validation

- `yarn test:unit` (24 files, 196 tests)
- `yarn typecheck`
- `yarn format:check`
- `yarn lint`
- `yarn source-lines:check`
- `yarn pack:check`
- `yarn deadcode:prod`
- Android `:react-native-nitro-geolocation:testDebugUnitTest` (95 tests)
- Android Kotlin/Java compile and four-ABI CMake build
- iOS location lifecycle and watch delivery contract tests
- iOS simulator Debug build for arm64 and x86_64

Android `lintDebug` still reports the repository's existing 19 MissingPermission/manifest errors; this change adds no correctness lint error.
