### PR TITLE
fix: gate latest on validated release prebuilts

### DIFF
--- a/.changeset/safe-latest-prebuilts.md
+++ b/.changeset/safe-latest-prebuilts.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Fix prebuilt packaging and portable checksums, and stage stable releases behind a validated, commit-matched manual `latest` promotion.

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -102,6 +102,21 @@ jobs:
       - name: Build XCFramework
         run: scripts/build-prebuilt-ios.sh build/prebuilt
 
+      - name: Verify the example consumes the packaged XCFramework
+        working-directory: examples/v0.81.1
+        env:
+          NITRO_GEOLOCATION_USE_PREBUILT: "1"
+          NITRO_GEOLOCATION_PREBUILT_URL_BASE: file://${{ github.workspace }}/build/prebuilt
+        run: |
+          bundle exec pod install --project-directory=ios
+          xcodebuild build -quiet \
+            -workspace ios/NitroGeolocationExample.xcworkspace \
+            -scheme NitroGeolocationExample \
+            -configuration Release \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "${{ runner.temp }}/prebuilt-consumer" \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -1,0 +1,102 @@
+name: Promote validated GA to latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact stable version to promote, for example 2.0.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-latest-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Validate release assets and promote npm tag
+    runs-on: ubuntu-latest
+    environment: npm-latest
+    steps:
+      - name: Checkout the exact release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/react-native-nitro-geolocation@${{ inputs.version }}
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          install: false
+
+      - name: Trust and install tools via mise
+        run: |
+          mise trust --yes
+          mise install node
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          mise reshim node
+
+      - name: Validate exact source version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          actual="$(node -p "require('./packages/react-native-nitro-geolocation/package.json').version")"
+          test "$actual" = "$VERSION"
+
+      - name: Download all release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: react-native-nitro-geolocation@${{ inputs.version }}
+        run: |
+          test "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = "false"
+          gh release download "$TAG" --dir "${{ runner.temp }}/release-assets"
+
+      - name: Verify required prebuilts and checksums
+        env:
+          ASSET_DIR: ${{ runner.temp }}/release-assets
+          VERSION: ${{ inputs.version }}
+        run: |
+          android="react-native-nitro-geolocation-${VERSION}-android.aar"
+          ios="react-native-nitro-geolocation-${VERSION}-ios.xcframework.zip"
+          test -s "$ASSET_DIR/$android"
+          test -s "$ASSET_DIR/$android.sha256"
+          test -s "$ASSET_DIR/$ios"
+          test -s "$ASSET_DIR/$ios.sha256"
+          cd "$ASSET_DIR"
+          test "$(wc -l < "$android.sha256" | tr -d ' ')" = "1"
+          test "$(awk '{ sub(/^\*/, "", $2); print $2 }' "$android.sha256")" = "$android"
+          test "$(wc -l < "$ios.sha256" | tr -d ' ')" = "1"
+          test "$(awk '{ sub(/^\*/, "", $2); print $2 }' "$ios.sha256")" = "$ios"
+          sha256sum --check "$android.sha256"
+          sha256sum --check "$ios.sha256"
+
+          android_entries="$(unzip -Z1 "$android")"
+          ios_entries="$(unzip -Z1 "$ios")"
+          for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+            grep -Fxq "jni/$abi/libnitrogeolocation.so" <<< "$android_entries"
+          done
+          for slice in ios-arm64 ios-arm64_x86_64-simulator; do
+            grep -Fxq "NitroGeolocation.xcframework/$slice/NitroGeolocation.framework/NitroGeolocation" <<< "$ios_entries"
+            grep -Fxq "NitroGeolocation.xcframework/$slice/NitroGeolocation.framework/PrivacyInfo.xcprivacy" <<< "$ios_entries"
+          done
+          if grep -Eq '\.swift(interface|module)' <<< "$ios_entries"; then
+            echo "The iOS prebuilt unexpectedly contains a textual Swift module." >&2
+            exit 1
+          fi
+
+      - name: Configure npm authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/npmrc
+        run: npm config set "//registry.npmjs.org/:_authToken" "$NODE_AUTH_TOKEN"
+
+      - name: Promote validated candidate to latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/npmrc
+        run: node scripts/promote-latest.mjs "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Create release PR or publish packages
+      - name: Verify documentation matches the package release channel
+        run: yarn workspace docs check:versions
+
+      - name: Create release PR or publish packages to a safe candidate tag
         id: changesets
         uses: changesets/action@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Before opening a PR:
 
 - The repo uses a single Changesets-driven workflow in `.github/workflows/release.yml` for every published package.
 - On `main`, that workflow either updates the version PR or publishes the packages that were versioned by a merged Changesets PR.
+- Stable `react-native-nitro-geolocation` releases are first published under the `ga-candidate` npm tag. The release workflow then builds and uploads both platform prebuilts; it never assigns `latest` directly.
+- After the prebuilt workflow and release evidence pass, an authorized maintainer can run **Promote validated GA to latest** with the exact stable version. The protected `npm-latest` environment should require reviewer approval.
 - Git tags and GitHub Releases follow the package-version format that Changesets generates, such as `react-native-nitro-geolocation@1.2.0` and `@react-native-nitro-geolocation/rozenite-plugin@1.0.2`.
 - Keep package release notes in each package's `CHANGELOG.md`; Changesets uses the matching version section when it creates GitHub Releases.
 

--- a/examples/v0.81.1/.maestro/permission-details.yaml
+++ b/examples/v0.81.1/.maestro/permission-details.yaml
@@ -16,7 +16,7 @@ appId: nitrogeolocation.example
           text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
-    timeout: 10000
+    timeout: 30000
 - stopApp
 - openLink:
     link: nitrogeolocation://app/permission-details
@@ -85,7 +85,7 @@ appId: nitrogeolocation.example
           text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
-    timeout: 10000
+    timeout: 30000
 - stopApp
 - openLink:
     link: nitrogeolocation://app/permission-details
@@ -129,7 +129,7 @@ appId: nitrogeolocation.example
                 text: "Wait|대기"
       - extendedWaitUntil:
           visible: "Geolocation API"
-          timeout: 10000
+          timeout: 30000
       - stopApp
       - openLink:
           link: nitrogeolocation://app/permission-details
@@ -161,7 +161,7 @@ appId: nitrogeolocation.example
           text: "Wait|대기"
 - extendedWaitUntil:
     visible: "Geolocation API"
-    timeout: 10000
+    timeout: 30000
 - stopApp
 - openLink:
     link: nitrogeolocation://app/permission-details

--- a/examples/v0.81.1/ios/Podfile.lock
+++ b/examples/v0.81.1/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroGeolocation (1.4.3):
+  - NitroGeolocation (2.0.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2767,7 +2767,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroGeolocation: 8062747b8bb6751225dae6211c68c301dbe2a528
+  NitroGeolocation: b55ed115c860dfbd4ddc20a9e4f70b142a486b99
   NitroModules: b5c5baefa71a65c40e129876a8b7943a9aef6aa5
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "lint": "biome ci --formatter-enabled=false --linter-enabled=true .",
     "lint:fix": "biome check --write .",
     "release:publish": "node scripts/publish-release.mjs",
+    "release:promote-latest": "node scripts/promote-latest.mjs",
+    "test:release-policy": "node --test tests/release-policy.test.mjs",
     "test:unit": "yarn workspace react-native-nitro-geolocation test",
     "test:ios-location-lifecycle": "bash scripts/test-ios-location-lifecycle.sh",
     "test:e2e:web": "yarn workspace react-native-nitro-geolocation-web-e2e build",

--- a/scripts/build-prebuilt-android.sh
+++ b/scripts/build-prebuilt-android.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_DIR="$ROOT_DIR/packages/react-native-nitro-geolocation"
 EXAMPLE_ANDROID_DIR="$ROOT_DIR/examples/v0.81.1/android"
-OUT_DIR="${1:-$ROOT_DIR/build/prebuilt}"
+OUT_DIR_INPUT="${1:-$ROOT_DIR/build/prebuilt}"
 
 VERSION="$(node -p "require('$PACKAGE_DIR/package.json').version")"
 ASSET_NAME="react-native-nitro-geolocation-${VERSION}-android.aar"
 
-mkdir -p "$OUT_DIR"
+mkdir -p "$OUT_DIR_INPUT"
+OUT_DIR="$(cd "$OUT_DIR_INPUT" && pwd)"
 
 (
   cd "$EXAMPLE_ANDROID_DIR"
@@ -28,6 +29,9 @@ if [[ -z "$AAR_PATH" ]]; then
 fi
 
 cp "$AAR_PATH" "$OUT_DIR/$ASSET_NAME"
-shasum -a 256 "$OUT_DIR/$ASSET_NAME" > "$OUT_DIR/$ASSET_NAME.sha256"
+(
+  cd "$OUT_DIR"
+  shasum -a 256 "$ASSET_NAME" > "$ASSET_NAME.sha256"
+)
 
 echo "$OUT_DIR/$ASSET_NAME"

--- a/scripts/build-prebuilt-ios.sh
+++ b/scripts/build-prebuilt-ios.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_DIR="$ROOT_DIR/packages/react-native-nitro-geolocation"
 EXAMPLE_DIR="$ROOT_DIR/examples/v0.81.1"
 IOS_DIR="$EXAMPLE_DIR/ios"
-OUT_DIR="${1:-$ROOT_DIR/build/prebuilt}"
+OUT_DIR_INPUT="${1:-$ROOT_DIR/build/prebuilt}"
 BUILD_DIR="$ROOT_DIR/build/ios-prebuilt"
 
 VERSION="$(node -p "require('$PACKAGE_DIR/package.json').version")"
@@ -13,15 +13,20 @@ ASSET_NAME="react-native-nitro-geolocation-${VERSION}-ios.xcframework.zip"
 WORKSPACE="$IOS_DIR/NitroGeolocationExample.xcworkspace"
 SCHEME="NitroGeolocation"
 
-mkdir -p "$OUT_DIR" "$BUILD_DIR"
+mkdir -p "$OUT_DIR_INPUT" "$BUILD_DIR"
+OUT_DIR="$(cd "$OUT_DIR_INPUT" && pwd)"
 
 (
   if [[ -f "$EXAMPLE_DIR/Gemfile" ]]; then
     cd "$EXAMPLE_DIR"
-    USE_FRAMEWORKS=static NITRO_GEOLOCATION_USE_PREBUILT=0 bundle exec pod install --project-directory=ios
+    USE_FRAMEWORKS=static \
+      NITRO_GEOLOCATION_USE_PREBUILT=0 \
+      bundle exec pod install --project-directory=ios
   else
     cd "$IOS_DIR"
-    USE_FRAMEWORKS=static NITRO_GEOLOCATION_USE_PREBUILT=0 pod install
+    USE_FRAMEWORKS=static \
+      NITRO_GEOLOCATION_USE_PREBUILT=0 \
+      pod install
   fi
 )
 
@@ -29,23 +34,32 @@ rm -rf "$BUILD_DIR/NitroGeolocation.xcframework" \
   "$BUILD_DIR/ios.xcarchive" \
   "$BUILD_DIR/ios-simulator.xcarchive"
 
-xcodebuild archive \
+# This package's native surface is linked through Nitro's generated registry;
+# consumers do not import its Swift module. Nitro Modules exposes C++20 headers,
+# while Swift's textual-interface verifier currently reparses imported C++ as
+# C++17. Avoid shipping an invalid interface and validate the linkable static
+# framework slices instead.
+xcodebuild archive -quiet \
   -workspace "$WORKSPACE" \
   -scheme "$SCHEME" \
   -configuration Release \
   -destination "generic/platform=iOS" \
   -archivePath "$BUILD_DIR/ios.xcarchive" \
   SKIP_INSTALL=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+  BUILD_LIBRARY_FOR_DISTRIBUTION=NO
 
-xcodebuild archive \
+xcodebuild archive -quiet \
   -workspace "$WORKSPACE" \
   -scheme "$SCHEME" \
   -configuration Release \
   -destination "generic/platform=iOS Simulator" \
   -archivePath "$BUILD_DIR/ios-simulator.xcarchive" \
   SKIP_INSTALL=NO \
-  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+  BUILD_LIBRARY_FOR_DISTRIBUTION=NO
+
+rm -rf \
+  "$BUILD_DIR/ios.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework/Modules/NitroGeolocation.swiftmodule" \
+  "$BUILD_DIR/ios-simulator.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework/Modules/NitroGeolocation.swiftmodule"
 
 xcodebuild -create-xcframework \
   -framework "$BUILD_DIR/ios.xcarchive/Products/Library/Frameworks/NitroGeolocation.framework" \
@@ -61,6 +75,9 @@ rm -f "$OUT_DIR/$ASSET_NAME" "$OUT_DIR/$ASSET_NAME.sha256"
   cd "$BUILD_DIR"
   /usr/bin/ditto -c -k --sequesterRsrc --keepParent NitroGeolocation.xcframework "$OUT_DIR/$ASSET_NAME"
 )
-shasum -a 256 "$OUT_DIR/$ASSET_NAME" > "$OUT_DIR/$ASSET_NAME.sha256"
+(
+  cd "$OUT_DIR"
+  shasum -a 256 "$ASSET_NAME" > "$ASSET_NAME.sha256"
+)
 
 echo "$OUT_DIR/$ASSET_NAME"

--- a/scripts/promote-latest.mjs
+++ b/scripts/promote-latest.mjs
@@ -1,0 +1,93 @@
+import { execFileSync } from "node:child_process";
+import {
+  assertCandidateTag,
+  assertPromotableVersion,
+  compareStableVersions,
+  defaultCandidateTag,
+  protectedPackageName
+} from "./release-policy.mjs";
+
+const packageName = protectedPackageName;
+const registry = "https://registry.npmjs.org";
+const version = process.argv[2];
+const dryRun = process.argv.includes("--dry-run");
+const candidateTag =
+  process.env.NITRO_GEOLOCATION_GA_CANDIDATE_TAG ?? defaultCandidateTag;
+
+if (version === undefined) {
+  throw new Error("Usage: node scripts/promote-latest.mjs <x.y.z> [--dry-run]");
+}
+assertPromotableVersion(version);
+assertCandidateTag(candidateTag);
+
+const npmView = (...args) =>
+  execFileSync("npm", ["view", ...args, "--registry", registry, "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"]
+  }).trim();
+
+const publishedVersion = JSON.parse(
+  npmView(`${packageName}@${version}`, "version")
+);
+if (publishedVersion !== version) {
+  throw new Error(
+    `npm does not resolve ${packageName}@${version} to the requested version`
+  );
+}
+
+const publishedGitHead = JSON.parse(
+  npmView(`${packageName}@${version}`, "gitHead")
+);
+const checkedOutGitHead = execFileSync("git", ["rev-parse", "HEAD"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "inherit"]
+}).trim();
+if (publishedGitHead !== checkedOutGitHead) {
+  throw new Error(
+    `npm gitHead ${publishedGitHead ?? "is missing"}; expected release commit ${checkedOutGitHead}`
+  );
+}
+
+const distTags = JSON.parse(npmView(packageName, "dist-tags"));
+if (distTags[candidateTag] !== version) {
+  throw new Error(
+    `${candidateTag} points to ${distTags[candidateTag] ?? "nothing"}, not ${version}`
+  );
+}
+
+const currentLatest = distTags.latest;
+if (currentLatest !== undefined) {
+  assertPromotableVersion(currentLatest);
+  if (compareStableVersions(version, currentLatest) < 0) {
+    throw new Error(
+      `Refusing to move latest backwards from ${currentLatest} to ${version}`
+    );
+  }
+}
+
+if (dryRun) {
+  console.log(`Would promote ${packageName}@${version} to latest.`);
+  process.exit(0);
+}
+
+execFileSync(
+  "npm",
+  [
+    "dist-tag",
+    "add",
+    `${packageName}@${version}`,
+    "latest",
+    "--registry",
+    registry
+  ],
+  {
+    stdio: "inherit"
+  }
+);
+
+const updatedTags = JSON.parse(npmView(packageName, "dist-tags"));
+if (updatedTags.latest !== version) {
+  throw new Error(`latest promotion verification failed for ${version}`);
+}
+
+console.log(`Promoted ${packageName}@${version} to latest.`);

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { resolvePublishTag } from "./release-policy.mjs";
 
 const dryRun = process.argv.includes("--dry-run");
 
@@ -50,13 +51,20 @@ try {
       throw new Error(`Release workspace not found: ${release.name}`);
     }
 
+    const publishTag = resolvePublishTag(release);
+    if (publishTag !== release.tag) {
+      console.log(
+        `Publishing ${release.name}@${release.version} under the protected candidate tag ${publishTag}; latest requires manual promotion after prebuilt validation.`
+      );
+    }
+
     const args = [
       "publish",
       path.resolve(workspaceLocation),
       "--access",
       release.access,
       "--tag",
-      release.tag,
+      publishTag,
       "--registry",
       "https://registry.npmjs.org",
       "--loglevel",

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -1,0 +1,59 @@
+const stableVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export const defaultCandidateTag = "ga-candidate";
+export const protectedPackageName = "react-native-nitro-geolocation";
+
+export const isStableVersion = (version) => stableVersionPattern.test(version);
+
+export const assertCandidateTag = (candidateTag) => {
+  if (
+    candidateTag.length === 0 ||
+    candidateTag !== candidateTag.trim() ||
+    /\s/.test(candidateTag)
+  ) {
+    throw new Error("The GA candidate tag must be a non-empty npm tag");
+  }
+  if (candidateTag === "latest") {
+    throw new Error("The GA candidate tag must never be latest");
+  }
+};
+
+export const resolvePublishTag = (
+  release,
+  candidateTag = process.env.NITRO_GEOLOCATION_GA_CANDIDATE_TAG ??
+    defaultCandidateTag
+) => {
+  assertCandidateTag(candidateTag);
+
+  if (
+    release.name === protectedPackageName &&
+    release.tag === "latest" &&
+    isStableVersion(release.version)
+  ) {
+    return candidateTag;
+  }
+
+  return release.tag;
+};
+
+export const assertPromotableVersion = (version) => {
+  if (!isStableVersion(version)) {
+    throw new Error(
+      `Only an exact stable x.y.z version can be promoted to latest: ${version}`
+    );
+  }
+};
+
+export const compareStableVersions = (left, right) => {
+  assertPromotableVersion(left);
+  assertPromotableVersion(right);
+
+  const leftParts = left.split(".").map((part) => BigInt(part));
+  const rightParts = right.split(".").map((part) => BigInt(part));
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] > rightParts[index]) return 1;
+    if (leftParts[index] < rightParts[index]) return -1;
+  }
+  return 0;
+};

--- a/tests/release-policy.test.mjs
+++ b/tests/release-policy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertCandidateTag,
+  assertPromotableVersion,
+  compareStableVersions,
+  isStableVersion,
+  resolvePublishTag
+} from "../scripts/release-policy.mjs";
+
+test("stable releases are staged instead of publishing to latest", () => {
+  assert.equal(
+    resolvePublishTag({
+      name: "react-native-nitro-geolocation",
+      version: "2.0.0",
+      tag: "latest"
+    }),
+    "ga-candidate"
+  );
+});
+
+test("prerelease tags are preserved", () => {
+  assert.equal(
+    resolvePublishTag({
+      name: "react-native-nitro-geolocation",
+      version: "2.0.0-rc.3",
+      tag: "rc"
+    }),
+    "rc"
+  );
+});
+
+test("unrelated workspace release tags are preserved", () => {
+  assert.equal(
+    resolvePublishTag({
+      name: "devtools-plugin",
+      version: "1.0.0",
+      tag: "latest"
+    }),
+    "latest"
+  );
+});
+
+test("candidate tag cannot bypass the latest guard", () => {
+  assert.throws(
+    () =>
+      resolvePublishTag(
+        {
+          name: "react-native-nitro-geolocation",
+          version: "2.0.0",
+          tag: "latest"
+        },
+        "latest"
+      ),
+    /must never be latest/
+  );
+  assert.throws(() => assertCandidateTag(""), /non-empty npm tag/);
+  assert.throws(() => assertCandidateTag("ga candidate"), /non-empty npm tag/);
+});
+
+test("only exact stable versions are promotable", () => {
+  assert.equal(isStableVersion("2.0.0"), true);
+  assert.equal(isStableVersion("02.0.0"), false);
+  assert.equal(isStableVersion("2.0.0-rc.3"), false);
+  assert.doesNotThrow(() => assertPromotableVersion("2.0.0"));
+  assert.throws(() => assertPromotableVersion("2.0.0-rc.3"), /Only an exact/);
+});
+
+test("stable version comparison prevents latest rollbacks", () => {
+  assert.equal(compareStableVersions("2.0.0", "1.99.99"), 1);
+  assert.equal(compareStableVersions("2.0.0", "2.0.0"), 0);
+  assert.equal(compareStableVersions("1.99.99", "2.0.0"), -1);
+});


### PR DESCRIPTION
## Summary

- publish stable geolocation releases to `ga-candidate` first, then require a protected manual promotion that validates the exact stable version, npm `gitHead`, GitHub release assets, portable checksums, platform slices, and rollback safety
- repair Android/iOS prebuilt output paths and checksums, avoid invalid Swift textual interfaces, and compile the example against the packaged XCFramework in CI
- add the release-policy guard/tests, documentation-version release gate, refreshed source-mode Pod lock, and more reliable permission-details startup waits

## Verification

- release policy: 6 tests
- format, lint, actionlint, shellcheck, docs version/route checks, diff checks
- TypeScript across 4 projects; JS unit suite: 24 files / 196 tests
- Android native unit tests and full AAR build for all 4 ABIs
- iOS lifecycle/watch/checksum contracts and full device/simulator XCFramework build
- portable checksum and archive-structure validation for both platforms
- clean Release simulator consumer build using the packaged XCFramework
- full Android native Maestro suite, including enabled/disabled services, stale readiness, permanently denied permission, provider watcher, and unified background events
- package build, dead-code checks, pack checks, and npm pack dry run

## Release safety

`latest` remains `1.4.3`; this PR does not publish or move any npm dist-tag. After merge, configure required reviewers on the `npm-latest` GitHub environment before using the promotion workflow.