### PR TITLE
fix: build docs before release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
         run: yarn install
 
       - name: Verify documentation matches the package release channel
-        run: yarn workspace docs check:versions
+        run: |
+          yarn workspace docs build
+          yarn workspace docs check:versions
 
       - name: Create release PR or publish packages to a safe candidate tag
         id: changesets


### PR DESCRIPTION
## Summary

- build the Rspress documentation before checking generated release routes
- keep the release-channel source and route gate intact on clean GitHub runners

## Root cause

The release workflow ran `docs check:versions` without first creating `docs/doc_build`. Local verification had passed only because that ignored build directory already existed.

## Verification

- moved the existing local `docs/doc_build` aside to reproduce a clean runner
- `yarn workspace docs build`
- `yarn workspace docs check:versions` (42 mirrored sources, 22 routes)
- `actionlint .github/workflows/*.yml`
- `yarn format:check`
- `yarn lint`

This PR does not publish packages or modify npm dist-tags.