### PR TITLE
fix: build Rozenite plugin before iOS release validation

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
 
+      - name: Build the Rozenite plugin used by the example
+        run: yarn workspace @react-native-nitro-geolocation/rozenite-plugin build
+
       - name: Install Ruby dependencies
         working-directory: examples/v0.81.1
         run: bundle install

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release:promote-latest": "node scripts/promote-latest.mjs",
     "release:sync-version": "node scripts/sync-release-version.mjs",
     "release:version": "yarn changeset version && yarn release:sync-version && yarn workspace docs build && yarn workspace docs check:versions",
-    "test:release": "node --test tests/release-policy.test.mjs tests/release-version-sync.test.mjs",
+    "test:release": "node --test tests/release-policy.test.mjs tests/release-version-sync.test.mjs tests/release-workflow.test.mjs",
     "test:release-policy": "node --test tests/release-policy.test.mjs",
     "test:unit": "yarn workspace react-native-nitro-geolocation test",
     "test:ios-location-lifecycle": "bash scripts/test-ios-location-lifecycle.sh",

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+test("the iOS release consumer builds its JS workspace dependency", async () => {
+  const workflow = await readFile(
+    path.join(root, ".github/workflows/prebuilt-binaries.yml"),
+    "utf8"
+  );
+  const installDependencies = workflow.indexOf(
+    "- name: Install JS dependencies"
+  );
+  const buildRozenite = workflow.indexOf(
+    "- name: Build the Rozenite plugin used by the example"
+  );
+  const verifyConsumer = workflow.indexOf(
+    "- name: Verify the example consumes the packaged XCFramework"
+  );
+
+  assert.notEqual(installDependencies, -1);
+  assert.notEqual(buildRozenite, -1);
+  assert.notEqual(verifyConsumer, -1);
+  assert.ok(installDependencies < buildRozenite);
+  assert.ok(buildRozenite < verifyConsumer);
+  assert.match(
+    workflow.slice(buildRozenite, verifyConsumer),
+    /yarn workspace @react-native-nitro-geolocation\/rozenite-plugin build/
+  );
+});


### PR DESCRIPTION
## Summary

- build the Rozenite plugin before validating the packaged XCFramework with the example app
- add a release workflow regression test that enforces the required build order
- include the new regression test in the release test suite

## Root cause

The XCFramework archive completed successfully, but the example consumer build failed during Metro bundling because packages/rozenite-devtools-plugin/dist/react-native.cjs had not been generated after the clean workspace install.

## Validation

- yarn workspace @react-native-nitro-geolocation/rozenite-plugin build
- yarn test:release
- iOS production Metro bundle
- yarn format:check
- yarn lint
- actionlint .github/workflows/prebuilt-binaries.yml

## Release recovery

After this is merged, manually dispatch Prebuilt Binaries for react-native-nitro-geolocation@2.0.0-rc.3 so the run uses the updated workflow definition.