### PR TITLE
fix: target repository for release asset upload

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -156,10 +156,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ref.outputs.tag }}
         run: |
-          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ref.outputs.tag }}
-        run: gh release upload "$TAG" build/prebuilt/* --clobber
+        run: gh release upload "$TAG" build/prebuilt/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -30,3 +30,24 @@ test("the iOS release consumer builds its JS workspace dependency", async () => 
     /yarn workspace @react-native-nitro-geolocation\/rozenite-plugin build/
   );
 });
+
+test("release asset publication targets the repository explicitly", async () => {
+  const workflow = await readFile(
+    path.join(root, ".github/workflows/prebuilt-binaries.yml"),
+    "utf8"
+  );
+  const publishJob = workflow.slice(workflow.indexOf("  publish:"));
+
+  assert.match(
+    publishJob,
+    /gh release view "\$TAG" --repo "\$GITHUB_REPOSITORY"/
+  );
+  assert.match(
+    publishJob,
+    /gh release create "\$TAG" --repo "\$GITHUB_REPOSITORY"/
+  );
+  assert.match(
+    publishJob,
+    /gh release upload "\$TAG" build\/prebuilt\/\* --repo "\$GITHUB_REPOSITORY" --clobber/
+  );
+});


### PR DESCRIPTION
## Summary

- pass the explicit GitHub repository to release view, create, and upload commands
- allow the artifact publication job to run without a checkout
- add a release workflow regression test for all three commands

## Verification

- yarn test:release
- yarn format:check
- yarn lint
- yarn changeset status --since=origin/main
- verified release view works from outside a Git worktree when the repository is explicit

## Follow-up

After merge, rerun the rc.4 prebuilt workflow or upload the preserved Actions artifacts so the six validated assets appear on the GitHub Release.