### PR TITLE
refactor: remove modern API terminology

### DIFF
--- a/.changeset/pre/calm-pandas-cancel.md
+++ b/.changeset/pre/calm-pandas-cancel.md
@@ -2,4 +2,4 @@
 "react-native-nitro-geolocation": minor
 ---
 
-Add request-scoped `AbortSignal` cancellation to the Modern API `getCurrentPosition()` call on Android, iOS, and web.
+Add request-scoped `AbortSignal` cancellation to `getCurrentPosition()` on Android, iOS, and web.

--- a/.changeset/pre/calm-wolves-explain.md
+++ b/.changeset/pre/calm-wolves-explain.md
@@ -2,4 +2,4 @@
 "react-native-nitro-geolocation": major
 ---
 
-Replace Modern API numeric location error codes with readable string discriminants while preserving numeric W3C codes under `/compat`.
+Replace API numeric location error codes with readable string discriminants while preserving numeric W3C codes under `/compat`.

--- a/.changeset/pre/clean-maps-retire.md
+++ b/.changeset/pre/clean-maps-retire.md
@@ -2,5 +2,5 @@
 "react-native-nitro-geolocation": major
 ---
 
-Remove the deprecated `ModernGeolocationConfiguration` alias. Use
-`GeolocationConfiguration` for the root modern API instead.
+Remove the deprecated duplicate configuration alias. Use
+`GeolocationConfiguration` instead.

--- a/.changeset/pre/curvy-watches-listen.md
+++ b/.changeset/pre/curvy-watches-listen.md
@@ -3,5 +3,5 @@
 ---
 
 Make Watch Manager v2 delivery semantics the default: native acquisition stays
-shared, while each Modern API watch independently enforces its own callback
+shared, while each watch independently enforces its own callback
 thresholds and cleanup lifecycle.

--- a/.changeset/pre/quiet-geckos-observe.md
+++ b/.changeset/pre/quiet-geckos-observe.md
@@ -2,6 +2,6 @@
 "react-native-nitro-geolocation": minor
 ---
 
-Add optional Modern response metadata for delivery source, age, horizontal
+Add optional response metadata for delivery source, age, horizontal
 accuracy quality, and stale reasons without changing location acceptance
 policy.

--- a/.changeset/pre/quiet-lions-watch.md
+++ b/.changeset/pre/quiet-lions-watch.md
@@ -2,4 +2,4 @@
 "react-native-nitro-geolocation": minor
 ---
 
-Add active Modern API watch snapshots and document native merge and cleanup semantics.
+Add active watch snapshots and document native merge and cleanup semantics.

--- a/.changeset/pre/silly-cats-focus.md
+++ b/.changeset/pre/silly-cats-focus.md
@@ -2,6 +2,6 @@
 "react-native-nitro-geolocation": major
 ---
 
-Remove `enableHighAccuracy` from the Modern API. Modern requests and Android
+Remove `enableHighAccuracy` from the API. Requests and Android
 settings now use explicit platform `accuracy` presets, while the `/compat`
 entry point retains `enableHighAccuracy` for drop-in compatibility.

--- a/.changeset/tidy-api-terminology.md
+++ b/.changeset/tidy-api-terminology.md
@@ -1,0 +1,8 @@
+---
+"react-native-nitro-geolocation": patch
+"@react-native-nitro-geolocation/rozenite-plugin": patch
+---
+
+Simplify API terminology across package documentation, migration tooling,
+examples, and internal implementation names while keeping the Compat API
+unchanged.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![NPM](https://img.shields.io/npm/v/react-native-nitro-geolocation)](https://www.npmjs.com/package/react-native-nitro-geolocation)
 
-**Nitro-powered geolocation for modern React Native apps**
+**Nitro-powered geolocation for React Native apps**
 
 A native iOS/Android geolocation module for React Native 0.75+ apps using the
 New Architecture and Nitro Modules. Start by replacing
 [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation)
-with `/compat`, then move to a typed Modern API when you are ready.
-The current release line adds web support for Modern and `/compat` foreground
-geolocation plus a native Background Location API for tracking, geofencing,
+with `/compat`, then move to the typed API when you are ready.
+The current release line adds foreground web support through both the package
+import and `/compat`, plus a native Background Location API for tracking, geofencing,
 storage recovery, Headless JS, and HTTP sync.
 
 - 🎯 **Simple functional API** — Direct function calls, no complex abstractions
@@ -39,10 +39,10 @@ Full documentation available at:
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import or `/compat` callback API |
+| Web support required | Use the package import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import and the `/compat`
+Web support is available for the package import and the `/compat`
 subpath. Browser builds resolve both entries to implementations backed by
 `navigator.geolocation` and do not load Nitro native bindings. Background
 location remains native-only.
@@ -54,7 +54,7 @@ location remains native-only.
 React Native Nitro Geolocation provides **three public API surfaces** to fit
 your needs:
 
-### 1. Modern API (Recommended)
+### 1. API (Recommended)
 
 **Simple functional API** with direct calls and a single hook for tracking:
 
@@ -82,13 +82,13 @@ if (status === "granted") {
 }
 ```
 
-Modern foreground responses include optional observational metadata for the
+Foreground responses include optional observational metadata for the
 delivery source, age, horizontal-accuracy quality band, and stale reason. This
 metadata never causes the library to reject a stale or low-accuracy position;
 applications can apply their own policy. The `/compat` response shape is
 unchanged.
 
-See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
+See the [API guide](https://react-native-nitro-geolocation.pages.dev/guide/api)
 for watches, geocoding, heading, cached reads, Android settings, and iOS
 accuracy authorization.
 
@@ -229,7 +229,7 @@ permission set from the Android background setup guide when using
 ### 4. DevTools Plugin
 
 Use the Rozenite DevTools plugin to mock locations during development with an
-interactive map. It works with the Modern API root import.
+interactive map. It works with the package import.
 
 ![DevTools Plugin Demo](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
 
@@ -264,7 +264,7 @@ Use the docs site for the detailed flows:
 
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/guide/quick-start) - install, set native permissions, and read your first location.
 - [Swift Package Manager](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager) - RN 0.87 compatibility and migration gate.
-- [Modern API](https://react-native-nitro-geolocation.pages.dev/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
+- [API](https://react-native-nitro-geolocation.pages.dev/guide/api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/guide/compat-api) - callback compatibility and web behavior.
 - [Background Location](https://react-native-nitro-geolocation.pages.dev/background/overview) - native background tracking, geofencing, storage recovery, Headless JS, HTTP sync, and delivery diagnosis.
 - [Migration Assistance](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance) - choose the community or service migration path.
@@ -276,7 +276,7 @@ Use the docs site for the detailed flows:
 - [Introduction](https://react-native-nitro-geolocation.pages.dev/guide/)
 - [Quick Start Guide](https://react-native-nitro-geolocation.pages.dev/guide/quick-start)
 - [Swift Package Manager Guide](https://react-native-nitro-geolocation.pages.dev/guide/swift-package-manager)
-- [Modern API Reference](https://react-native-nitro-geolocation.pages.dev/guide/modern-api)
+- [API Reference](https://react-native-nitro-geolocation.pages.dev/guide/api)
 - [Compat API Reference](https://react-native-nitro-geolocation.pages.dev/guide/compat-api)
 - [Migration Skills](https://react-native-nitro-geolocation.pages.dev/guide/migration-assistance)
 - [Community Migration](https://react-native-nitro-geolocation.pages.dev/guide/community-migration)

--- a/docs/docs/_nav.json
+++ b/docs/docs/_nav.json
@@ -25,8 +25,8 @@
     "text": "Foreground APIs",
     "items": [
       {
-        "text": "Modern API",
-        "link": "/guide/modern-api"
+        "text": "API",
+        "link": "/guide/api"
       },
       {
         "text": "Compatibility API",

--- a/docs/docs/background/overview.md
+++ b/docs/docs/background/overview.md
@@ -7,9 +7,8 @@ description: Decide when to use native background location, understand platform 
 
 Use the Background API when the product must record location while the app is
 not active, monitor geofences, recover events recorded while JavaScript was
-unavailable, or run native delivery behavior. For an active screen, use the
-Modern foreground `useWatchPosition` API instead; it has a simpler permission
-and lifecycle model.
+unavailable, or run native delivery behavior. For an active screen, use
+`useWatchPosition()` instead; it has a simpler permission and lifecycle model.
 
 ```ts
 import {

--- a/docs/docs/background/start-stop.md
+++ b/docs/docs/background/start-stop.md
@@ -61,7 +61,7 @@ export async function stopTracking() {
 }
 ```
 
-`android.locationProvider` uses the same public values as the root API:
+`android.locationProvider` uses the same public values as foreground configuration:
 `'auto'`, `'playServices'`, or `'android'`. Use `'android'` to force the
 platform `LocationManager`; the Nitro-only `'android_platform'` spelling is not
 part of the public API.

--- a/docs/docs/guide/_meta.json
+++ b/docs/docs/guide/_meta.json
@@ -26,7 +26,7 @@
   "v2-error-migration",
   "v2-unified-background-events",
   { "type": "section-header", "label": "Foreground location" },
-  { "type": "file", "name": "modern-api", "label": "Modern API reference" },
+  { "type": "file", "name": "api", "label": "API reference" },
   { "type": "file", "name": "compat-api", "label": "Compatibility API" },
   "watch-observability",
   "gps-offline-recipe",

--- a/docs/docs/guide/agent-context-map.md
+++ b/docs/docs/guide/agent-context-map.md
@@ -36,7 +36,7 @@ Avoid these until needed:
 
 | Area | Responsibility | Main files |
 | --- | --- | --- |
-| Modern foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
+| Foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
 | Community compatibility API | `@react-native-community/geolocation`-style callbacks and configuration. | `src/compat/`, `src/NitroGeolocationCompat.nitro.ts` |
 | Background API | Public background exports, listener narrowing, iOS lifecycle subscriptions, storage methods, geofence helpers, activity recognition helpers, HTTP sync helper, and task registration. | `src/background/index.ts`, `src/background/locationLifecycle.ts`, `src/background/task.ts`, `src/background/types.ts`, `src/background/NitroBackgroundLocation.nitro.ts` |
 | Web fallback | Browser geolocation behavior and web E2E support. | `src/web/`, `src/index.web.tsx`, `src/background/index.web.ts` |

--- a/docs/docs/guide/api.md
+++ b/docs/docs/guide/api.md
@@ -1,10 +1,10 @@
 ---
-title: Modern API
+title: API
 ---
 
 > Simple functional API with direct calls and minimal abstractions
 
-The Modern API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
+This API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
 
 ## Find an API by task
 
@@ -84,7 +84,7 @@ export type GeolocationConfiguration = {
 
 **Web behavior**:
 
-- Browser builds resolve the root import to a web entry that uses
+- Browser builds resolve the main package import to a web entry that uses
   `navigator.geolocation`.
 - `setConfiguration()` is a no-op on web. Browser permission prompts are driven
   by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
@@ -371,12 +371,12 @@ when the page becomes visible or active. Provider-specific optional fields stay
 - Use `getLastKnownPosition()` for a synchronous read of the module cache. Use
   `getLastKnownPositionAsync()` to query native/provider caches without starting
   a fresh request.
-- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
+- Errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
 
 ### Web Notes
 
-Modern API web support uses the browser standard `navigator.geolocation` API.
+Web support uses the browser standard `navigator.geolocation` API.
 It requires a secure context (`https://`, `localhost`, or another browser-trusted
 origin). Unsupported browsers or unavailable providers reject location requests
 with `POSITION_UNAVAILABLE`.
@@ -477,7 +477,7 @@ function LocationButton() {
   aborted prevents native or browser location work from starting. The promise
   rejects with the exact `signal.reason`; runtimes without a reason receive an
   `AbortError` fallback.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
@@ -596,7 +596,7 @@ interface GeolocationResponse {
 
 ### Mock and provider metadata
 
-`mocked` and `provider` are optional Modern API metadata fields added in v1.2.
+`mocked` and `provider` are optional response metadata fields added in v1.2.
 They describe the source of that particular position sample:
 
 - `mocked` reports whether the sample source identified it as simulated or
@@ -671,12 +671,12 @@ const token = watchPosition(
 unwatch(token);
 ```
 
-Starting in 2.0, Modern API errors use readable string discriminants. Keep
+Starting in 2.0, API errors use readable string discriminants. Keep
 comparisons against the `LocationErrorCodes` members shown below instead of
-copying their values. The expanded modern-only native setup/provider members
+copying their values. The additional native setup/provider members
 (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
 `SETTINGS_NOT_SATISFIED`) were originally added in v1.2; 2.0 keeps those member
-names while replacing every Modern numeric value with a string.
+names while replacing every previous numeric value with a string.
 
 The code is committed by the native layer before a `LocationError` is sent to
 JS. Both `watchPosition` error callbacks and public Promise rejections from
@@ -723,7 +723,7 @@ native/provider cache-only sources using `maximumAge`, `accuracy`,
 options are intentionally excluded, and the call never falls through to a
 fresh request. It resolves `undefined` when no cached location
 satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
-failures, such as permission denial, reject with the Modern `LocationError`
+failures, such as permission denial, reject with `LocationError`
 contract.
 
 ### Geocoding APIs
@@ -764,7 +764,7 @@ const addresses = await reverseGeocode({
 `reverseGeocode(coords)` rejects with `INTERNAL_ERROR` when latitude or
 longitude is non-finite or outside the valid coordinate range. Platform
 geocoder service failures reject with the same `{ code, message }`
-`LocationError` shape as the rest of the Modern API.
+`LocationError` shape as the rest of the API.
 
 ### Heading APIs
 
@@ -896,7 +896,7 @@ function LiveTracker() {
 **Options**:
 
 - `enabled?: boolean` - Start/stop watching (default: `false`)
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
 - `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
@@ -993,7 +993,7 @@ unwatch(token);
 
 ### getActiveWatches()
 
-Read the active Modern API position and heading subscriptions without starting
+Read the active position and heading subscriptions without starting
 or changing location services:
 
 ```tsx
@@ -1084,7 +1084,7 @@ function BackgroundTracker() {
 
 ## TypeScript Support
 
-All Modern API exports are fully typed:
+All exports are fully typed:
 
 ```typescript
 import type {
@@ -1109,8 +1109,8 @@ import type {
 `NullableDouble` is `number | null`. It is the shared scalar used by
 `GeolocationCoordinates.altitude`, `altitudeAccuracy`, `heading`, and `speed`.
 
-The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
-`GeolocationConfiguration` for the root Modern API.
+The deprecated 1.x configuration alias was removed in 2.0. Use
+`GeolocationConfiguration`.
 
 ### Type Inference
 
@@ -1130,7 +1130,7 @@ const status = await requestPermission();
 
 ## Comparison with Compat API
 
-| Feature          | Modern API                               | Compat API                               |
+| Feature          | Package import                   | Compat API                               |
 | ---------------- | ---------------------------------------- | ---------------------------------------- |
 | **Import**       | `react-native-nitro-geolocation`         | `react-native-nitro-geolocation/compat`  |
 | **Pattern**      | Functions + Hook                         | Callbacks                                |
@@ -1173,7 +1173,7 @@ function LocationTracker() {
 }
 ```
 
-**After (Modern API)**:
+**After**:
 
 ```tsx
 import { useWatchPosition } from 'react-native-nitro-geolocation';
@@ -1193,4 +1193,4 @@ function LocationTracker() {
 - No watch ID management
 - Automatic cleanup
 - Declarative enable/disable
-- Promise-based control flow and inferred Modern API results
+- Promise-based control flow and inferred results

--- a/docs/docs/guide/community-migration.md
+++ b/docs/docs/guide/community-migration.md
@@ -7,10 +7,10 @@ title: Community Migration
 Use this path for apps that import `@react-native-community/geolocation`,
 `navigator.geolocation`, or `react-native-nitro-geolocation/compat`.
 
-The safest migration is two-step: switch community imports to `/compat` first,
-verify the app still behaves the same, then move call sites to the Modern API
-where it improves ownership, permission timing, cache behavior, or Android
-settings handling.
+The safest migration is two-step: switch community imports to `/compat` first
+and verify the app still behaves the same. Then refactor selected call sites
+where direct functions or hooks improve ownership, permission timing, cache
+behavior, or Android settings handling.
 
 ## Agent Skill
 
@@ -30,8 +30,7 @@ The bundled bootstrap script performs the first safe mechanical pass:
 node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
 ```
 
-After the compat bootstrap, use the skill to refactor selected call sites to the
-Modern API.
+After the compat bootstrap, use the skill to refactor selected call sites.
 
 ## Migration Path
 
@@ -88,10 +87,10 @@ Geolocation.getCurrentPosition(
 );
 ```
 
-### Step 3: Modern API
+### Step 3: Direct functions and hooks
 
-After the `/compat` migration is stable, move individual call sites to the
-Modern API:
+After the `/compat` migration is stable, replace individual callback call sites
+with direct functions or hooks:
 
 ```tsx
 import {

--- a/docs/docs/guide/compat-api.md
+++ b/docs/docs/guide/compat-api.md
@@ -6,7 +6,7 @@ title: Compatibility API (/compat)
 > shapes and numeric error contract. It does not install a
 > `navigator.geolocation` global, and documented platform defaults or ignored
 > options can differ. Review the matrix below before calling it drop-in for your
-> application. New code should prefer the [Modern API](./modern-api.md).
+> application. New code should prefer the [API](./api.md).
 
 ## Import Path
 
@@ -47,7 +47,7 @@ import type {
 } from 'react-native-nitro-geolocation/compat';
 ```
 
-No type import from the Modern root is required. TypeScript can resolve this
+No type import from the main package is required. TypeScript can resolve this
 subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
 
 ## Compatibility Scope
@@ -55,13 +55,13 @@ subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
 This API is compatible with the core native
 `@react-native-community/geolocation` callback shape. It preserves the listed
 methods and numeric error contract for existing iOS and Android apps while the
-Modern API gives new code a Promise/function API. The matrix is the compatibility
+API gives new code a Promise/function API. The matrix is the compatibility
 boundary; options described as ignored/no-op and the missing global polyfill are
 intentional differences.
 
 | Community API | Nitro `/compat` | Notes |
 | --- | ---: | --- |
-| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
+| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the main package import. |
 | `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
 | `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
 | `watchPosition` | Supported | Returns a numeric watch id. |
@@ -70,7 +70,7 @@ intentional differences.
 | `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
 | Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
 
-The root Modern API and `/compat` subpath both support web by delegating to the
+The package import and `/compat` subpath both support web by delegating to the
 browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
 shape and legacy error constants, while `setRNConfiguration()` is a no-op and
 `requestAuthorization()` calls the success callback immediately because browsers
@@ -92,7 +92,7 @@ do not expose a standalone geolocation authorization prompt.
 
 Preserves the legacy configuration API. Use it for iOS authorization/background
 settings. Android provider selection and request behavior should be configured
-per call or through the Modern API root import.
+per call or through the main package import.
 
 ```ts
 Geolocation.setRNConfiguration(config: {
@@ -108,7 +108,7 @@ Supported options:
 - `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
 - `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
 - `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
-- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the main package import when you need Android fused/provider selection.
 
 ### `requestAuthorization()`
 

--- a/docs/docs/guide/devtools.md
+++ b/docs/docs/guide/devtools.md
@@ -7,7 +7,7 @@ Mock geolocation data in development with an interactive map interface using the
 This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) before proceeding.
 
 :::warning API Compatibility
-This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
+This DevTools plugin only works with the **package import** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
 :::
 
 ## Installation
@@ -202,7 +202,7 @@ The DevTools plugin should only be enabled in development builds. Rozenite DevTo
 :::
 
 :::tip
-The plugin only intercepts Modern API calls. Compatibility API calls keep their callback behavior.
+The plugin only intercepts calls made through the package import. Compatibility API calls keep their callback behavior.
 :::
 
 ## Troubleshooting

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -12,8 +12,8 @@ pick one path; you do not need to read every guide before starting.
 | --- | --- | --- |
 | Add foreground location to a new app | [Install and get a location](./quick-start.md) | A foreground-only screen that renders coordinates |
 | Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All seven 2.0 breaking changes reviewed and tested |
-| Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then an optional Modern API refactor |
-| Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | A direct Modern API migration |
+| Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then optionally adopt direct functions and hooks |
+| Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | Named imports from the package |
 | Use an Expo app | [Expo development builds](./expo-development-build.md) | A custom native build; Expo Go is not supported |
 | Track when the app is not active | [Background Location](../background/overview.md) | Native background tracking with platform-specific setup |
 | Evaluate the RC for release | [Release readiness](./release-readiness.md) | Tested-stack, RC-policy, and ship-checklist review |
@@ -25,7 +25,7 @@ The package has three intentionally separate entry points.
 
 | Surface | Import | Best for | Platform boundary |
 | --- | --- | --- | --- |
-| **Modern API** | `react-native-nitro-geolocation` | New foreground code, Promise APIs, typed readiness, React watches | Native and web foreground |
+| **Functions and hooks** | `react-native-nitro-geolocation` | New foreground code, Promise APIs, typed readiness, React watches | Native and web foreground |
 | **Compatibility API** | `react-native-nitro-geolocation/compat` | A controlled migration from the core community callback API | Native and web foreground |
 | **Background API** | `react-native-nitro-geolocation/background` | Tracking, geofencing, persistence, Headless JS, and native sync | Native only; web imports return unsupported results |
 
@@ -43,7 +43,7 @@ default, or platform-specific option behaves identically. Review the
 - CocoaPods is the recommended production iOS dependency path. React Native
   0.87.x SwiftPM-only projects have an experimental precompiled integration;
   use the exact compatibility matrix in the Swift Package Manager guide.
-- The Modern and Compatibility foreground APIs support browser builds through
+- Both foreground APIs support browser builds through
   `navigator.geolocation`. Background Location is native-only.
 - Android and iOS share public contracts but retain documented OS behavior and
   reliability limits.

--- a/docs/docs/guide/migration-assistance.md
+++ b/docs/docs/guide/migration-assistance.md
@@ -7,18 +7,18 @@ title: Migration overview
 Use this guide when migrating an existing app from
 `@react-native-community/geolocation`, `navigator.geolocation`,
 `react-native-geolocation-service`, or `react-native-nitro-geolocation/compat`
-toward the Modern API.
+toward direct functions and hooks.
 
 ## Choose a path
 
 For `@react-native-community/geolocation`, first make the mechanical
 dependency/import change and verify the app still builds. Then refactor the
-callback-based compatibility code to Modern API calls. See
+callback-based compatibility code to direct function calls. See
 [Community Migration](/guide/community-migration).
 
-For `react-native-geolocation-service`, migrate directly to named Modern API
-imports. Its Android fused-provider and settings-dialog options map to Modern
-APIs such as `setConfiguration({ locationProvider: 'playServices' })` and
+For `react-native-geolocation-service`, migrate directly to named imports from
+the package. Its Android fused-provider and settings-dialog options map to APIs
+such as `setConfiguration({ locationProvider: 'playServices' })` and
 `requestLocationSettings()`. See [Service Migration](/guide/service-migration).
 
 The final target state should avoid runtime imports from
@@ -42,7 +42,7 @@ Install it with the Vercel Labs `skills` CLI:
 npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
 ```
 
-For `react-native-geolocation-service`, migrate directly to the Modern API with:
+For `react-native-geolocation-service`, migrate directly to the package import with:
 
 [`service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
 
@@ -59,18 +59,19 @@ The community migration skill uses a two-phase workflow:
    `@react-native-community/geolocation` import sources to
    `react-native-nitro-geolocation/compat`, removes the legacy package, and
    prints validation commands for scripts that exist in the target app.
-2. Refactor `/compat` call sites to Modern API best practices using explicit
+2. Refactor `/compat` call sites to recommended API patterns using explicit
    criteria for permission timing, React lifecycle ownership, watch cleanup,
    cache-vs-fresh reads, accuracy, and Android provider/settings handling.
 
-The service migration skill skips `/compat` and targets the Modern API directly.
+The service migration skill skips `/compat` and targets the package import
+directly.
 It preserves service-specific behavior such as `accuracy`, fused-provider
 intent, Android settings-dialog handling, `mocked`/`provider` metadata, and
 provider-related error codes.
 
-## Modern API Targets
+## Migration Targets
 
-| Legacy or compat usage | Modern API target |
+| Legacy or compat usage | Direct target |
 | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
 | latest position already observed by this JS module | `getLastKnownPosition()` |

--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -175,7 +175,7 @@ export function FirstLocation() {
 
 ## Continue only for your use case
 
-- [Modern API reference](./modern-api.md) for readiness, cached reads, watches,
+- [API reference](./api.md) for readiness, cached reads, watches,
   geocoding, and heading.
 - [Community migration](./community-migration.md) if this replaces the community
   callback package.

--- a/docs/docs/guide/react-native-directory.md
+++ b/docs/docs/guide/react-native-directory.md
@@ -13,7 +13,7 @@ Native Directory.
 | --- | --- |
 | iOS | Supported |
 | Android | Supported |
-| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
+| Web | Package import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
 | New Architecture | Required target; implemented through Nitro Modules |
 | Expo Go | Not supported |
 | Expo development builds | Supported with native setup |
@@ -24,19 +24,19 @@ Native Directory.
 Recommended short description:
 
 ```txt
-Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed API, or add web foreground support and native background tracking/geofencing.
 ```
 
 Recommended caveat:
 
 ```txt
-Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and web support through the package import or `/compat` using navigator.geolocation. Expo Go and browser background location are not supported.
 ```
 
 ## Pre-Submission Checklist
 
 - README explains when to use the package and when not to use it.
-- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
+- README includes compat coverage, package-import and `/compat` web behavior, and Expo limitations.
 - npm package has discoverability keywords.
 - Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
 - Docs include Expo development build guidance.

--- a/docs/docs/guide/release-readiness.md
+++ b/docs/docs/guide/release-readiness.md
@@ -45,7 +45,7 @@ combination is continuously exercised.
 | iOS dependency manager | CocoaPods; experimental SwiftPM on RN 0.87.x with Nitro Modules 0.37.1 | SwiftPM uses the matching precompiled release artifact and has no source fallback |
 | Android build | Consumer app's supported Android toolchain | Native permissions and foreground-service rules vary by OS level |
 | Native foreground | iOS and Android | Test permission and provider behavior on target devices |
-| Web foreground | Modern root and `/compat` through `navigator.geolocation` | Secure-context and browser permission rules apply |
+| Web foreground | package import and `/compat` through `navigator.geolocation` | Secure-context and browser permission rules apply |
 | Background | iOS and Android through `/background` | Native-only and best effort under OS lifecycle policy |
 | Prebuilts | Matching release assets when compatible | Android requires matching React Native and Nitro major/minor versions; source fallback otherwise |
 

--- a/docs/docs/guide/service-migration.md
+++ b/docs/docs/guide/service-migration.md
@@ -4,8 +4,8 @@ title: Service Migration
 
 # Service Migration
 
-Apps that use `react-native-geolocation-service` should migrate directly to the
-Modern API:
+Apps that use `react-native-geolocation-service` should migrate directly to
+named imports from the package:
 
 ```ts
 import {
@@ -24,7 +24,7 @@ import {
 
 Do not migrate through `react-native-nitro-geolocation/compat`. The service
 package exposes Android fused-provider and settings-dialog behavior that maps
-more closely to Nitro Geolocation's Modern Android provider/settings API.
+more closely to Nitro Geolocation's Android provider/settings API.
 
 ## Agent Skill
 
@@ -45,7 +45,7 @@ node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inv
 node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
 ```
 
-If the app startup file is obvious, the script can also add the Modern startup
+If the app startup file is obvious, the script can also add the startup
 configuration:
 
 ```bash
@@ -74,7 +74,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 
 ## API Mapping
 
-| `react-native-geolocation-service` | Nitro Modern API |
+| `react-native-geolocation-service` | Nitro Geolocation |
 | --- | --- |
 | `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` |
 | `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` |
@@ -90,7 +90,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 | `position.provider` | `GeolocationResponse.provider` |
 | numeric service error code | readable 2.x `LocationErrorCode` discriminant |
 
-`forceRequestLocation` has no direct Modern option. Preserve that fallback
+`forceRequestLocation` has no direct equivalent option. Preserve that fallback
 behavior manually only after reviewing the intended UX.
 
 ## One-Shot Location
@@ -131,11 +131,11 @@ Do not add `requestLocationSettings()` when the legacy call explicitly used
 `showLocationDialog: false`.
 
 When `showLocationDialog` was omitted, review the flow manually. The service
-package default was `true`; Nitro Modern API requires an explicit settings flow.
+package default was `true`; Nitro Geolocation requires an explicit settings flow.
 
 ## Watches
 
-Use the low-level Modern watch API as the first safe target:
+Use the low-level watch API as the first safe target:
 
 ```diff
 - const watchId = Geolocation.watchPosition(onPosition, onError, {
@@ -162,8 +162,8 @@ debouncing.
 
 ## Permission Differences
 
-Legacy `requestAuthorization()` can return `disabled`. Modern
-`requestPermission()` returns permission status only:
+Legacy `requestAuthorization()` can return `disabled`. The
+`requestPermission()` function returns permission status only:
 
 ```ts
 const status = await requestPermission();
@@ -186,7 +186,7 @@ const status = await requestPermission();
 
 Review call sites that omit options:
 
-| Option | Service default | Nitro Modern default |
+| Option | Service default | Nitro default |
 | --- | --- | --- |
 | `getCurrentPosition.timeout` | `Infinity` | `600000` |
 | `getCurrentPosition.maximumAge` | `Infinity` | `0` |

--- a/docs/docs/guide/troubleshooting.md
+++ b/docs/docs/guide/troubleshooting.md
@@ -58,7 +58,7 @@ guidance/remediation fields in product UI rather than inferring prompt behavior
 from an OS name alone.
 
 Then reproduce one explicit location request and record the structured error
-`code` and `message`. Modern 2.0 codes are strings; `/compat` codes remain
+`code` and `message`. 2.0 API codes are strings; `/compat` codes remain
 numeric. Remove exact coordinates from logs before sharing them.
 
 ## 3. Separate foreground and background failures
@@ -99,7 +99,7 @@ Include:
 - exact Geolocation, Nitro Modules, React Native, React, and Expo versions;
 - iOS/Android/browser version, device or simulator, and CPU architecture;
 - CocoaPods/prebuilt/source-build path and whether a clean native rebuild ran;
-- minimal root, `/compat`, or `/background` import and options;
+- minimal main package, `/compat`, or `/background` import and options;
 - doctor JSON plus permission/readiness or background diagnosis;
 - expected result, actual result, and smallest reproduction steps;
 - whether the problem happens in Debug, Release, and a physical device;

--- a/docs/docs/guide/upgrade-from-v1.md
+++ b/docs/docs/guide/upgrade-from-v1.md
@@ -13,7 +13,7 @@ a branch and keep the currently deployed 1.x version available for rollback.
 
 1. Record the exact working React Native, Nitro Modules, and Geolocation
    versions from the current lockfile.
-2. Inventory root, `/compat`, and `/background` imports separately.
+2. Inventory main package, `/compat`, and `/background` imports separately.
 3. Create or keep tests for permission denial, a fresh fix, cached reads,
    watches, Android settings resolution, and background event recovery used by
    your product.
@@ -33,17 +33,17 @@ lockfile and native dependency state before attempting API migrations.
 
 | Change | Who is affected | Required action | Verification |
 | --- | --- | --- | --- |
-| String Modern error codes | Root API callers comparing or persisting numeric codes | Compare against `LocationErrorCodes`; migrate persisted values | Denial, timeout, unavailable-provider tests |
-| Removed configuration alias | Type imports of `ModernGeolocationConfiguration` | Use `GeolocationConfiguration` | Typecheck |
-| Watch Manager v2 semantics | Apps with multiple Modern watches or implicit cleanup assumptions | Verify per-watch thresholds and ownership | Two-watch and unmount/stop tests |
+| String error codes | Main package callers comparing or persisting numeric codes | Compare against `LocationErrorCodes`; migrate persisted values | Denial, timeout, unavailable-provider tests |
+| Removed configuration alias | Type imports of the deprecated 1.x configuration alias | Use `GeolocationConfiguration` | Typecheck |
+| Watch Manager v2 semantics | Apps with multiple watches or implicit cleanup assumptions | Verify per-watch thresholds and ownership | Two-watch and unmount/stop tests |
 | Split last-known reads | Callers awaiting or passing options to `getLastKnownPosition()` | Choose synchronous module cache or async platform cache | Empty, fresh, and stale cache tests |
-| Removed Modern `enableHighAccuracy` | Root current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
+| Removed `enableHighAccuracy` | Foreground current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
 | Unified background events | Background provider/lifecycle listeners and persisted event consumers | Handle the unified discriminated stream | Live plus stored-event tests |
 | Deterministic settings result | Code expecting cancel/unavailable to reject | Branch on `result.outcome` | Satisfied, cancelled, unavailable tests |
 
-## 1. Use string Modern error codes
+## 1. Use string error codes
 
-The Modern root API no longer uses numeric codes. `/compat` intentionally keeps
+The package import no longer uses numeric codes. `/compat` intentionally keeps
 the numeric W3C contract.
 
 ```ts
@@ -52,7 +52,7 @@ if (error.code === 1) {
   showPermissionHelp();
 }
 
-// 2.0 Modern API
+// 2.0 API
 import { LocationErrorCodes } from 'react-native-nitro-geolocation';
 
 if (error.code === LocationErrorCodes.PERMISSION_DENIED) {
@@ -71,19 +71,16 @@ numeric codes.
 ## 2. Replace the removed configuration alias
 
 ```ts
-// 1.x
-import type { ModernGeolocationConfiguration } from 'react-native-nitro-geolocation';
-
 // 2.0
 import type { GeolocationConfiguration } from 'react-native-nitro-geolocation';
 ```
 
-This is a type-only rename. **Verify:** search for the old name and run the app's
-full TypeScript check.
+Delete imports of the deprecated 1.x configuration alias and use the type above.
+**Verify:** run the app's full TypeScript check.
 
 ## 3. Verify Watch Manager v2 behavior
 
-Native acquisition can be shared, but each Modern watch now enforces its own
+Native acquisition can be shared, but each watch now enforces its own
 callback thresholds and cleanup lifecycle. Do not assume that stopping one watch
 stops another, or that one watch's distance/interval policy controls all
 subscribers.
@@ -113,13 +110,13 @@ Neither 2.0 function starts a fresh location request. Use
 observing a current/watch position populates the module cache; an expired
 platform cache is filtered by `maximumAge`.
 
-## 5. Replace Modern `enableHighAccuracy`
+## 5. Replace `enableHighAccuracy`
 
 ```ts
-// 1.x Modern API
+// 1.x API
 await getCurrentPosition({ enableHighAccuracy: true });
 
-// 2.0 Modern API
+// 2.0 API
 await getCurrentPosition({
   accuracy: { android: 'high', ios: 'best' },
 });
@@ -176,8 +173,8 @@ actual request failure.
 
 Before merging the upgrade:
 
-- [ ] No `ModernGeolocationConfiguration` root type imports remain.
-- [ ] No Modern root options still use `enableHighAccuracy`.
+- [ ] No imports of the deprecated 1.x configuration alias remain.
+- [ ] No foreground options still use `enableHighAccuracy`.
 - [ ] Numeric error comparisons exist only under `/compat` or in explicit legacy
       data migration code.
 - [ ] Every last-known call deliberately chooses module cache or platform cache.

--- a/docs/docs/guide/v2-error-migration.md
+++ b/docs/docs/guide/v2-error-migration.md
@@ -4,9 +4,9 @@ title: 2.0 Error Migration
 
 # 2.0 Error Migration
 
-React Native Nitro Geolocation 2.0 replaces numeric error codes in the Modern
-API with readable string discriminants. This is a Modern API change only. The
-`/compat` entry point keeps the W3C-style numeric `1`, `2`, and `3` contract.
+React Native Nitro Geolocation 2.0 replaces the package's numeric error codes
+with readable string discriminants. This change does not affect `/compat`, which
+keeps the W3C-style numeric `1`, `2`, and `3` contract.
 
 ## Update comparisons
 
@@ -73,7 +73,7 @@ function describeLocationFailure(error: unknown): string {
 
 ## Migrate persisted errors
 
-Do not reinterpret an old number as a new string. If an app stores Modern API
+Do not reinterpret an old number as a new string. If an app stores API
 errors, translate known 1.x values once with the table above, write the 2.x
 string, and discard unknown values. The native Android background status store
 does this migration automatically for errors recorded by this package.
@@ -96,5 +96,5 @@ Geolocation.getCurrentPosition(
 );
 ```
 
-Keeping the two contracts separate prevents a Modern-only provider error from
-leaking into the browser-compatible surface.
+Keeping the two contracts separate prevents the additional provider error codes
+from leaking into the browser-compatible surface.

--- a/docs/docs/guide/watch-observability.md
+++ b/docs/docs/guide/watch-observability.md
@@ -1,6 +1,6 @@
 # Watch observability
 
-Use `getActiveWatches()` to inspect the Modern API watches that currently own
+Use `getActiveWatches()` to inspect the watches that currently own
 native position or heading subscriptions:
 
 ```ts
@@ -34,7 +34,7 @@ changes. Entries are sorted by token and contain:
 - `token`: the value accepted by `unwatch()`.
 - `kind`: `position` for `watchPosition()` or `heading` for `watchHeading()`.
 
-The snapshot covers the Modern API root import. It does not include Compat API
+The snapshot covers the main package import. It does not include Compat API
 watches, one-shot position or heading requests, or Background Location.
 Android watches that finish because of `maxUpdates` disappear from the next
 snapshot automatically. Web snapshots include active browser position watches;
@@ -44,7 +44,7 @@ unsupported web heading requests are not reported as active.
 
 - `unwatch(token)` removes a matching position or heading watch. Repeating it,
   or passing an unknown token, is safe and has no effect.
-- `stopObserving()` removes every Modern API position and heading watch,
+- `stopObserving()` removes every position and heading watch,
   including development-tool and browser watches. It does not cancel one-shot
   position requests or Background Location. On iOS it also leaves one-shot
   heading requests running. On Android, the current native heading manager

--- a/docs/docs/guide/why-nitro-module.md
+++ b/docs/docs/guide/why-nitro-module.md
@@ -40,7 +40,7 @@ User callback executed
 - Multiple listeners share one event stream
 - Requires JSON serialization on every update
 
-### Modern API: Direct Callback Architecture (`React Native Nitro Geolocation`)
+### Direct Callback Architecture (`React Native Nitro Geolocation`)
 
 ```
 JavaScript Layer
@@ -69,7 +69,7 @@ React Native Nitro Geolocation now provides a React-friendly layer on top of the
 User Code (React Components)
   ↓ useWatchPosition({ enabled: true })
   ↓ Declarative, auto-cleanup
-Modern API Layer (direct functions + hooks)
+Functions and hooks
   ↓ watchPosition(callback)
 JSI Layer (Nitro Modules)
   ↓ Direct callbacks, no Bridge
@@ -87,7 +87,7 @@ Device GPS/Network
 
 **Architecture Layers**:
 1. **Presentation** (Hooks): `useWatchPosition`
-2. **Modern API** (Functions): `getCurrentPosition`, `watchPosition`, `unwatch`
+2. **Functions and hooks**: `getCurrentPosition`, `watchPosition`, `unwatch`
 3. **JSI Bridge** (Nitro): Direct native communication
 4. **Native** (Platform): iOS/Android location APIs
 
@@ -120,10 +120,10 @@ Nitro Modules use **Nitrogen** code generation to create JSI bindings:
 `React Native Nitro Geolocation` transforms the geolocation API at multiple levels:
 
 1. **Low-level**: Bridge-based events → JSI direct callbacks (Nitro Modules)
-2. **High-level**: Imperative callbacks → Declarative hooks (Modern API)
+2. **High-level**: Imperative callbacks → Declarative hooks
 
 This provides:
 - **Performance**: Native-level speed via JSI
 - **Developer Experience**: React-friendly hooks with TanStack Query patterns
-- **Flexibility**: Choose Modern API (hooks) or Compat API (callbacks)
+- **Flexibility**: Choose direct functions and hooks or Compat callbacks
 - **Compatibility**: Preserves the core callback methods and numeric errors via `/compat`, with documented boundaries

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,7 +20,7 @@ features:
   - title: Start a new integration
     details: 'Check the support boundary, add foreground-only permissions, and render your first coordinates. <a href="/v2/guide/quick-start.html">Install and get a location →</a>'
   - title: Replace community geolocation
-    details: 'Move foreground imports to the /compat surface first, verify the app, then adopt the Modern API at your pace. <a href="/v2/guide/community-migration.html">Open community migration →</a>'
+    details: 'Move foreground imports to the /compat surface first, verify the app, then adopt direct functions and hooks at your pace. <a href="/v2/guide/community-migration.html">Open community migration →</a>'
   - title: Upgrade from 1.x
     details: 'Review every 2.0 breaking change, apply the migration in gates, and keep a tested rollback path. <a href="/v2/guide/upgrade-from-v1.html">Open the upgrade checklist →</a>'
   - title: Add background location

--- a/docs/docs/v1/guide/_meta.json
+++ b/docs/docs/v1/guide/_meta.json
@@ -6,7 +6,7 @@
   "service-migration",
   "expo-development-build",
   "react-native-directory",
-  "modern-api",
+  "api",
   "compat-api",
   "agent-context-map",
   "devtools",

--- a/docs/docs/v1/guide/agent-context-map.md
+++ b/docs/docs/v1/guide/agent-context-map.md
@@ -34,7 +34,7 @@ Avoid these until needed:
 
 | Area | Responsibility | Main files |
 | --- | --- | --- |
-| Modern foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
+| Foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
 | Community compatibility API | `@react-native-community/geolocation`-style callbacks and configuration. | `src/compat/`, `src/NitroGeolocationCompat.nitro.ts` |
 | Background API | Public background exports, listener narrowing, storage methods, geofence helpers, activity recognition helpers, HTTP sync helper, and task registration. | `src/background/index.ts`, `src/background/task.ts`, `src/background/types.ts`, `src/background/NitroBackgroundLocation.nitro.ts` |
 | Web fallback | Browser geolocation behavior and web E2E support. | `src/web/`, `src/index.web.tsx`, `src/background/index.web.ts` |

--- a/docs/docs/v1/guide/api.md
+++ b/docs/docs/v1/guide/api.md
@@ -1,10 +1,10 @@
 ---
-title: Modern API (Recommended)
+title: API (Recommended)
 ---
 
 > Simple functional API with direct calls and minimal abstractions
 
-The Modern API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
+This API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
 
 ## Design Philosophy
 
@@ -59,11 +59,6 @@ export type GeolocationConfiguration = {
   locationProvider?: 'playServices' | 'android' | 'auto';
 };
 
-/**
- * @deprecated Use `GeolocationConfiguration` instead.
- * This alias is kept only for backward compatibility.
- */
-export type ModernGeolocationConfiguration = GeolocationConfiguration;
 ```
 
 **When to call**:
@@ -73,7 +68,7 @@ export type ModernGeolocationConfiguration = GeolocationConfiguration;
 
 **Web behavior**:
 
-- Browser builds resolve the root import to a web entry that uses
+- Browser builds resolve the main package import to a web entry that uses
   `navigator.geolocation`.
 - `setConfiguration()` is a no-op on web. Browser permission prompts are driven
   by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
@@ -231,12 +226,12 @@ current Core Location service status and does not show a settings dialog.
   Android `granularity`.
 - Use `getLastKnownPosition()` when you want an explicit cached read without
   starting a fresh native request.
-- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
+- Errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
 
 ### Web Notes
 
-Modern API web support uses the browser standard `navigator.geolocation` API.
+Web support uses the browser standard `navigator.geolocation` API.
 It requires a secure context (`https://`, `localhost`, or another browser-trusted
 origin). Unsupported browsers or unavailable providers reject location requests
 with `POSITION_UNAVAILABLE`.
@@ -327,7 +322,7 @@ function LocationButton() {
 
 - `timeout?: number` - Request timeout in ms (default: 600000 / 10 min)
 - `maximumAge?: number` - Max age of cached location in ms (default: 0)
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the API in v2.
 - `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`. When a preset is provided for the current platform, it takes precedence over `enableHighAccuracy`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
@@ -405,7 +400,7 @@ interface GeolocationResponse {
 }
 ```
 
-`mocked` and `provider` are optional metadata fields added to the Modern API response in v1.2. The `/compat` API keeps the `@react-native-community/geolocation` response shape and does not include these fields.
+`mocked` and `provider` are optional metadata fields added to the API response in v1.2. The `/compat` API keeps the `@react-native-community/geolocation` response shape and does not include these fields.
 
 **Error Handling**:
 
@@ -431,7 +426,7 @@ const token = watchPosition(
 unwatch(token);
 ```
 
-Modern API errors use the following codes. The expanded modern-only native
+API errors use the following codes. The expanded native
 setup/provider codes (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
 `SETTINGS_NOT_SATISFIED`) were added in v1.2; codes 1-3 remain aligned with the
 legacy browser-style contract.
@@ -514,7 +509,7 @@ const addresses = await reverseGeocode({
 `reverseGeocode(coords)` rejects with `INTERNAL_ERROR` when latitude or
 longitude is non-finite or outside the valid coordinate range. Platform
 geocoder service failures reject with the same `{ code, message }`
-`LocationError` shape as the rest of the Modern API.
+`LocationError` shape as the rest of the API.
 
 ### Heading APIs
 
@@ -646,7 +641,7 @@ function LiveTracker() {
 **Options**:
 
 - `enabled?: boolean` - Start/stop watching (default: `false`)
-- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the Modern API in v2.
+- `enableHighAccuracy?: boolean` - Deprecated since `v1.2`. Kept for v1 compatibility only; prefer `accuracy`. It is expected to be removed from the API in v2.
 - `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset, available since `v1.2`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
 - `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
@@ -820,7 +815,7 @@ function BackgroundTracker() {
 
 ## TypeScript Support
 
-All Modern API exports are fully typed:
+All exports are fully typed:
 
 ```typescript
 import type {
@@ -835,7 +830,7 @@ import type {
 } from 'react-native-nitro-geolocation';
 ```
 
-`ModernGeolocationConfiguration` is still exported as a deprecated compatibility alias.
+A deprecated configuration alias is also exported for backward compatibility.
 
 ### Type Inference
 
@@ -855,7 +850,7 @@ const status = await requestPermission();
 
 ## Comparison with Compat API
 
-| Feature          | Modern API                               | Compat API                               |
+| Feature          | Package import                   | Compat API                               |
 | ---------------- | ---------------------------------------- | ---------------------------------------- |
 | **Import**       | `react-native-nitro-geolocation`         | `react-native-nitro-geolocation/compat`  |
 | **Pattern**      | Functions + Hook                         | Callbacks                                |
@@ -898,7 +893,7 @@ function LocationTracker() {
 }
 ```
 
-**After (Modern API)**:
+**After**:
 
 ```tsx
 import { useWatchPosition } from 'react-native-nitro-geolocation';

--- a/docs/docs/v1/guide/community-migration.md
+++ b/docs/docs/v1/guide/community-migration.md
@@ -7,10 +7,10 @@ title: Community Migration
 Use this path for apps that import `@react-native-community/geolocation`,
 `navigator.geolocation`, or `react-native-nitro-geolocation/compat`.
 
-The safest migration is two-step: switch community imports to `/compat` first,
-verify the app still behaves the same, then move call sites to the Modern API
-where it improves ownership, permission timing, cache behavior, or Android
-settings handling.
+The safest migration is two-step: switch community imports to `/compat` first
+and verify the app still behaves the same. Then refactor selected call sites
+where direct functions or hooks improve ownership, permission timing, cache
+behavior, or Android settings handling.
 
 ## Agent Skill
 
@@ -30,8 +30,7 @@ The bundled bootstrap script performs the first safe mechanical pass:
 node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
 ```
 
-After the compat bootstrap, use the skill to refactor selected call sites to the
-Modern API.
+After the compat bootstrap, use the skill to refactor selected call sites.
 
 ## Migration Path
 
@@ -88,10 +87,10 @@ Geolocation.getCurrentPosition(
 );
 ```
 
-### Step 3: Modern API
+### Step 3: Direct functions and hooks
 
-After the `/compat` migration is stable, move individual call sites to the
-Modern API:
+After the `/compat` migration is stable, replace individual callback call sites
+with direct functions or hooks:
 
 ```tsx
 import {

--- a/docs/docs/v1/guide/compat-api.md
+++ b/docs/docs/v1/guide/compat-api.md
@@ -3,7 +3,7 @@ title: Compat API (Compatibility)
 ---
 
 > ⚠️ **This is the compat callback-based API for compatibility with @react-native-community/geolocation.**
-> For new projects, we recommend using the [Modern API](./modern-api.md) with functions and the `useWatchPosition` hook.
+> For new projects, we recommend using the [API](./api.md) with functions and the `useWatchPosition` hook.
 
 ## Import Path
 
@@ -23,12 +23,12 @@ import {
 
 This API is drop-in compatible with the core native
 `@react-native-community/geolocation` surface. It preserves the callback-based
-shape for existing iOS and Android apps while the Modern API gives new code a
+shape for existing iOS and Android apps while the package import gives new code a
 Promise/function API.
 
 | Community API | Nitro `/compat` | Notes |
 | --- | ---: | --- |
-| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
+| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the main package import. |
 | `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
 | `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
 | `watchPosition` | Supported | Returns a numeric watch id. |
@@ -37,7 +37,7 @@ Promise/function API.
 | `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
 | Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
 
-The root Modern API and `/compat` subpath both support web by delegating to the
+The package import and `/compat` subpath both support web by delegating to the
 browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
 shape and legacy error constants, while `setRNConfiguration()` is a no-op and
 `requestAuthorization()` calls the success callback immediately because browsers
@@ -58,7 +58,7 @@ do not expose a standalone geolocation authorization prompt.
 
 Preserves the legacy configuration API. Use it for iOS authorization/background
 settings. Android provider selection and request behavior should be configured
-per call or through the Modern API root import.
+per call or through the main package import.
 
 ```ts
 Geolocation.setRNConfiguration(config: {
@@ -74,7 +74,7 @@ Supported options:
 - `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
 - `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
 - `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
-- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the main package import when you need Android fused/provider selection.
 
 ### `requestAuthorization()`
 

--- a/docs/docs/v1/guide/devtools.md
+++ b/docs/docs/v1/guide/devtools.md
@@ -7,7 +7,7 @@ Mock geolocation data in development with an interactive map interface using the
 This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) before proceeding.
 
 :::warning API Compatibility
-This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
+This DevTools plugin only works with the **package import** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
 :::
 
 ## Installation
@@ -202,7 +202,7 @@ The DevTools plugin should only be enabled in development builds. Rozenite DevTo
 :::
 
 :::tip
-The plugin only intercepts Modern API calls. Compat API calls keep the drop-in replacement behavior.
+The plugin only intercepts calls made through the package import. Compat API calls keep the drop-in replacement behavior.
 :::
 
 ## Troubleshooting

--- a/docs/docs/v1/guide/index.md
+++ b/docs/docs/v1/guide/index.md
@@ -8,11 +8,11 @@ This project — **React Native Nitro Geolocation** — is a native iOS/Android
 module designed for the **Nitro Module** system. It is best positioned as a
 React Native 0.75+ / New Architecture path for replacing the core native
 `@react-native-community/geolocation` API with `/compat`, then gradually moving
-to a typed Modern API.
+to a typed API.
 
-The current release line adds a clearer three-surface story: Modern and
-`/compat` foreground geolocation on web, plus a native Background Location API
-for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
+The current release line has three surfaces: the package import and `/compat`
+for foreground geolocation on web, plus a native Background Location API for
+tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
 
 ## When should I use this?
 
@@ -23,10 +23,10 @@ for tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import or `/compat` callback API |
+| Web support required | Use the main package import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import and the `/compat`
+Web support is available for the main package import and the `/compat`
 subpath. Browser builds resolve both entries to implementations backed by
 `navigator.geolocation` and do not load Nitro native bindings. Background
 location remains native-only.
@@ -34,7 +34,7 @@ location remains native-only.
 React Native Nitro Geolocation provides **three public API surfaces** to fit
 your needs:
 
-## 1. Modern API (Recommended)
+## 1. Functions and hooks (Recommended)
 
 **Simple functional API** with direct calls and minimal abstractions.
 
@@ -129,9 +129,9 @@ web bundles can still import shared code safely. Start with the
 [Background Location guide](/background/overview) when you need full background
 tracking, geofencing, storage recovery, or native sync.
 
-## Why Modern API?
+## Why functions and hooks?
 
-The Modern API brings simplicity and React hook patterns to geolocation:
+The API brings simplicity and React hook patterns to geolocation:
 
 ### Declarative vs Imperative
 
@@ -201,7 +201,7 @@ We created a geolocation API that:
 
 Instead of complex provider patterns or class-based APIs, we provide:
 
-| Concept | Modern API |
+| Concept | API |
 |---------|------------|
 | **Configuration** | `setConfiguration()` |
 | **Permission** | `checkPermission()`, `requestPermission()` |
@@ -223,27 +223,29 @@ Instead of complex provider patterns or class-based APIs, we provide:
 
 The package has three clear surfaces:
 
-- **Modern API** - typed foreground geolocation, geocoding, watching, cached reads, and Android settings helpers.
+- **Functions and hooks** - typed foreground geolocation, geocoding, watching, cached reads, and Android settings helpers.
 - **Compat API** - a `/compat` path for migrating the core `@react-native-community/geolocation` surface.
 - **Background API** - native tracking, geofencing, storage recovery, Headless JS, and HTTP sync.
 
-Modern and `/compat` foreground APIs also support web through the browser
-`navigator.geolocation` API.
+The package import and `/compat` also support foreground geolocation on web
+through the browser `navigator.geolocation` API.
 
 The benchmark measures cached location reads and the JS-to-native call path. It
 does not make cold GPS acquisition itself 22x faster.
 
-Whether you're upgrading an existing app or building a new one using the latest React Native architecture, **React Native Nitro Geolocation** gives you the Modern API with a migration-friendly compat path.
+Whether you're upgrading an existing app or building a new one using the latest
+React Native architecture, **React Native Nitro Geolocation** provides direct
+functions and hooks with a migration-friendly compat path.
 
 
 ## Next Steps
 
 - [Quick Start Guide](/guide/quick-start) — Get up and running in minutes
 - [Migration Skills](/guide/migration-assistance) — Choose the right agent skill for community or service migrations
-- [Community Migration](/guide/community-migration) — Move from community imports to `/compat` and the Modern API
-- [Service Migration](/guide/service-migration) — Move from `react-native-geolocation-service` directly to the Modern API
+- [Community Migration](/guide/community-migration) — Move from community imports to `/compat`, then direct functions and hooks
+- [Service Migration](/guide/service-migration) — Move from `react-native-geolocation-service` directly to the package import
 - [Expo Development Build Guide](/guide/expo-development-build) — Use the package in Expo custom native builds
-- [Modern API Reference](/guide/modern-api) — Explore functions and hooks
+- [API Reference](/guide/api) — Explore functions and hooks
 - [Compat API Reference](/guide/compat-api) — Compatibility documentation
 - [Why Nitro Module?](/guide/why-nitro-module) — Architecture deep dive
 - [Benchmark Results](/guide/benchmark) — Performance comparison

--- a/docs/docs/v1/guide/migration-assistance.md
+++ b/docs/docs/v1/guide/migration-assistance.md
@@ -7,7 +7,7 @@ title: Migration Skills
 Use this guide when migrating an existing app from
 `@react-native-community/geolocation`, `navigator.geolocation`,
 `react-native-geolocation-service`, or `react-native-nitro-geolocation/compat`
-toward the Modern API.
+toward direct functions and hooks.
 
 ## Agent Skill
 
@@ -25,7 +25,8 @@ Install it with the Vercel Labs `skills` CLI:
 npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
 ```
 
-For `react-native-geolocation-service`, migrate directly to the Modern API with:
+For `react-native-geolocation-service`, migrate directly to named imports from
+the package with:
 
 [`service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
 
@@ -42,11 +43,12 @@ The community migration skill uses a two-phase workflow:
    `@react-native-community/geolocation` import sources to
    `react-native-nitro-geolocation/compat`, removes the legacy package, and
    prints validation commands for scripts that exist in the target app.
-2. Refactor `/compat` call sites to Modern API best practices using explicit
+2. Refactor `/compat` call sites to recommended API patterns using explicit
    criteria for permission timing, React lifecycle ownership, watch cleanup,
    cache-vs-fresh reads, accuracy, and Android provider/settings handling.
 
-The service migration skill skips `/compat` and targets the Modern API directly.
+The service migration skill skips `/compat` and targets the package import
+directly.
 It preserves service-specific behavior such as `accuracy`, fused-provider
 intent, Android settings-dialog handling, `mocked`/`provider` metadata, and
 provider-related error codes.
@@ -55,12 +57,12 @@ provider-related error codes.
 
 For `@react-native-community/geolocation`, first make the mechanical
 dependency/import change and verify the app still builds. Then refactor the
-callback-based compat code to Modern API calls. See
+callback-based compat code to direct function calls. See
 [Community Migration](/guide/community-migration).
 
-For `react-native-geolocation-service`, migrate directly to named Modern API
-imports. That package's Android fused-provider and settings-dialog options map
-more naturally to Modern APIs such as
+For `react-native-geolocation-service`, migrate directly to named imports from
+the package. Its Android fused-provider and settings-dialog options map
+more naturally to APIs such as
 `setConfiguration({ locationProvider: 'playServices' })` and
 `requestLocationSettings()`. See [Service Migration](/guide/service-migration).
 
@@ -69,9 +71,9 @@ The final target state should avoid runtime imports from
 `react-native-nitro-geolocation/compat` unless the app deliberately keeps a
 compatibility fallback.
 
-## Modern API Targets
+## Migration Targets
 
-| Legacy or compat usage | Modern API target |
+| Legacy or compat usage | Direct target |
 | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
 | cache-first startup location reads | `await getLastKnownPosition(options)` |

--- a/docs/docs/v1/guide/quick-start.md
+++ b/docs/docs/v1/guide/quick-start.md
@@ -107,7 +107,7 @@ async function handleUseMyLocation() {
 
 If Android needs a settings prompt or an explicit cached read, configure the
 provider in your startup `setConfiguration()` call and add the settings helpers
-from the [Modern API reference](/guide/modern-api).
+from the [API reference](/guide/api).
 
 ```tsx
 import {
@@ -128,7 +128,7 @@ const cached = await getLastKnownPosition({
 
 ## Next Steps
 
-- [Modern API Reference](/guide/modern-api) — Complete documentation
+- [API Reference](/guide/api) — Complete documentation
 - [Compat API Reference](/guide/compat-api) — Compatibility methods
 - [Background Location](/background/overview) — Native background tracking, geofencing, and storage recovery
 - [Migration Guides](/guide/migration-assistance) — Move from community/service geolocation packages

--- a/docs/docs/v1/guide/react-native-directory.md
+++ b/docs/docs/v1/guide/react-native-directory.md
@@ -13,7 +13,7 @@ Native Directory.
 | --- | --- |
 | iOS | Supported |
 | Android | Supported |
-| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
+| Web | Package import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
 | New Architecture | Required target; implemented through Nitro Modules |
 | Expo Go | Not supported |
 | Expo development builds | Supported with native setup |
@@ -24,19 +24,19 @@ Native Directory.
 Recommended short description:
 
 ```txt
-Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed API, or add web foreground support and native background tracking/geofencing.
 ```
 
 Recommended caveat:
 
 ```txt
-Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and web support through the package import or `/compat` using navigator.geolocation. Expo Go and browser background location are not supported.
 ```
 
 ## Pre-Submission Checklist
 
 - README explains when to use the package and when not to use it.
-- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
+- README includes compat coverage, package-import and `/compat` web behavior, and Expo limitations.
 - npm package has discoverability keywords.
 - Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
 - Docs include Expo development build guidance.

--- a/docs/docs/v1/guide/service-migration.md
+++ b/docs/docs/v1/guide/service-migration.md
@@ -4,8 +4,8 @@ title: Service Migration
 
 # Service Migration
 
-Apps that use `react-native-geolocation-service` should migrate directly to the
-Modern API:
+Apps that use `react-native-geolocation-service` should migrate directly to
+named imports from the package:
 
 ```ts
 import {
@@ -24,7 +24,7 @@ import {
 
 Do not migrate through `react-native-nitro-geolocation/compat`. The service
 package exposes Android fused-provider and settings-dialog behavior that maps
-more closely to Nitro Geolocation's Modern Android provider/settings API.
+more closely to Nitro Geolocation's Android provider/settings API.
 
 ## Agent Skill
 
@@ -45,7 +45,7 @@ node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inv
 node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
 ```
 
-If the app startup file is obvious, the script can also add the Modern startup
+If the app startup file is obvious, the script can also add the startup
 configuration:
 
 ```bash
@@ -74,7 +74,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 
 ## API Mapping
 
-| `react-native-geolocation-service` | Nitro Modern API |
+| `react-native-geolocation-service` | Nitro Geolocation |
 | --- | --- |
 | `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` |
 | `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` |
@@ -90,7 +90,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 | `position.provider` | `GeolocationResponse.provider` |
 | error code `-1`, `1`, `2`, `3`, `4`, `5` | `LocationErrorCode` |
 
-`forceRequestLocation` has no direct Modern option. Preserve that fallback
+`forceRequestLocation` has no direct equivalent option. Preserve that fallback
 behavior manually only after reviewing the intended UX.
 
 ## One-Shot Location
@@ -131,11 +131,11 @@ Do not add `requestLocationSettings()` when the legacy call explicitly used
 `showLocationDialog: false`.
 
 When `showLocationDialog` was omitted, review the flow manually. The service
-package default was `true`; Nitro Modern API requires an explicit settings flow.
+package default was `true`; Nitro Geolocation requires an explicit settings flow.
 
 ## Watches
 
-Use the low-level Modern watch API as the first safe target:
+Use the low-level watch API as the first safe target:
 
 ```diff
 - const watchId = Geolocation.watchPosition(onPosition, onError, {
@@ -162,8 +162,8 @@ debouncing.
 
 ## Permission Differences
 
-Legacy `requestAuthorization()` can return `disabled`. Modern
-`requestPermission()` returns permission status only:
+Legacy `requestAuthorization()` can return `disabled`. The
+`requestPermission()` function returns permission status only:
 
 ```ts
 const status = await requestPermission();
@@ -186,7 +186,7 @@ const status = await requestPermission();
 
 Review call sites that omit options:
 
-| Option | Service default | Nitro Modern default |
+| Option | Service default | Nitro default |
 | --- | --- | --- |
 | `getCurrentPosition.timeout` | `Infinity` | `600000` |
 | `getCurrentPosition.maximumAge` | `Infinity` | `0` |

--- a/docs/docs/v1/guide/why-nitro-module.md
+++ b/docs/docs/v1/guide/why-nitro-module.md
@@ -40,7 +40,7 @@ User callback executed
 - Multiple listeners share one event stream
 - Requires JSON serialization on every update
 
-### Modern API: Direct Callback Architecture (`React Native Nitro Geolocation`)
+### Direct Callback Architecture (`React Native Nitro Geolocation`)
 
 ```
 JavaScript Layer
@@ -69,7 +69,7 @@ React Native Nitro Geolocation now provides a React-friendly layer on top of the
 User Code (React Components)
   ↓ useWatchPosition({ enabled: true })
   ↓ Declarative, auto-cleanup
-Modern API Layer (direct functions + hooks)
+Functions and hooks
   ↓ watchPosition(callback)
 JSI Layer (Nitro Modules)
   ↓ Direct callbacks, no Bridge
@@ -87,7 +87,7 @@ Device GPS/Network
 
 **Architecture Layers**:
 1. **Presentation** (Hooks): `useWatchPosition`
-2. **Modern API** (Functions): `getCurrentPosition`, `watchPosition`, `unwatch`
+2. **Functions and hooks**: `getCurrentPosition`, `watchPosition`, `unwatch`
 3. **JSI Bridge** (Nitro): Direct native communication
 4. **Native** (Platform): iOS/Android location APIs
 
@@ -120,10 +120,10 @@ Nitro Modules use **Nitrogen** code generation to create JSI bindings:
 `React Native Nitro Geolocation` transforms the geolocation API at multiple levels:
 
 1. **Low-level**: Bridge-based events → JSI direct callbacks (Nitro Modules)
-2. **High-level**: Imperative callbacks → Declarative hooks (Modern API)
+2. **High-level**: Imperative callbacks → Declarative hooks
 
 This provides:
 - **Performance**: Native-level speed via JSI
 - **Developer Experience**: React-friendly hooks with TanStack Query patterns
-- **Flexibility**: Choose Modern API (hooks) or Compat API (callbacks)
+- **Flexibility**: Choose direct functions and hooks or Compat callbacks
 - **Compatibility**: Drop-in compatible with the core native community API via `/compat`

--- a/docs/docs/v1/index.md
+++ b/docs/docs/v1/index.md
@@ -4,7 +4,7 @@ pageType: home
 hero:
   name: React Native Nitro Geolocation
   text: Nitro-powered native geolocation
-  tagline: Replace community geolocation with /compat, then move to a typed Modern API.
+  tagline: Replace community geolocation with /compat, then move to a typed API.
   actions:
     - theme: brand
       text: Introduction

--- a/docs/docs/v2/_nav.json
+++ b/docs/docs/v2/_nav.json
@@ -25,8 +25,8 @@
     "text": "Foreground APIs",
     "items": [
       {
-        "text": "Modern API",
-        "link": "/guide/modern-api"
+        "text": "API",
+        "link": "/guide/api"
       },
       {
         "text": "Compatibility API",

--- a/docs/docs/v2/background/overview.md
+++ b/docs/docs/v2/background/overview.md
@@ -7,9 +7,8 @@ description: Decide when to use native background location, understand platform 
 
 Use the Background API when the product must record location while the app is
 not active, monitor geofences, recover events recorded while JavaScript was
-unavailable, or run native delivery behavior. For an active screen, use the
-Modern foreground `useWatchPosition` API instead; it has a simpler permission
-and lifecycle model.
+unavailable, or run native delivery behavior. For an active screen, use
+`useWatchPosition()` instead; it has a simpler permission and lifecycle model.
 
 ```ts
 import {

--- a/docs/docs/v2/background/start-stop.md
+++ b/docs/docs/v2/background/start-stop.md
@@ -61,7 +61,7 @@ export async function stopTracking() {
 }
 ```
 
-`android.locationProvider` uses the same public values as the root API:
+`android.locationProvider` uses the same public values as foreground configuration:
 `'auto'`, `'playServices'`, or `'android'`. Use `'android'` to force the
 platform `LocationManager`; the Nitro-only `'android_platform'` spelling is not
 part of the public API.

--- a/docs/docs/v2/guide/_meta.json
+++ b/docs/docs/v2/guide/_meta.json
@@ -26,7 +26,7 @@
   "v2-error-migration",
   "v2-unified-background-events",
   { "type": "section-header", "label": "Foreground location" },
-  { "type": "file", "name": "modern-api", "label": "Modern API reference" },
+  { "type": "file", "name": "api", "label": "API reference" },
   { "type": "file", "name": "compat-api", "label": "Compatibility API" },
   "watch-observability",
   "gps-offline-recipe",

--- a/docs/docs/v2/guide/agent-context-map.md
+++ b/docs/docs/v2/guide/agent-context-map.md
@@ -36,7 +36,7 @@ Avoid these until needed:
 
 | Area | Responsibility | Main files |
 | --- | --- | --- |
-| Modern foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
+| Foreground API | Public wrappers for current position, watch, permission, provider, geocoding, heading, settings, and availability APIs. | `src/api/`, `src/NitroGeolocation.nitro.ts` |
 | Community compatibility API | `@react-native-community/geolocation`-style callbacks and configuration. | `src/compat/`, `src/NitroGeolocationCompat.nitro.ts` |
 | Background API | Public background exports, listener narrowing, iOS lifecycle subscriptions, storage methods, geofence helpers, activity recognition helpers, HTTP sync helper, and task registration. | `src/background/index.ts`, `src/background/locationLifecycle.ts`, `src/background/task.ts`, `src/background/types.ts`, `src/background/NitroBackgroundLocation.nitro.ts` |
 | Web fallback | Browser geolocation behavior and web E2E support. | `src/web/`, `src/index.web.tsx`, `src/background/index.web.ts` |

--- a/docs/docs/v2/guide/api.md
+++ b/docs/docs/v2/guide/api.md
@@ -1,10 +1,10 @@
 ---
-title: Modern API
+title: API
 ---
 
 > Simple functional API with direct calls and minimal abstractions
 
-The Modern API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
+This API provides a straightforward approach to geolocation with direct function calls and a single hook for continuous tracking.
 
 ## Find an API by task
 
@@ -84,7 +84,7 @@ export type GeolocationConfiguration = {
 
 **Web behavior**:
 
-- Browser builds resolve the root import to a web entry that uses
+- Browser builds resolve the main package import to a web entry that uses
   `navigator.geolocation`.
 - `setConfiguration()` is a no-op on web. Browser permission prompts are driven
   by `getCurrentPosition()` / `watchPosition()`, not by a standalone platform
@@ -371,12 +371,12 @@ when the page becomes visible or active. Provider-specific optional fields stay
 - Use `getLastKnownPosition()` for a synchronous read of the module cache. Use
   `getLastKnownPositionAsync()` to query native/provider caches without starting
   a fresh request.
-- Modern API errors include `PLAY_SERVICE_NOT_AVAILABLE`,
+- Errors include `PLAY_SERVICE_NOT_AVAILABLE`,
   `SETTINGS_NOT_SATISFIED`, and `TIMEOUT`.
 
 ### Web Notes
 
-Modern API web support uses the browser standard `navigator.geolocation` API.
+Web support uses the browser standard `navigator.geolocation` API.
 It requires a secure context (`https://`, `localhost`, or another browser-trusted
 origin). Unsupported browsers or unavailable providers reject location requests
 with `POSITION_UNAVAILABLE`.
@@ -477,7 +477,7 @@ function LocationButton() {
   aborted prevents native or browser location work from starting. The promise
   rejects with the exact `signal.reason`; runtimes without a reason receive an
   `AbortError` fallback.
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`. `permission` follows the granted permission level, `coarse` avoids fine GPS-only requests, and `fine` requires fine location permission.
 - `waitForAccurateLocation?: boolean` - Android-only Fused request tuning, available since `v1.2`.
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update in ms, available since `v1.2`.
@@ -596,7 +596,7 @@ interface GeolocationResponse {
 
 ### Mock and provider metadata
 
-`mocked` and `provider` are optional Modern API metadata fields added in v1.2.
+`mocked` and `provider` are optional response metadata fields added in v1.2.
 They describe the source of that particular position sample:
 
 - `mocked` reports whether the sample source identified it as simulated or
@@ -671,12 +671,12 @@ const token = watchPosition(
 unwatch(token);
 ```
 
-Starting in 2.0, Modern API errors use readable string discriminants. Keep
+Starting in 2.0, API errors use readable string discriminants. Keep
 comparisons against the `LocationErrorCodes` members shown below instead of
-copying their values. The expanded modern-only native setup/provider members
+copying their values. The additional native setup/provider members
 (`INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and
 `SETTINGS_NOT_SATISFIED`) were originally added in v1.2; 2.0 keeps those member
-names while replacing every Modern numeric value with a string.
+names while replacing every previous numeric value with a string.
 
 The code is committed by the native layer before a `LocationError` is sent to
 JS. Both `watchPosition` error callbacks and public Promise rejections from
@@ -723,7 +723,7 @@ native/provider cache-only sources using `maximumAge`, `accuracy`,
 options are intentionally excluded, and the call never falls through to a
 fresh request. It resolves `undefined` when no cached location
 satisfies the options, including a native `POSITION_UNAVAILABLE` result. Other
-failures, such as permission denial, reject with the Modern `LocationError`
+failures, such as permission denial, reject with `LocationError`
 contract.
 
 ### Geocoding APIs
@@ -764,7 +764,7 @@ const addresses = await reverseGeocode({
 `reverseGeocode(coords)` rejects with `INTERNAL_ERROR` when latitude or
 longitude is non-finite or outside the valid coordinate range. Platform
 geocoder service failures reject with the same `{ code, message }`
-`LocationError` shape as the rest of the Modern API.
+`LocationError` shape as the rest of the API.
 
 ### Heading APIs
 
@@ -896,7 +896,7 @@ function LiveTracker() {
 **Options**:
 
 - `enabled?: boolean` - Start/stop watching (default: `false`)
-- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. Modern 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
+- `accuracy?: { android?: 'high' | 'balanced' | 'low' | 'passive'; ios?: 'bestForNavigation' | 'best' | 'nearestTenMeters' | 'hundredMeters' | 'kilometer' | 'threeKilometers' | 'reduced' }` - Platform-specific accuracy preset. 2.0 callers use this option; `enableHighAccuracy` remains only on `/compat`.
 - `granularity?: 'permission' | 'coarse' | 'fine'` - Android-only request granularity, available since `v1.2`
 - `waitForAccurateLocation?: boolean` - Android-only high-accuracy initial update tuning, available since `v1.2`
 - `maxUpdateAge?: number` - Android-only maximum age for an initial update, available since `v1.2`
@@ -993,7 +993,7 @@ unwatch(token);
 
 ### getActiveWatches()
 
-Read the active Modern API position and heading subscriptions without starting
+Read the active position and heading subscriptions without starting
 or changing location services:
 
 ```tsx
@@ -1084,7 +1084,7 @@ function BackgroundTracker() {
 
 ## TypeScript Support
 
-All Modern API exports are fully typed:
+All exports are fully typed:
 
 ```typescript
 import type {
@@ -1109,8 +1109,8 @@ import type {
 `NullableDouble` is `number | null`. It is the shared scalar used by
 `GeolocationCoordinates.altitude`, `altitudeAccuracy`, `heading`, and `speed`.
 
-The deprecated `ModernGeolocationConfiguration` alias was removed in 2.0. Use
-`GeolocationConfiguration` for the root Modern API.
+The deprecated 1.x configuration alias was removed in 2.0. Use
+`GeolocationConfiguration`.
 
 ### Type Inference
 
@@ -1130,7 +1130,7 @@ const status = await requestPermission();
 
 ## Comparison with Compat API
 
-| Feature          | Modern API                               | Compat API                               |
+| Feature          | Package import                   | Compat API                               |
 | ---------------- | ---------------------------------------- | ---------------------------------------- |
 | **Import**       | `react-native-nitro-geolocation`         | `react-native-nitro-geolocation/compat`  |
 | **Pattern**      | Functions + Hook                         | Callbacks                                |
@@ -1173,7 +1173,7 @@ function LocationTracker() {
 }
 ```
 
-**After (Modern API)**:
+**After**:
 
 ```tsx
 import { useWatchPosition } from 'react-native-nitro-geolocation';
@@ -1193,4 +1193,4 @@ function LocationTracker() {
 - No watch ID management
 - Automatic cleanup
 - Declarative enable/disable
-- Promise-based control flow and inferred Modern API results
+- Promise-based control flow and inferred results

--- a/docs/docs/v2/guide/community-migration.md
+++ b/docs/docs/v2/guide/community-migration.md
@@ -7,10 +7,10 @@ title: Community Migration
 Use this path for apps that import `@react-native-community/geolocation`,
 `navigator.geolocation`, or `react-native-nitro-geolocation/compat`.
 
-The safest migration is two-step: switch community imports to `/compat` first,
-verify the app still behaves the same, then move call sites to the Modern API
-where it improves ownership, permission timing, cache behavior, or Android
-settings handling.
+The safest migration is two-step: switch community imports to `/compat` first
+and verify the app still behaves the same. Then refactor selected call sites
+where direct functions or hooks improve ownership, permission timing, cache
+behavior, or Android settings handling.
 
 ## Agent Skill
 
@@ -30,8 +30,7 @@ The bundled bootstrap script performs the first safe mechanical pass:
 node <skill-dir>/scripts/migrate-to-compat.mjs --root <app-root>
 ```
 
-After the compat bootstrap, use the skill to refactor selected call sites to the
-Modern API.
+After the compat bootstrap, use the skill to refactor selected call sites.
 
 ## Migration Path
 
@@ -88,10 +87,10 @@ Geolocation.getCurrentPosition(
 );
 ```
 
-### Step 3: Modern API
+### Step 3: Direct functions and hooks
 
-After the `/compat` migration is stable, move individual call sites to the
-Modern API:
+After the `/compat` migration is stable, replace individual callback call sites
+with direct functions or hooks:
 
 ```tsx
 import {

--- a/docs/docs/v2/guide/compat-api.md
+++ b/docs/docs/v2/guide/compat-api.md
@@ -6,7 +6,7 @@ title: Compatibility API (/compat)
 > shapes and numeric error contract. It does not install a
 > `navigator.geolocation` global, and documented platform defaults or ignored
 > options can differ. Review the matrix below before calling it drop-in for your
-> application. New code should prefer the [Modern API](./modern-api.md).
+> application. New code should prefer the [API](./api.md).
 
 ## Import Path
 
@@ -47,7 +47,7 @@ import type {
 } from 'react-native-nitro-geolocation/compat';
 ```
 
-No type import from the Modern root is required. TypeScript can resolve this
+No type import from the main package is required. TypeScript can resolve this
 subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
 
 ## Compatibility Scope
@@ -55,13 +55,13 @@ subpath with `node`, `node16`, `nodenext`, and `bundler` module resolution.
 This API is compatible with the core native
 `@react-native-community/geolocation` callback shape. It preserves the listed
 methods and numeric error contract for existing iOS and Android apps while the
-Modern API gives new code a Promise/function API. The matrix is the compatibility
+API gives new code a Promise/function API. The matrix is the compatibility
 boundary; options described as ignored/no-op and the missing global polyfill are
 intentional differences.
 
 | Community API | Nitro `/compat` | Notes |
 | --- | ---: | --- |
-| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the Modern API root import. |
+| `setRNConfiguration` | Supported | Preserves the legacy config method; Android provider selection is handled by the main package import. |
 | `requestAuthorization` | Supported | iOS authorization follows configured `Info.plist` keys and `authorizationLevel`. |
 | `getCurrentPosition` | Supported | Keeps the legacy callback and error shape. |
 | `watchPosition` | Supported | Returns a numeric watch id. |
@@ -70,7 +70,7 @@ intentional differences.
 | `navigator.geolocation` polyfill | Not supported | Import `/compat` directly instead of installing a global polyfill. |
 | Web | Supported | Browser builds use `navigator.geolocation` for `getCurrentPosition`, `watchPosition`, `clearWatch`, and `stopObserving`. |
 
-The root Modern API and `/compat` subpath both support web by delegating to the
+The package import and `/compat` subpath both support web by delegating to the
 browser `navigator.geolocation` API. The `/compat` web entry keeps the callback
 shape and legacy error constants, while `setRNConfiguration()` is a no-op and
 `requestAuthorization()` calls the success callback immediately because browsers
@@ -92,7 +92,7 @@ do not expose a standalone geolocation authorization prompt.
 
 Preserves the legacy configuration API. Use it for iOS authorization/background
 settings. Android provider selection and request behavior should be configured
-per call or through the Modern API root import.
+per call or through the main package import.
 
 ```ts
 Geolocation.setRNConfiguration(config: {
@@ -108,7 +108,7 @@ Supported options:
 - `skipPermissionRequests` (boolean) - Required by the public type. Pass `false` for legacy compatibility, or `true` when you request permissions yourself before using Geolocation APIs. For deterministic app flows, request permissions explicitly before calling location APIs.
 - `authorizationLevel` (string, iOS-only) - Either `"whenInUse"`, `"always"`, or `"auto"`. Changes whether the user will be asked to give "always" or "when in use" location services permission. Any other value or `auto` will use the default behaviour, where the permission level is based on the contents of your `Info.plist`.
 - `enableBackgroundLocationUpdates` (boolean, iOS-only) - When using `skipPermissionRequests`, toggles whether to enable Core Location background updates. Defaults to false unless explicitly set.
-- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the Modern API root import when you need Android fused/provider selection.
+- `locationProvider` (string, Android-only) - Either `"playServices"`, `"android"`, or `"auto"`. Preserved for API compatibility on `/compat`; use the main package import when you need Android fused/provider selection.
 
 ### `requestAuthorization()`
 

--- a/docs/docs/v2/guide/devtools.md
+++ b/docs/docs/v2/guide/devtools.md
@@ -7,7 +7,7 @@ Mock geolocation data in development with an interactive map interface using the
 This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) before proceeding.
 
 :::warning API Compatibility
-This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
+This DevTools plugin only works with the **package import** (`react-native-nitro-geolocation`). It does **not** support the Compat API (`react-native-nitro-geolocation/compat`).
 :::
 
 ## Installation
@@ -202,7 +202,7 @@ The DevTools plugin should only be enabled in development builds. Rozenite DevTo
 :::
 
 :::tip
-The plugin only intercepts Modern API calls. Compatibility API calls keep their callback behavior.
+The plugin only intercepts calls made through the package import. Compatibility API calls keep their callback behavior.
 :::
 
 ## Troubleshooting

--- a/docs/docs/v2/guide/index.md
+++ b/docs/docs/v2/guide/index.md
@@ -12,8 +12,8 @@ pick one path; you do not need to read every guide before starting.
 | --- | --- | --- |
 | Add foreground location to a new app | [Install and get a location](./quick-start.md) | A foreground-only screen that renders coordinates |
 | Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All seven 2.0 breaking changes reviewed and tested |
-| Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then an optional Modern API refactor |
-| Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | A direct Modern API migration |
+| Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then optionally adopt direct functions and hooks |
+| Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | Named imports from the package |
 | Use an Expo app | [Expo development builds](./expo-development-build.md) | A custom native build; Expo Go is not supported |
 | Track when the app is not active | [Background Location](../background/overview.md) | Native background tracking with platform-specific setup |
 | Evaluate the RC for release | [Release readiness](./release-readiness.md) | Tested-stack, RC-policy, and ship-checklist review |
@@ -25,7 +25,7 @@ The package has three intentionally separate entry points.
 
 | Surface | Import | Best for | Platform boundary |
 | --- | --- | --- | --- |
-| **Modern API** | `react-native-nitro-geolocation` | New foreground code, Promise APIs, typed readiness, React watches | Native and web foreground |
+| **Functions and hooks** | `react-native-nitro-geolocation` | New foreground code, Promise APIs, typed readiness, React watches | Native and web foreground |
 | **Compatibility API** | `react-native-nitro-geolocation/compat` | A controlled migration from the core community callback API | Native and web foreground |
 | **Background API** | `react-native-nitro-geolocation/background` | Tracking, geofencing, persistence, Headless JS, and native sync | Native only; web imports return unsupported results |
 
@@ -43,7 +43,7 @@ default, or platform-specific option behaves identically. Review the
 - CocoaPods is the recommended production iOS dependency path. React Native
   0.87.x SwiftPM-only projects have an experimental precompiled integration;
   use the exact compatibility matrix in the Swift Package Manager guide.
-- The Modern and Compatibility foreground APIs support browser builds through
+- Both foreground APIs support browser builds through
   `navigator.geolocation`. Background Location is native-only.
 - Android and iOS share public contracts but retain documented OS behavior and
   reliability limits.

--- a/docs/docs/v2/guide/migration-assistance.md
+++ b/docs/docs/v2/guide/migration-assistance.md
@@ -7,18 +7,18 @@ title: Migration overview
 Use this guide when migrating an existing app from
 `@react-native-community/geolocation`, `navigator.geolocation`,
 `react-native-geolocation-service`, or `react-native-nitro-geolocation/compat`
-toward the Modern API.
+toward direct functions and hooks.
 
 ## Choose a path
 
 For `@react-native-community/geolocation`, first make the mechanical
 dependency/import change and verify the app still builds. Then refactor the
-callback-based compatibility code to Modern API calls. See
+callback-based compatibility code to direct function calls. See
 [Community Migration](/guide/community-migration).
 
-For `react-native-geolocation-service`, migrate directly to named Modern API
-imports. Its Android fused-provider and settings-dialog options map to Modern
-APIs such as `setConfiguration({ locationProvider: 'playServices' })` and
+For `react-native-geolocation-service`, migrate directly to named imports from
+the package. Its Android fused-provider and settings-dialog options map to APIs
+such as `setConfiguration({ locationProvider: 'playServices' })` and
 `requestLocationSettings()`. See [Service Migration](/guide/service-migration).
 
 The final target state should avoid runtime imports from
@@ -42,7 +42,7 @@ Install it with the Vercel Labs `skills` CLI:
 npx skills add jingjing2222/react-native-nitro-geolocation --skill community-migration
 ```
 
-For `react-native-geolocation-service`, migrate directly to the Modern API with:
+For `react-native-geolocation-service`, migrate directly to the package import with:
 
 [`service-migration`](https://github.com/jingjing2222/react-native-nitro-geolocation/tree/main/skills/service-migration).
 
@@ -59,18 +59,19 @@ The community migration skill uses a two-phase workflow:
    `@react-native-community/geolocation` import sources to
    `react-native-nitro-geolocation/compat`, removes the legacy package, and
    prints validation commands for scripts that exist in the target app.
-2. Refactor `/compat` call sites to Modern API best practices using explicit
+2. Refactor `/compat` call sites to recommended API patterns using explicit
    criteria for permission timing, React lifecycle ownership, watch cleanup,
    cache-vs-fresh reads, accuracy, and Android provider/settings handling.
 
-The service migration skill skips `/compat` and targets the Modern API directly.
+The service migration skill skips `/compat` and targets the package import
+directly.
 It preserves service-specific behavior such as `accuracy`, fused-provider
 intent, Android settings-dialog handling, `mocked`/`provider` metadata, and
 provider-related error codes.
 
-## Modern API Targets
+## Migration Targets
 
-| Legacy or compat usage | Modern API target |
+| Legacy or compat usage | Direct target |
 | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` |
 | latest position already observed by this JS module | `getLastKnownPosition()` |

--- a/docs/docs/v2/guide/quick-start.md
+++ b/docs/docs/v2/guide/quick-start.md
@@ -175,7 +175,7 @@ export function FirstLocation() {
 
 ## Continue only for your use case
 
-- [Modern API reference](./modern-api.md) for readiness, cached reads, watches,
+- [API reference](./api.md) for readiness, cached reads, watches,
   geocoding, and heading.
 - [Community migration](./community-migration.md) if this replaces the community
   callback package.

--- a/docs/docs/v2/guide/react-native-directory.md
+++ b/docs/docs/v2/guide/react-native-directory.md
@@ -13,7 +13,7 @@ Native Directory.
 | --- | --- |
 | iOS | Supported |
 | Android | Supported |
-| Web | Modern API root import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
+| Web | Package import and `/compat` supported through `navigator.geolocation`; background location remains native-only |
 | New Architecture | Required target; implemented through Nitro Modules |
 | Expo Go | Not supported |
 | Expo development builds | Supported with native setup |
@@ -24,19 +24,19 @@ Native Directory.
 Recommended short description:
 
 ```txt
-Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed Modern API, or add web foreground support and native background tracking/geofencing.
+Nitro-powered geolocation for React Native 0.75+ New Architecture apps. Use /compat to replace @react-native-community/geolocation, move to a typed API, or add web foreground support and native background tracking/geofencing.
 ```
 
 Recommended caveat:
 
 ```txt
-Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and Modern API or `/compat` web through navigator.geolocation. Expo Go and browser background location are not supported.
+Targets bare React Native/RN CLI apps with New Architecture enabled, Expo development/custom native builds, and web support through the package import or `/compat` using navigator.geolocation. Expo Go and browser background location are not supported.
 ```
 
 ## Pre-Submission Checklist
 
 - README explains when to use the package and when not to use it.
-- README includes compat coverage, Modern API and `/compat` web behavior, and Expo limitations.
+- README includes compat coverage, package-import and `/compat` web behavior, and Expo limitations.
 - npm package has discoverability keywords.
 - Repository topics include React Native, geolocation, Nitro, JSI, platform, and Android provider keywords.
 - Docs include Expo development build guidance.

--- a/docs/docs/v2/guide/release-readiness.md
+++ b/docs/docs/v2/guide/release-readiness.md
@@ -45,7 +45,7 @@ combination is continuously exercised.
 | iOS dependency manager | CocoaPods; experimental SwiftPM on RN 0.87.x with Nitro Modules 0.37.1 | SwiftPM uses the matching precompiled release artifact and has no source fallback |
 | Android build | Consumer app's supported Android toolchain | Native permissions and foreground-service rules vary by OS level |
 | Native foreground | iOS and Android | Test permission and provider behavior on target devices |
-| Web foreground | Modern root and `/compat` through `navigator.geolocation` | Secure-context and browser permission rules apply |
+| Web foreground | package import and `/compat` through `navigator.geolocation` | Secure-context and browser permission rules apply |
 | Background | iOS and Android through `/background` | Native-only and best effort under OS lifecycle policy |
 | Prebuilts | Matching release assets when compatible | Android requires matching React Native and Nitro major/minor versions; source fallback otherwise |
 

--- a/docs/docs/v2/guide/service-migration.md
+++ b/docs/docs/v2/guide/service-migration.md
@@ -4,8 +4,8 @@ title: Service Migration
 
 # Service Migration
 
-Apps that use `react-native-geolocation-service` should migrate directly to the
-Modern API:
+Apps that use `react-native-geolocation-service` should migrate directly to
+named imports from the package:
 
 ```ts
 import {
@@ -24,7 +24,7 @@ import {
 
 Do not migrate through `react-native-nitro-geolocation/compat`. The service
 package exposes Android fused-provider and settings-dialog behavior that maps
-more closely to Nitro Geolocation's Modern Android provider/settings API.
+more closely to Nitro Geolocation's Android provider/settings API.
 
 ## Agent Skill
 
@@ -45,7 +45,7 @@ node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inv
 node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
 ```
 
-If the app startup file is obvious, the script can also add the Modern startup
+If the app startup file is obvious, the script can also add the startup
 configuration:
 
 ```bash
@@ -74,7 +74,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 
 ## API Mapping
 
-| `react-native-geolocation-service` | Nitro Modern API |
+| `react-native-geolocation-service` | Nitro Geolocation |
 | --- | --- |
 | `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` |
 | `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` |
@@ -90,7 +90,7 @@ Use `locationProvider: 'android'` only when the legacy app intentionally used
 | `position.provider` | `GeolocationResponse.provider` |
 | numeric service error code | readable 2.x `LocationErrorCode` discriminant |
 
-`forceRequestLocation` has no direct Modern option. Preserve that fallback
+`forceRequestLocation` has no direct equivalent option. Preserve that fallback
 behavior manually only after reviewing the intended UX.
 
 ## One-Shot Location
@@ -131,11 +131,11 @@ Do not add `requestLocationSettings()` when the legacy call explicitly used
 `showLocationDialog: false`.
 
 When `showLocationDialog` was omitted, review the flow manually. The service
-package default was `true`; Nitro Modern API requires an explicit settings flow.
+package default was `true`; Nitro Geolocation requires an explicit settings flow.
 
 ## Watches
 
-Use the low-level Modern watch API as the first safe target:
+Use the low-level watch API as the first safe target:
 
 ```diff
 - const watchId = Geolocation.watchPosition(onPosition, onError, {
@@ -162,8 +162,8 @@ debouncing.
 
 ## Permission Differences
 
-Legacy `requestAuthorization()` can return `disabled`. Modern
-`requestPermission()` returns permission status only:
+Legacy `requestAuthorization()` can return `disabled`. The
+`requestPermission()` function returns permission status only:
 
 ```ts
 const status = await requestPermission();
@@ -186,7 +186,7 @@ const status = await requestPermission();
 
 Review call sites that omit options:
 
-| Option | Service default | Nitro Modern default |
+| Option | Service default | Nitro default |
 | --- | --- | --- |
 | `getCurrentPosition.timeout` | `Infinity` | `600000` |
 | `getCurrentPosition.maximumAge` | `Infinity` | `0` |

--- a/docs/docs/v2/guide/troubleshooting.md
+++ b/docs/docs/v2/guide/troubleshooting.md
@@ -58,7 +58,7 @@ guidance/remediation fields in product UI rather than inferring prompt behavior
 from an OS name alone.
 
 Then reproduce one explicit location request and record the structured error
-`code` and `message`. Modern 2.0 codes are strings; `/compat` codes remain
+`code` and `message`. 2.0 API codes are strings; `/compat` codes remain
 numeric. Remove exact coordinates from logs before sharing them.
 
 ## 3. Separate foreground and background failures
@@ -99,7 +99,7 @@ Include:
 - exact Geolocation, Nitro Modules, React Native, React, and Expo versions;
 - iOS/Android/browser version, device or simulator, and CPU architecture;
 - CocoaPods/prebuilt/source-build path and whether a clean native rebuild ran;
-- minimal root, `/compat`, or `/background` import and options;
+- minimal main package, `/compat`, or `/background` import and options;
 - doctor JSON plus permission/readiness or background diagnosis;
 - expected result, actual result, and smallest reproduction steps;
 - whether the problem happens in Debug, Release, and a physical device;

--- a/docs/docs/v2/guide/upgrade-from-v1.md
+++ b/docs/docs/v2/guide/upgrade-from-v1.md
@@ -13,7 +13,7 @@ a branch and keep the currently deployed 1.x version available for rollback.
 
 1. Record the exact working React Native, Nitro Modules, and Geolocation
    versions from the current lockfile.
-2. Inventory root, `/compat`, and `/background` imports separately.
+2. Inventory main package, `/compat`, and `/background` imports separately.
 3. Create or keep tests for permission denial, a fresh fix, cached reads,
    watches, Android settings resolution, and background event recovery used by
    your product.
@@ -33,17 +33,17 @@ lockfile and native dependency state before attempting API migrations.
 
 | Change | Who is affected | Required action | Verification |
 | --- | --- | --- | --- |
-| String Modern error codes | Root API callers comparing or persisting numeric codes | Compare against `LocationErrorCodes`; migrate persisted values | Denial, timeout, unavailable-provider tests |
-| Removed configuration alias | Type imports of `ModernGeolocationConfiguration` | Use `GeolocationConfiguration` | Typecheck |
-| Watch Manager v2 semantics | Apps with multiple Modern watches or implicit cleanup assumptions | Verify per-watch thresholds and ownership | Two-watch and unmount/stop tests |
+| String error codes | Main package callers comparing or persisting numeric codes | Compare against `LocationErrorCodes`; migrate persisted values | Denial, timeout, unavailable-provider tests |
+| Removed configuration alias | Type imports of the deprecated 1.x configuration alias | Use `GeolocationConfiguration` | Typecheck |
+| Watch Manager v2 semantics | Apps with multiple watches or implicit cleanup assumptions | Verify per-watch thresholds and ownership | Two-watch and unmount/stop tests |
 | Split last-known reads | Callers awaiting or passing options to `getLastKnownPosition()` | Choose synchronous module cache or async platform cache | Empty, fresh, and stale cache tests |
-| Removed Modern `enableHighAccuracy` | Root current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
+| Removed `enableHighAccuracy` | Foreground current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
 | Unified background events | Background provider/lifecycle listeners and persisted event consumers | Handle the unified discriminated stream | Live plus stored-event tests |
 | Deterministic settings result | Code expecting cancel/unavailable to reject | Branch on `result.outcome` | Satisfied, cancelled, unavailable tests |
 
-## 1. Use string Modern error codes
+## 1. Use string error codes
 
-The Modern root API no longer uses numeric codes. `/compat` intentionally keeps
+The package import no longer uses numeric codes. `/compat` intentionally keeps
 the numeric W3C contract.
 
 ```ts
@@ -52,7 +52,7 @@ if (error.code === 1) {
   showPermissionHelp();
 }
 
-// 2.0 Modern API
+// 2.0 API
 import { LocationErrorCodes } from 'react-native-nitro-geolocation';
 
 if (error.code === LocationErrorCodes.PERMISSION_DENIED) {
@@ -71,19 +71,16 @@ numeric codes.
 ## 2. Replace the removed configuration alias
 
 ```ts
-// 1.x
-import type { ModernGeolocationConfiguration } from 'react-native-nitro-geolocation';
-
 // 2.0
 import type { GeolocationConfiguration } from 'react-native-nitro-geolocation';
 ```
 
-This is a type-only rename. **Verify:** search for the old name and run the app's
-full TypeScript check.
+Delete imports of the deprecated 1.x configuration alias and use the type above.
+**Verify:** run the app's full TypeScript check.
 
 ## 3. Verify Watch Manager v2 behavior
 
-Native acquisition can be shared, but each Modern watch now enforces its own
+Native acquisition can be shared, but each watch now enforces its own
 callback thresholds and cleanup lifecycle. Do not assume that stopping one watch
 stops another, or that one watch's distance/interval policy controls all
 subscribers.
@@ -113,13 +110,13 @@ Neither 2.0 function starts a fresh location request. Use
 observing a current/watch position populates the module cache; an expired
 platform cache is filtered by `maximumAge`.
 
-## 5. Replace Modern `enableHighAccuracy`
+## 5. Replace `enableHighAccuracy`
 
 ```ts
-// 1.x Modern API
+// 1.x API
 await getCurrentPosition({ enableHighAccuracy: true });
 
-// 2.0 Modern API
+// 2.0 API
 await getCurrentPosition({
   accuracy: { android: 'high', ios: 'best' },
 });
@@ -176,8 +173,8 @@ actual request failure.
 
 Before merging the upgrade:
 
-- [ ] No `ModernGeolocationConfiguration` root type imports remain.
-- [ ] No Modern root options still use `enableHighAccuracy`.
+- [ ] No imports of the deprecated 1.x configuration alias remain.
+- [ ] No foreground options still use `enableHighAccuracy`.
 - [ ] Numeric error comparisons exist only under `/compat` or in explicit legacy
       data migration code.
 - [ ] Every last-known call deliberately chooses module cache or platform cache.

--- a/docs/docs/v2/guide/v2-error-migration.md
+++ b/docs/docs/v2/guide/v2-error-migration.md
@@ -4,9 +4,9 @@ title: 2.0 Error Migration
 
 # 2.0 Error Migration
 
-React Native Nitro Geolocation 2.0 replaces numeric error codes in the Modern
-API with readable string discriminants. This is a Modern API change only. The
-`/compat` entry point keeps the W3C-style numeric `1`, `2`, and `3` contract.
+React Native Nitro Geolocation 2.0 replaces the package's numeric error codes
+with readable string discriminants. This change does not affect `/compat`, which
+keeps the W3C-style numeric `1`, `2`, and `3` contract.
 
 ## Update comparisons
 
@@ -73,7 +73,7 @@ function describeLocationFailure(error: unknown): string {
 
 ## Migrate persisted errors
 
-Do not reinterpret an old number as a new string. If an app stores Modern API
+Do not reinterpret an old number as a new string. If an app stores API
 errors, translate known 1.x values once with the table above, write the 2.x
 string, and discard unknown values. The native Android background status store
 does this migration automatically for errors recorded by this package.
@@ -96,5 +96,5 @@ Geolocation.getCurrentPosition(
 );
 ```
 
-Keeping the two contracts separate prevents a Modern-only provider error from
-leaking into the browser-compatible surface.
+Keeping the two contracts separate prevents the additional provider error codes
+from leaking into the browser-compatible surface.

--- a/docs/docs/v2/guide/watch-observability.md
+++ b/docs/docs/v2/guide/watch-observability.md
@@ -1,6 +1,6 @@
 # Watch observability
 
-Use `getActiveWatches()` to inspect the Modern API watches that currently own
+Use `getActiveWatches()` to inspect the watches that currently own
 native position or heading subscriptions:
 
 ```ts
@@ -34,7 +34,7 @@ changes. Entries are sorted by token and contain:
 - `token`: the value accepted by `unwatch()`.
 - `kind`: `position` for `watchPosition()` or `heading` for `watchHeading()`.
 
-The snapshot covers the Modern API root import. It does not include Compat API
+The snapshot covers the main package import. It does not include Compat API
 watches, one-shot position or heading requests, or Background Location.
 Android watches that finish because of `maxUpdates` disappear from the next
 snapshot automatically. Web snapshots include active browser position watches;
@@ -44,7 +44,7 @@ unsupported web heading requests are not reported as active.
 
 - `unwatch(token)` removes a matching position or heading watch. Repeating it,
   or passing an unknown token, is safe and has no effect.
-- `stopObserving()` removes every Modern API position and heading watch,
+- `stopObserving()` removes every position and heading watch,
   including development-tool and browser watches. It does not cancel one-shot
   position requests or Background Location. On iOS it also leaves one-shot
   heading requests running. On Android, the current native heading manager

--- a/docs/docs/v2/guide/why-nitro-module.md
+++ b/docs/docs/v2/guide/why-nitro-module.md
@@ -40,7 +40,7 @@ User callback executed
 - Multiple listeners share one event stream
 - Requires JSON serialization on every update
 
-### Modern API: Direct Callback Architecture (`React Native Nitro Geolocation`)
+### Direct Callback Architecture (`React Native Nitro Geolocation`)
 
 ```
 JavaScript Layer
@@ -69,7 +69,7 @@ React Native Nitro Geolocation now provides a React-friendly layer on top of the
 User Code (React Components)
   ↓ useWatchPosition({ enabled: true })
   ↓ Declarative, auto-cleanup
-Modern API Layer (direct functions + hooks)
+Functions and hooks
   ↓ watchPosition(callback)
 JSI Layer (Nitro Modules)
   ↓ Direct callbacks, no Bridge
@@ -87,7 +87,7 @@ Device GPS/Network
 
 **Architecture Layers**:
 1. **Presentation** (Hooks): `useWatchPosition`
-2. **Modern API** (Functions): `getCurrentPosition`, `watchPosition`, `unwatch`
+2. **Functions and hooks**: `getCurrentPosition`, `watchPosition`, `unwatch`
 3. **JSI Bridge** (Nitro): Direct native communication
 4. **Native** (Platform): iOS/Android location APIs
 
@@ -120,10 +120,10 @@ Nitro Modules use **Nitrogen** code generation to create JSI bindings:
 `React Native Nitro Geolocation` transforms the geolocation API at multiple levels:
 
 1. **Low-level**: Bridge-based events → JSI direct callbacks (Nitro Modules)
-2. **High-level**: Imperative callbacks → Declarative hooks (Modern API)
+2. **High-level**: Imperative callbacks → Declarative hooks
 
 This provides:
 - **Performance**: Native-level speed via JSI
 - **Developer Experience**: React-friendly hooks with TanStack Query patterns
-- **Flexibility**: Choose Modern API (hooks) or Compat API (callbacks)
+- **Flexibility**: Choose direct functions and hooks or Compat callbacks
 - **Compatibility**: Preserves the core callback methods and numeric errors via `/compat`, with documented boundaries

--- a/docs/docs/v2/index.md
+++ b/docs/docs/v2/index.md
@@ -20,7 +20,7 @@ features:
   - title: Start a new integration
     details: 'Check the support boundary, add foreground-only permissions, and render your first coordinates. <a href="/v2/guide/quick-start.html">Install and get a location →</a>'
   - title: Replace community geolocation
-    details: 'Move foreground imports to the /compat surface first, verify the app, then adopt the Modern API at your pace. <a href="/v2/guide/community-migration.html">Open community migration →</a>'
+    details: 'Move foreground imports to the /compat surface first, verify the app, then adopt direct functions and hooks at your pace. <a href="/v2/guide/community-migration.html">Open community migration →</a>'
   - title: Upgrade from 1.x
     details: 'Review every 2.0 breaking change, apply the migration in gates, and keep a tested rollback path. <a href="/v2/guide/upgrade-from-v1.html">Open the upgrade checklist →</a>'
   - title: Add background location

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -39,7 +39,7 @@ This page documents a 2.x feature and is not part of the 1.x API snapshot.
 export default defineConfig({
   root: path.join(__dirname, "docs"),
   title: "React Native Nitro Geolocation",
-  description: "Nitro-powered native geolocation for modern React Native apps",
+  description: "Nitro-powered native geolocation for React Native apps",
   icon: "/logo.png",
   logo: "/logo.png",
   logoText: "React Native Nitro Geolocation",
@@ -68,7 +68,7 @@ export default defineConfig({
       "meta",
       {
         property: "og:description",
-        content: "Nitro-powered native geolocation for modern React Native apps"
+        content: "Nitro-powered native geolocation for React Native apps"
       }
     ],
     ["meta", { property: "og:image", content: "/logo.png" }],
@@ -82,7 +82,7 @@ export default defineConfig({
       "meta",
       {
         name: "twitter:description",
-        content: "Nitro-powered native geolocation for modern React Native apps"
+        content: "Nitro-powered native geolocation for React Native apps"
       }
     ],
     ["meta", { name: "twitter:image", content: "/logo.png" }]

--- a/docs/scripts/check-version-routes.mjs
+++ b/docs/scripts/check-version-routes.mjs
@@ -14,9 +14,9 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
 const isReleaseCandidate = /-rc\.\d+$/.test(packageJson.version);
 const requiredRoutes = [
   "index.html",
-  "guide/modern-api.html",
+  "guide/api.html",
   "v2/index.html",
-  "v2/guide/modern-api.html",
+  "v2/guide/api.html",
   "v2/guide/release-readiness.html",
   "v2/guide/swift-package-manager.html",
   "v2/guide/troubleshooting.html",
@@ -81,21 +81,18 @@ for (const href of requiredDecisionLinks) {
   }
 }
 
-const v2Modern = await readFile(
-  path.join(buildRoot, "v2/guide/modern-api.html"),
-  "utf8"
-);
+const v2Api = await readFile(path.join(buildRoot, "v2/guide/api.html"), "utf8");
 
-if (isReleaseCandidate && !v2Modern.includes(">2.0 RC<")) {
+if (isReleaseCandidate && !v2Api.includes(">2.0 RC<")) {
   throw new Error("A deep v2 page does not expose the persistent RC marker.");
 }
 
-if (!isReleaseCandidate && v2Modern.includes(">2.0 RC<")) {
+if (!isReleaseCandidate && v2Api.includes(">2.0 RC<")) {
   throw new Error("A stable 2.0 page still exposes the RC marker.");
 }
 
 if (
-  !v2Modern.includes('href="https://react-native-nitro-geolocation.pages.dev/"')
+  !v2Api.includes('href="https://react-native-nitro-geolocation.pages.dev/"')
 ) {
   throw new Error("A deep v2 page does not expose the stable 1.x docs link.");
 }

--- a/examples/v0.81.1/.maestro/README.md
+++ b/examples/v0.81.1/.maestro/README.md
@@ -138,10 +138,10 @@ When adding a flow:
 - Tests `geocode(address)` and `reverseGeocode(coords)` through native platform geocoders
 - Uses a specific Seoul address query and validates the returned coordinate candidate is near the Seoul fixture
 - Reverse geocodes deterministic Seoul fixture coordinates and verifies a readable address is returned
-- Verifies invalid inputs reject through the Modern API structured `INTERNAL_ERROR` contract
+- Verifies invalid inputs reject through the structured `INTERNAL_ERROR` contract
 
 ### `accuracy-presets.yaml`
-- Tests `accuracy.android` and `accuracy.ios` through real Modern API native requests
+- Tests `accuracy.android` and `accuracy.ios` through real native requests
 - Uses `setLocation` and the app verifies returned coordinates against the injected fixture, so the assertion is not a static option display
 - Checks preset override behavior with `enableHighAccuracy` set to the opposite boolean
 - Checks invalid preset rejection by crossing the Nitro native boundary with a deliberately unsupported preset
@@ -308,7 +308,7 @@ current simulator runtime; the physical-device false flow must be interpreted
 against the device OS and the returned sample.
 
 ### `api-errors.yaml`
-- Opens the API Errors screen and triggers real native Modern API errors.
+- Opens the API Errors screen and triggers real native API errors.
 - Uses the public screen buttons directly; the flow does not toggle devtools or inject JS-only errors.
 - Starts once with permissions denied and asserts the native `PERMISSION_DENIED` result rendered by the screen.
 - Starts again with permissions allowed, verifies a real position request, then forces a native `TIMEOUT` result and asserts its rendered `{ code, message }` shape.

--- a/examples/v0.81.1/.maestro/api-errors.yaml
+++ b/examples/v0.81.1/.maestro/api-errors.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# Modern API error contract: trigger real native errors, display their
+# API error contract: trigger real native errors, display their
 # structured { code, message } shape, then assert the rendered result.
 
 - launchApp:
@@ -46,7 +46,7 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Readable Modern API errors without numeric lookup tables"
+    visible: "Readable API errors without numeric lookup tables"
     timeout: 10000
 
 - tapOn:
@@ -102,7 +102,7 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Readable Modern API errors without numeric lookup tables"
+    visible: "Readable API errors without numeric lookup tables"
     timeout: 10000
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
+++ b/examples/v0.81.1/.maestro/mocked-metadata-android-true.yaml
@@ -4,7 +4,7 @@ appId: nitrogeolocation.example
 #
 # This flow verifies the mocked-location branch only. Maestro setLocation()
 # injects a test-provider location, so Android should expose mocked=true and
-# a native provider through the modern metadata response. Coordinate injection is
+# a native provider through the metadata response. Coordinate injection is
 # part of this true-case fixture.
 
 - launchApp:

--- a/examples/v0.81.1/.maestro/watch-manager-v2.yaml
+++ b/examples/v0.81.1/.maestro/watch-manager-v2.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# Proves that two natural Modern API consumers keep independent delivery
+# Proves that two API consumers keep independent delivery
 # thresholds and that removing one subscription leaves the other alive.
 
 - launchApp:

--- a/examples/v0.81.1/.maestro/watch-observability.yaml
+++ b/examples/v0.81.1/.maestro/watch-observability.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# Uses only the public Modern API to prove native watch snapshots and cleanup.
+# Uses only the public API to prove native watch snapshots and cleanup.
 
 - launchApp:
     clearState: true
@@ -29,7 +29,7 @@ appId: nitrogeolocation.example
 - waitForAnimationToEnd
 
 - extendedWaitUntil:
-    visible: "Inspect active Modern API position and heading watches"
+    visible: "Inspect active position and heading watches"
     timeout: 10000
 
 - tapOn:

--- a/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e-unavailable.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# Web Modern API provider-disabled contract through react-native-webview.
+# Web provider-disabled contract through react-native-webview.
 # Android runner disables device location before invoking this flow.
 
 - launchApp:

--- a/examples/v0.81.1/.maestro/web-e2e.yaml
+++ b/examples/v0.81.1/.maestro/web-e2e.yaml
@@ -1,6 +1,6 @@
 appId: nitrogeolocation.example
 ---
-# Web Modern API contract through react-native-webview.
+# Web API contract through react-native-webview.
 # Requires examples/web-e2e dev server on port 4173.
 
 - launchApp:

--- a/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
+++ b/examples/v0.81.1/src/screens/ApiErrorsScreen.tsx
@@ -33,7 +33,7 @@ const ERROR_CODE_CONTRACT = [
   {
     code: LocationErrorCodes.INTERNAL_ERROR,
     name: getLocationErrorCodeName(LocationErrorCodes.INTERNAL_ERROR),
-    meaning: "Modern-only internal/native failure"
+    meaning: "Internal/native failure"
   },
   {
     code: LocationErrorCodes.PERMISSION_DENIED,
@@ -55,12 +55,12 @@ const ERROR_CODE_CONTRACT = [
     name: getLocationErrorCodeName(
       LocationErrorCodes.PLAY_SERVICE_NOT_AVAILABLE
     ),
-    meaning: "Modern-only Google Play Services failure"
+    meaning: "Google Play Services failure"
   },
   {
     code: LocationErrorCodes.SETTINGS_NOT_SATISFIED,
     name: getLocationErrorCodeName(LocationErrorCodes.SETTINGS_NOT_SATISFIED),
-    meaning: "Modern-only provider/settings failure"
+    meaning: "Provider/settings failure"
   }
 ] as const;
 
@@ -128,7 +128,7 @@ export default function ApiErrorsScreen() {
     <ScenarioScreen
       prefix="api-errors"
       title="API Errors"
-      subtitle="Readable Modern API errors without numeric lookup tables"
+      subtitle="Readable API errors without numeric lookup tables"
     >
       <ScenarioSection
         index={1}
@@ -166,7 +166,7 @@ export default function ApiErrorsScreen() {
       <ScenarioSection
         index={2}
         title="Position Request"
-        description="Fetch a current position through the native Modern API path."
+        description="Fetch a current position through the native API path."
         divided
       >
         <ScenarioButton
@@ -192,7 +192,7 @@ export default function ApiErrorsScreen() {
       <ScenarioSection
         index={3}
         title="Error Handling"
-        description="Trigger a native timeout edge case and compare its string code with the Modern API contract below."
+        description="Trigger a native timeout edge case and compare its string code with the API contract below."
         divided
       >
         <ScenarioButton

--- a/examples/v0.81.1/src/screens/DefaultScreen.tsx
+++ b/examples/v0.81.1/src/screens/DefaultScreen.tsx
@@ -44,7 +44,7 @@ const defaultSections: DefaultScreenSection[] = [
 export default function DefaultScreen({
   nativeGeolocation = false,
   sections = defaultSections,
-  subtitle = "Root API",
+  subtitle = "API",
   title = "Geolocation API"
 }: DefaultScreenProps) {
   // Permission state

--- a/examples/v0.81.1/src/screens/GeocodingScreen.tsx
+++ b/examples/v0.81.1/src/screens/GeocodingScreen.tsx
@@ -225,7 +225,7 @@ export default function GeocodingScreen() {
       <ScenarioSection
         index={2}
         title="Negative Scenarios"
-        description="Invalid user input should reject with the Modern API structured error contract instead of rendering a synthetic pass state."
+        description="Invalid user input should reject with the structured API error contract instead of rendering a synthetic pass state."
         divided
       >
         <ScenarioButton

--- a/examples/v0.81.1/src/screens/WatchObservabilityScreen.tsx
+++ b/examples/v0.81.1/src/screens/WatchObservabilityScreen.tsx
@@ -59,7 +59,7 @@ export default function WatchObservabilityScreen() {
       status: snapshot.length === 0 ? "passed" : "failed",
       message:
         snapshot.length === 0
-          ? "No Modern API watches are active."
+          ? "No watches are active."
           : `Found ${snapshot.length} active watch(es).`
     });
   };
@@ -180,7 +180,7 @@ export default function WatchObservabilityScreen() {
       status: snapshot.length === 0 ? "passed" : "failed",
       message:
         snapshot.length === 0
-          ? "stopObserving removed every Modern API watch."
+          ? "stopObserving removed every API watch."
           : `${snapshot.length} watch(es) remained after stopObserving.`
     });
   };
@@ -194,7 +194,7 @@ export default function WatchObservabilityScreen() {
     <ScenarioScreen
       prefix={PREFIX}
       title="Watch Observability"
-      subtitle="Inspect active Modern API position and heading watches"
+      subtitle="Inspect active position and heading watches"
     >
       <ScenarioSection index={1} title="Snapshot">
         <ScenarioButton

--- a/examples/v0.81.1/src/screens/scenario/types.ts
+++ b/examples/v0.81.1/src/screens/scenario/types.ts
@@ -47,14 +47,14 @@ export type ScenarioResult = {
  * };
  * ```
  *
- * @property {LocationErrorCode} code - Modern API string error code, or
+ * @property {LocationErrorCode} code - API string error code, or
  * `internalError` when a caught value does not expose a known code.
  * @property {string} name - Human-readable name for `code`.
  * @property {string} message - Error message captured from the native
  * exception.
  */
 export type CapturedLocationError = {
-  /** Modern API string `LocationErrorCode`, or `internalError` fallback. */
+  /** API string `LocationErrorCode`, or `internalError` fallback. */
   code: LocationErrorCode;
   /** Human-readable name for `code`. */
   name: string;

--- a/examples/v0.81.1/src/type-contracts/integrity-metadata.ts
+++ b/examples/v0.81.1/src/type-contracts/integrity-metadata.ts
@@ -14,7 +14,7 @@ const coords = {
   speed: null
 };
 
-const modernPosition: GeolocationResponse = {
+const position: GeolocationResponse = {
   coords,
   timestamp: 1779015190000,
   mocked: true,
@@ -31,7 +31,7 @@ const providers: LocationProviderUsed[] = [
 
 const compatPosition: CompatGeolocationResponse = {
   coords,
-  timestamp: modernPosition.timestamp
+  timestamp: position.timestamp
 };
 
 // @ts-expect-error Compat keeps the community response shape.
@@ -39,7 +39,7 @@ void compatPosition.mocked;
 // @ts-expect-error Compat keeps the community response shape.
 void compatPosition.provider;
 
-// @ts-expect-error Modern providers are a closed native-provider union.
+// @ts-expect-error Providers are a closed native-provider union.
 providers.push("bluetooth");
 
-void [modernPosition, providers, compatPosition];
+void [position, providers, compatPosition];

--- a/examples/v0.81.1/src/type-contracts/v2.ts
+++ b/examples/v0.81.1/src/type-contracts/v2.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error v2 removes the duplicate Modern configuration alias.
-import type { ModernGeolocationConfiguration } from "react-native-nitro-geolocation";
 import type {
   LocationReadiness,
   LocationReadinessRemediation,
@@ -17,15 +15,13 @@ import {
 } from "react-native-nitro-geolocation";
 import type { GeolocationOptions as CompatGeolocationOptions } from "react-native-nitro-geolocation/compat";
 
-void (undefined as unknown as ModernGeolocationConfiguration);
-
-const modernRequest: LocationRequestOptions = {
-  // @ts-expect-error v2 Modern callers choose an explicit accuracy preset.
+const request: LocationRequestOptions = {
+  // @ts-expect-error v2 callers choose an explicit accuracy preset.
   enableHighAccuracy: true
 };
 
-const modernSettings: LocationSettingsOptions = {
-  // @ts-expect-error v2 Modern settings use accuracy.android.
+const settings: LocationSettingsOptions = {
+  // @ts-expect-error v2 settings use accuracy.android.
   enableHighAccuracy: true
 };
 
@@ -58,8 +54,8 @@ selectProvider("high", true, true);
 selectProvider(true, true, true);
 
 void [
-  modernRequest,
-  modernSettings,
+  request,
+  settings,
   settingsResultPromise,
   detailedSettingsResultPromise,
   settingsOutcome,

--- a/examples/web-e2e/index.html
+++ b/examples/web-e2e/index.html
@@ -10,7 +10,7 @@
       <header>
         <h1>Nitro Geolocation Web E2E</h1>
         <p>
-          Modern API browser adapter contract with real
+          Browser adapter contract with real
           navigator.geolocation calls.
         </p>
       </header>

--- a/examples/web-e2e/src/apiAssertions.ts
+++ b/examples/web-e2e/src/apiAssertions.ts
@@ -14,7 +14,7 @@ import {
 } from "react-native-nitro-geolocation";
 import { setScenario } from "./dom";
 
-export function assertModernApiAvailability() {
+export function assertApiAvailability() {
   const apiShape = {
     checkPermission: typeof checkPermission,
     getPermissionDetails: typeof getPermissionDetails,
@@ -31,7 +31,7 @@ export function assertModernApiAvailability() {
   const apiReady = Object.values(apiShape).every((type) => type === "function");
   setScenario("api-availability", apiReady ? "pass" : "fail", apiShape);
   if (!apiReady) {
-    throw new Error("Modern API browser export is incomplete.");
+    throw new Error("Browser API export is incomplete.");
   }
 }
 

--- a/examples/web-e2e/src/locationAssertions.ts
+++ b/examples/web-e2e/src/locationAssertions.ts
@@ -43,7 +43,7 @@ export function assertLocationMetadata(
 ) {
   const metadata = position.metadata;
   if (!metadata) {
-    throw new Error("Modern position missing location metadata.");
+    throw new Error("Position missing location metadata.");
   }
   if (metadata.source !== expectedSource) {
     throw new Error(
@@ -55,18 +55,16 @@ export function assertLocationMetadata(
     !Number.isFinite(metadata.age) ||
     metadata.age < 0
   ) {
-    throw new Error(`Modern position has invalid age: ${metadata.age}.`);
+    throw new Error(`Position has invalid age: ${metadata.age}.`);
   }
   if (
     !(["high", "medium", "low", "unknown"] as const).includes(metadata.quality)
   ) {
-    throw new Error(
-      `Modern position has invalid quality: ${metadata.quality}.`
-    );
+    throw new Error(`Position has invalid quality: ${metadata.quality}.`);
   }
 }
 
-export function assertModernPosition(
+export function assertPositionWithMetadata(
   position: GeolocationResponse,
   source: NonNullable<GeolocationResponse["metadata"]>["source"]
 ) {

--- a/examples/web-e2e/src/runner.ts
+++ b/examples/web-e2e/src/runner.ts
@@ -15,7 +15,7 @@ import {
   watchPosition
 } from "react-native-nitro-geolocation";
 import {
-  assertModernApiAvailability,
+  assertApiAvailability,
   expectSatisfiedLocationSettings
 } from "./apiAssertions";
 import {
@@ -34,7 +34,7 @@ import {
 } from "./lastKnownAssertions";
 import {
   type ExpectedLocation,
-  assertModernPosition,
+  assertPositionWithMetadata,
   expectedLocations,
   getErrorCode,
   isNearExpected
@@ -216,7 +216,7 @@ async function getCurrentPositionUntilExpected({
 
 export async function runSuccessSuite() {
   setScenario("api-availability", "running");
-  assertModernApiAvailability();
+  assertApiAvailability();
 
   runCompatApiAvailabilityCheck();
 
@@ -293,7 +293,7 @@ export async function runSuccessSuite() {
         timeoutMs: 30000
       });
     },
-    (result) => assertModernPosition(result.position, "currentPosition")
+    (result) => assertPositionWithMetadata(result.position, "currentPosition")
   );
 
   await runStep(
@@ -309,7 +309,7 @@ export async function runSuccessSuite() {
       expectLatestCachedPosition(
         cached,
         position.position.timestamp,
-        (cached) => assertModernPosition(cached, "moduleCache")
+        (cached) => assertPositionWithMetadata(cached, "moduleCache")
       )
   );
 
@@ -320,7 +320,7 @@ export async function runSuccessSuite() {
       expectValidCachedPosition(
         cached,
         "Async browser module cache did not return a position.",
-        (cached) => assertModernPosition(cached, "moduleCache")
+        (cached) => assertPositionWithMetadata(cached, "moduleCache")
       )
   );
 
@@ -353,7 +353,7 @@ export async function runSuccessSuite() {
         }
       });
     },
-    (result) => assertModernPosition(result.position, "watchPosition")
+    (result) => assertPositionWithMetadata(result.position, "watchPosition")
   );
 
   await runStep(

--- a/examples/web-e2e/src/scenarios.ts
+++ b/examples/web-e2e/src/scenarios.ts
@@ -38,7 +38,7 @@ export const scenarios: Scenario[] = [
   {
     id: "api-availability",
     title: "API availability",
-    detail: "Root browser export exposes Modern API functions.",
+    detail: "The browser export exposes the API functions.",
     status: "idle"
   },
   {
@@ -100,8 +100,7 @@ export const scenarios: Scenario[] = [
   {
     id: "last-known-cold-cache",
     title: "getLastKnownPosition cold cache",
-    detail:
-      "Sync read returns undefined before any Modern position is observed.",
+    detail: "Sync read returns undefined before any position is observed.",
     status: "idle"
   },
   {

--- a/packages/react-native-nitro-geolocation/CHANGELOG.md
+++ b/packages/react-native-nitro-geolocation/CHANGELOG.md
@@ -51,18 +51,18 @@
 
 ### Major Changes
 
-- 8bbd6de: Replace Modern API numeric location error codes with readable string discriminants while preserving numeric W3C codes under `/compat`.
-- cbb4d17: Remove the deprecated `ModernGeolocationConfiguration` alias. Use
-  `GeolocationConfiguration` for the root modern API instead.
+- 8bbd6de: Replace API numeric location error codes with readable string discriminants while preserving numeric W3C codes under `/compat`.
+- cbb4d17: Remove the deprecated duplicate configuration alias. Use
+  `GeolocationConfiguration` instead.
 - 65e100e: Make Watch Manager v2 delivery semantics the default: native acquisition stays
-  shared, while each Modern API watch independently enforces its own callback
+  shared, while each watch independently enforces its own callback
   thresholds and cleanup lifecycle.
 - 189a661: Split last-known position reads into synchronous module-cache and asynchronous
   platform-cache APIs. `getLastKnownPosition()` now returns the module cache
   immediately, while `getLastKnownPositionAsync(options)` queries cache-only native
   sources or filters observed Web and DevTools caches without starting a fresh
   location request.
-- 3a54d84: Remove `enableHighAccuracy` from the Modern API. Modern requests and Android
+- 3a54d84: Remove `enableHighAccuracy` from the API. Requests and Android
   settings now use explicit platform `accuracy` presets, while the `/compat`
   entry point retains `enableHighAccuracy` for drop-in compatibility.
 - c03b5ac: Route provider status and iOS location lifecycle changes through the unified
@@ -81,13 +81,13 @@
 - 7b6f4dc: Add `requestLocationSettingsDetailed()` as the explicit detailed-result API for
   Android settings resolution while preserving the v2 deterministic method.
 - 4c24ecb: Add a read-only `getPermissionDetails()` API for normalized permission scope, accuracy, prompt capability, and settings guidance across native and Web.
-- 0b2ee95: Add request-scoped `AbortSignal` cancellation to the Modern API `getCurrentPosition()` call on Android, iOS, and web.
+- 0b2ee95: Add request-scoped `AbortSignal` cancellation to `getCurrentPosition()` on Android, iOS, and web.
 - a56f54f: Add per-call opt-in mock and provider metadata to the Compat API without changing its default response shape.
-- 292d12b: Add optional Modern response metadata for delivery source, age, horizontal
+- 292d12b: Add optional response metadata for delivery source, age, horizontal
   accuracy quality, and stale reasons without changing location acceptance
   policy.
 - 791353b: Add native background reliability timestamps, run- and config-generation-aware serialized HTTP sync with bounded burst coalescing and automatic batch draining, long-run assertions, and a foreground/background/termination/reboot verification contract.
-- fe9521a: Add active Modern API watch snapshots and document native merge and cleanup semantics.
+- fe9521a: Add active watch snapshots and document native merge and cleanup semantics.
 - 91c342e: Add a read-only `getLocationReadiness()` diagnosis API with permission, provider, services, availability, cache, Play Services state, and remediation codes.
 - 8463f74: Add a cancellable provider status watcher that emits an initial snapshot and distinct readiness changes.
 - 441fb48: Add an iOS Core Location pause and app-triggered resume lifecycle listener.
@@ -168,7 +168,7 @@
 
 - 8216b3d: Add Compat API web support through a browser conditional export backed by `navigator.geolocation`.
 - 104417c: Prefer Google Play Services fused location for Android `auto` and `playServices` provider configuration, with Android platform provider fallback when fused location is unavailable or cannot start. Keep explicit `android` provider configuration on the platform `LocationManager` path.
-- 16681aa: Add Modern API web support through a browser conditional export backed by `navigator.geolocation`.
+- 16681aa: Add web support to the package entry point through a browser conditional export backed by `navigator.geolocation`.
 - b90c38b: Add a dedicated `./background` API with native-storage-backed background location tracking, geofencing, activity recognition events, Headless JS delivery, HTTP sync, documentation, and E2E examples.
 
 ### Patch Changes
@@ -218,24 +218,24 @@
 ### Patch Changes
 
 - 043e788: Clarify that Android `locationProvider: "auto"` currently uses the platform `LocationManager` by default, while `playServices` explicitly opts into Google Play Services fused location.
-- 3842d7a: Add an Agent Skills-compatible Modern API migration playbook with a package-manager-aware compat bootstrap script for migrations from legacy geolocation APIs.
+- 3842d7a: Add an Agent Skills-compatible API migration playbook with a package-manager-aware compat bootstrap script for migrations from legacy geolocation APIs.
 
 ## 1.2.0
 
 ### Minor Changes
 
-- efc25f1: Add platform-specific accuracy presets to the Modern API while preserving `enableHighAccuracy`.
+- efc25f1: Add platform-specific accuracy presets to the API while preserving `enableHighAccuracy`.
   Android now supports `high`, `balanced`, `low`, and `passive` presets, and iOS supports Core Location accuracy presets including `bestForNavigation`, `nearestTenMeters`, and `reduced`.
-  `enableHighAccuracy` is now deprecated for the Modern API in favor of explicit accuracy presets.
-- 93c2ce2: Add Android provider/settings APIs to the Modern API: `hasServicesEnabled()`, `getProviderStatus()`, and `requestLocationSettings(options?)`. Android now checks native provider state and uses Google Play Services `SettingsClient` to show the system settings resolution dialog when high-accuracy location requirements are not satisfied.
-- d54aa44: Add optional `mocked` and `provider` metadata to root location responses with Android and iOS native mappings.
-  Add `GeolocationConfiguration` as the preferred root API configuration type while preserving `ModernGeolocationConfiguration` as a deprecated compatibility alias.
+  `enableHighAccuracy` is now deprecated for the API in favor of explicit accuracy presets.
+- 93c2ce2: Add Android provider/settings APIs: `hasServicesEnabled()`, `getProviderStatus()`, and `requestLocationSettings(options?)`. Android now checks native provider state and uses Google Play Services `SettingsClient` to show the system settings resolution dialog when high-accuracy location requirements are not satisfied.
+- d54aa44: Add optional `mocked` and `provider` metadata to location responses with Android and iOS native mappings.
+  Add `GeolocationConfiguration` as the preferred API configuration type while preserving a deprecated compatibility alias.
   Keep the Compat API response shape unchanged for the drop-in replacement contract.
   Normalize missing native coordinate values to explicit `null` unions and include the same metadata in Rozenite DevTools mock responses.
-- 5bd6b3e: Add `geocode(address)` and `reverseGeocode(coords)` to the Modern API, backed by Android `Geocoder` and iOS `CLGeocoder` in the same package.
+- 5bd6b3e: Add `geocode(address)` and `reverseGeocode(coords)`, backed by Android `Geocoder` and iOS `CLGeocoder` in the same package.
 - cca38f3: Add explicit cached-position access with `getLastKnownPosition(options?)`, iOS location tuning options, and precise/reduced accuracy authorization APIs.
 - 48e70a6: Add `getLocationAvailability()`, heading APIs (`getHeading()` and `watchHeading()`), and selected Android request controls for granularity, accurate initial updates, update age/delay, and maximum watch updates.
-- b5efa00: Extend the Modern API location error contract with `INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and `SETTINGS_NOT_SATISFIED`. Native code now sends structured `{ code, message }` error classification directly to both callbacks and public Promise rejections, while preserving the `/compat` legacy error shape.
+- b5efa00: Extend the location error contract with `INTERNAL_ERROR`, `PLAY_SERVICE_NOT_AVAILABLE`, and `SETTINGS_NOT_SATISFIED`. Native code now sends structured `{ code, message }` error classification directly to both callbacks and public Promise rejections, while preserving the `/compat` callback error shape.
 - a27ca39: Avoid blocking the UI thread when Android resolves provider status after a successful location settings request by checking Google Location Accuracy asynchronously.
 
 ### Patch Changes
@@ -314,7 +314,7 @@
 ### Minor Changes
 
 - 4691c54: feat: version update for nitro-modules (0.29.6 -> 0.32.0)
-- 52ae0d1: feat: modern style API
+- 52ae0d1: feat: functional API
 - f20e92f: docs: update
 - a628093: chore: type alias variant_nulltype_double
 - db27c99: feat: origin method to compat(drop in)

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://img.shields.io/npm/v/react-native-nitro-geolocation)](https://www.npmjs.com/package/react-native-nitro-geolocation)
 
-**Nitro-powered geolocation for modern React Native apps**
+**Nitro-powered geolocation for React Native apps**
 
 > **2.0 release candidate:** this README documents RC contracts. Install with
 > `react-native-nitro-geolocation@rc` and use the
@@ -13,9 +13,9 @@
 A native iOS/Android geolocation module for React Native 0.75+ apps using the
 New Architecture and Nitro Modules. Start by replacing
 [`@react-native-community/geolocation`](https://github.com/michalchudziak/react-native-geolocation)
-with `/compat`, then move to a typed Modern API when you are ready.
-The current release line adds web support for Modern and `/compat` foreground
-geolocation plus a native Background Location API for tracking, geofencing,
+with `/compat`, then move to the typed API when you are ready.
+The current release line adds foreground web support through both the package
+import and `/compat`, plus a native Background Location API for tracking, geofencing,
 storage recovery, Headless JS, and HTTP sync.
 
 - 🎯 **Simple functional API** — Direct function calls, no complex abstractions
@@ -45,10 +45,10 @@ storage recovery, Headless JS, and HTTP sync.
 | New Architecture / Nitro-based app | Recommended |
 | Expo development build or custom native build | Supported with native setup |
 | Expo managed app without native rebuild | Use `expo-location` |
-| Web support required | Use the Modern API root import or `/compat` callback API |
+| Web support required | Use the package import or `/compat` callback API |
 | Full background tracking / geofencing | Use `react-native-nitro-geolocation/background` |
 
-Web support is available for the Modern API root import and the `/compat`
+Web support is available for the package import and the `/compat`
 subpath. Browser builds resolve both entries to implementations backed by
 `navigator.geolocation` and do not load Nitro native bindings. Background
 location remains native-only.
@@ -60,7 +60,7 @@ location remains native-only.
 React Native Nitro Geolocation provides **three public API surfaces** to fit
 your needs:
 
-### 1. Modern API (Recommended)
+### 1. API (Recommended)
 
 **Simple functional API** with direct calls and a single hook for tracking:
 
@@ -88,13 +88,13 @@ if (status === "granted") {
 }
 ```
 
-Modern foreground responses include optional observational metadata for the
+Foreground responses include optional observational metadata for the
 delivery source, age, horizontal-accuracy quality band, and stale reason. This
 metadata never causes the library to reject a stale or low-accuracy position;
 applications can apply their own policy. The `/compat` response shape is
 unchanged.
 
-See the [Modern API guide](https://react-native-nitro-geolocation.pages.dev/v2/guide/modern-api)
+See the [API guide](https://react-native-nitro-geolocation.pages.dev/v2/guide/api)
 for watches, geocoding, heading, cached reads, Android settings, and iOS
 accuracy authorization.
 
@@ -233,7 +233,7 @@ states, continue to [Install and get a location](https://react-native-nitro-geol
 ### 2. DevTools Plugin
 
 Use the Rozenite DevTools plugin to mock locations during development with an
-interactive map. It works with the Modern API root import.
+interactive map. It works with the package import.
 
 ![DevTools Plugin Demo](https://raw.githubusercontent.com/jingjing2222/react-native-nitro-geolocation/main/devtools.gif)
 
@@ -269,7 +269,7 @@ Use the docs site for the detailed flows:
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/v2/guide/quick-start) - install with minimum foreground permissions and render coordinates.
 - [Upgrade from 1.x](https://react-native-nitro-geolocation.pages.dev/v2/guide/upgrade-from-v1) - migrate all seven breaking contracts with rollback gates.
 - [Release Readiness](https://react-native-nitro-geolocation.pages.dev/v2/guide/release-readiness) - RC policy, tested reference stack, known limits, and ship checklist.
-- [Modern API](https://react-native-nitro-geolocation.pages.dev/v2/guide/modern-api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
+- [API](https://react-native-nitro-geolocation.pages.dev/v2/guide/api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/v2/guide/compat-api) - callback compatibility and documented boundaries.
 - [Background Location](https://react-native-nitro-geolocation.pages.dev/v2/background/overview) - native background setup, platform limits, tracking, recovery, and diagnosis.
 - [Troubleshooting](https://react-native-nitro-geolocation.pages.dev/v2/guide/troubleshooting) - collect readiness evidence and open a useful support report.

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidCurrentPositionManager.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/AndroidCurrentPositionManager.kt
@@ -71,14 +71,14 @@ internal class AndroidCurrentPositionManager(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             effectiveMaximumAge(request.options) > 0.0
         ) {
-            requestCurrentLocationModern(
+            requestViaGetCurrentLocation(
                 provider,
                 requestId,
                 request.handler,
                 remainingTimeoutMillis
             )
         } else {
-            requestCurrentLocationLegacy(
+            requestViaLocationUpdates(
                 provider,
                 requestId,
                 request.handler,
@@ -88,7 +88,7 @@ internal class AndroidCurrentPositionManager(
     }
 
     @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
-    private fun requestCurrentLocationModern(
+    private fun requestViaGetCurrentLocation(
         provider: String,
         requestId: String,
         handler: Handler,
@@ -111,7 +111,7 @@ internal class AndroidCurrentPositionManager(
                             pendingRequests.remove(requestId)
                             request.resolver(PositionResult.Success(locationToPosition(location)))
                         }
-                        location != null -> retryCurrentLocationLegacyAfterStaleModern(
+                        location != null -> retryViaLocationUpdatesAfterStaleGetCurrentLocation(
                             provider,
                             requestId,
                             handler,
@@ -146,7 +146,7 @@ internal class AndroidCurrentPositionManager(
         }
     }
 
-    private fun retryCurrentLocationLegacyAfterStaleModern(
+    private fun retryViaLocationUpdatesAfterStaleGetCurrentLocation(
         provider: String,
         requestId: String,
         handler: Handler,
@@ -159,10 +159,10 @@ internal class AndroidCurrentPositionManager(
             handlePositionTimeout(requestId)
             return
         }
-        requestCurrentLocationLegacy(provider, requestId, handler, remainingTimeoutMillis)
+        requestViaLocationUpdates(provider, requestId, handler, remainingTimeoutMillis)
     }
 
-    private fun requestCurrentLocationLegacy(
+    private fun requestViaLocationUpdates(
         provider: String,
         requestId: String,
         handler: Handler,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/GetCurrentPosition.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/GetCurrentPosition.kt
@@ -147,7 +147,7 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
     ) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             // Android 11+ supports getCurrentLocation
-            requestCurrentLocationModern(
+            requestViaGetCurrentLocation(
                     locationManager,
                     provider,
                     options,
@@ -157,7 +157,7 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
             )
         } else {
             // Fallback to requestLocationUpdates
-            requestCurrentLocationLegacy(
+            requestViaLocationUpdates(
                     locationManager,
                     provider,
                     options,
@@ -169,7 +169,7 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
     }
 
     @androidx.annotation.RequiresApi(android.os.Build.VERSION_CODES.R)
-    private fun requestCurrentLocationModern(
+    private fun requestViaGetCurrentLocation(
             locationManager: LocationManager,
             provider: String,
             options: ParsedOptions,
@@ -218,7 +218,7 @@ class GetCurrentPosition(private val reactContext: ReactApplicationContext) {
         }
     }
 
-    private fun requestCurrentLocationLegacy(
+    private fun requestViaLocationUpdates(
             locationManager: LocationManager,
             provider: String,
             options: ParsedOptions,

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/NitroGeolocation.kt
@@ -589,7 +589,7 @@ class NitroGeolocation(
     // MARK: - Helper Functions - Permission
 
     private fun getCurrentPermissionStatus(): PermissionStatus {
-        // Legacy Android (< 6.0)
+        // Android < 6.0 uses install-time permission grants.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return PermissionStatus.GRANTED
         }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/RequestAuthorization.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/RequestAuthorization.kt
@@ -11,7 +11,7 @@ import com.facebook.react.modules.core.PermissionListener
 
 // ===== Data Models =====
 sealed class PermissionState {
-    object LegacyAndroid : PermissionState()
+    object PreRuntimePermissions : PermissionState()
     object AlreadyGranted : PermissionState()
     object NeedsRequest : PermissionState()
     data class Error(val message: String) : PermissionState()
@@ -38,11 +38,11 @@ class RequestAuthorization(
     // ===== State Determination (Pure Functions) =====
     private fun determinePermissionState(): PermissionState =
             when {
-                isLegacyAndroid() -> PermissionState.LegacyAndroid
-                else -> determineModernAndroidState()
+                usesInstallTimePermissions() -> PermissionState.PreRuntimePermissions
+                else -> determineRuntimePermissionState()
             }
 
-    private fun determineModernAndroidState(): PermissionState =
+    private fun determineRuntimePermissionState(): PermissionState =
             when {
                 hasLocationPermission(reactContext) -> PermissionState.AlreadyGranted
                 reactContext.currentActivity == null ->
@@ -50,7 +50,8 @@ class RequestAuthorization(
                 else -> PermissionState.NeedsRequest
             }
 
-    private fun isLegacyAndroid(): Boolean = Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+    private fun usesInstallTimePermissions(): Boolean =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.M
 
     private fun hasLocationPermission(context: ReactApplicationContext): Boolean =
             LOCATION_PERMISSIONS.any { permission ->
@@ -84,7 +85,7 @@ class RequestAuthorization(
             error: ((error: CompatGeolocationError) -> Unit)?
     ) {
         when (state) {
-            is PermissionState.LegacyAndroid -> success?.invoke()
+            is PermissionState.PreRuntimePermissions -> success?.invoke()
             is PermissionState.AlreadyGranted -> success?.invoke()
             is PermissionState.NeedsRequest -> showPermissionDialog(success, error)
             is PermissionState.Error -> error?.invoke(createPermissionError(state.message))

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/LocationErrorCodePersistenceTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/LocationErrorCodePersistenceTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class LocationErrorCodePersistenceTest {
     @Test
-    fun `round trips every modern location error code`() {
+    fun `round trips every string location error code`() {
         LocationErrorCode.entries.forEach { code ->
             assertEquals(code, locationErrorCodeFromWireValue(locationErrorCodeToWireValue(code)))
         }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -3,7 +3,7 @@ import CoreLocation
 import NitroModules
 
 /**
- * Geolocation implementation for the native Modern API contract.
+ * Geolocation implementation for the native API contract.
  *
  * Key features:
  * - Callback-based native permission and getCurrentPosition for structured errors

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-nitro-geolocation",
   "version": "2.0.0-rc.4",
-  "description": "Nitro-powered native geolocation for modern React Native apps",
+  "description": "Nitro-powered native geolocation for React Native apps",
   "main": "src/index",
   "source": "src/index",
   "browser": "src/index.web.tsx",

--- a/packages/react-native-nitro-geolocation/src/api/getActiveWatches.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getActiveWatches.ts
@@ -4,7 +4,7 @@ import type { ActiveWatch } from "../publicTypes";
 import { readActiveWatches } from "./activeWatchSnapshot";
 
 /**
- * Return a point-in-time snapshot of active Modern API watches.
+ * Return a point-in-time snapshot of active position and heading watches.
  *
  * The snapshot includes both position and heading watches. Pass a returned
  * token to unwatch(), or call stopObserving() to remove every active watch.

--- a/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getLastKnownPosition.ts
@@ -13,8 +13,8 @@ import { readLastKnownPosition, rememberPosition } from "./positionCache";
  * Return the latest position observed by this JavaScript module.
  *
  * This synchronous read never calls a native or browser location source.
- * It returns `undefined` until a Modern current, watch, or async cache call
- * observes a position.
+ * It returns `undefined` until `getCurrentPosition()`, `watchPosition()`, or
+ * `getLastKnownPositionAsync()` observes a position.
  */
 export function getLastKnownPosition(): GeolocationResponse | undefined {
   return readLastKnownPosition();

--- a/packages/react-native-nitro-geolocation/src/api/setConfiguration.ts
+++ b/packages/react-native-nitro-geolocation/src/api/setConfiguration.ts
@@ -11,7 +11,7 @@ type NitroGeolocationConfiguration = Parameters<
 
 let configuredLocationProvider: LocationProvider | undefined;
 
-/** @internal Current Modern API provider preference for JS-level diagnosis. */
+/** @internal Current provider preference for JS-level diagnosis. */
 export function getConfiguredLocationProvider(): LocationProvider | undefined {
   return configuredLocationProvider;
 }

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -21,7 +21,7 @@ import type {
 
 // Keep the `/background` entry point self-contained: consumers should be able
 // to import every named type referenced by its public options, status, and
-// event contracts without reaching through the package root.
+// event contracts without reaching through the main package entry point.
 export type {
   AccuracyAuthorization,
   AndroidAccuracyPreset,

--- a/packages/react-native-nitro-geolocation/src/doctor.test.ts
+++ b/packages/react-native-nitro-geolocation/src/doctor.test.ts
@@ -598,7 +598,7 @@ describe("nitro-geolocation doctor", () => {
     );
   });
 
-  it("does not infer New Architecture from a modern React Native version", () => {
+  it("does not infer New Architecture from a recent React Native version", () => {
     const project = createProject({ newArchitecture: "absent" });
     projects.push(project);
 

--- a/packages/react-native-nitro-geolocation/src/index.web.tsx
+++ b/packages/react-native-nitro-geolocation/src/index.web.tsx
@@ -1,8 +1,8 @@
 /**
- * Browser implementation for the Modern API.
+ * Browser implementation for the main package entry point.
  *
  * This entry intentionally avoids Nitro native imports so web bundlers can use
- * the package root without loading native bindings.
+ * the main package entry point without loading native bindings.
  */
 
 export * from "./web";

--- a/packages/react-native-nitro-geolocation/src/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/publicTypes.ts
@@ -26,7 +26,7 @@ import type {
   ReverseGeocodedAddress as SchemaReverseGeocodedAddress
 } from "./types";
 
-/** API path that delivered a Modern location response. */
+/** API path that delivered a location response. */
 export type LocationResponseSource =
   | "currentPosition"
   | "watchPosition"
@@ -231,8 +231,8 @@ export interface CompatGeolocationConfiguration {
   /**
    * Android location provider compatibility option.
    *
-   * Preserved for the legacy `/compat` configuration surface. Use the Modern
-   * API root import when you need Android fused/provider selection.
+   * Preserved for the `/compat` configuration surface. Use
+   * `setConfiguration()` when you need Android fused/provider selection.
    */
   locationProvider?: LocationProvider;
 }

--- a/packages/react-native-nitro-geolocation/src/utils/errors.test.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/errors.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./errors";
 
 describe("LocationErrorCodes", () => {
-  it("uses readable, platform-independent Modern API codes", () => {
+  it("uses readable, platform-independent string codes", () => {
     expect(LocationErrorCodes.INTERNAL_ERROR).toBe("internalError");
     expect(LocationErrorCodes.PERMISSION_DENIED).toBe("permissionDenied");
     expect(LocationErrorCodes.POSITION_UNAVAILABLE).toBe("positionUnavailable");

--- a/packages/react-native-nitro-geolocation/src/utils/errors.ts
+++ b/packages/react-native-nitro-geolocation/src/utils/errors.ts
@@ -6,11 +6,11 @@ import type {
 export type LocationErrorCode = SchemaLocationErrorCode;
 
 /**
- * Readable Modern API error codes.
+ * Readable location error codes.
  *
- * `/compat` keeps the W3C numeric codes. The Modern API uses these string
- * discriminants so logs and serialized errors remain meaningful without a
- * numeric lookup table.
+ * `/compat` keeps the W3C numeric codes. The main package entry point uses
+ * these string discriminants so logs and serialized errors remain meaningful
+ * without a numeric lookup table.
  */
 export const LocationErrorCodes = {
   /** Unexpected module/native failure */
@@ -48,7 +48,7 @@ const locationErrorCodeNames: Record<LocationErrorCode, string> = {
 /**
  * Creates a standardized LocationError object.
  *
- * @param code - A Modern API location error code
+ * @param code - A location error code
  * @param message - A human-readable error message
  * @returns A LocationError object
  *

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -63,7 +63,7 @@ afterEach(() => {
   Reflect.deleteProperty(globalThis, "navigator");
 });
 
-describe("web Modern API", () => {
+describe("web API", () => {
   it("uses a stable availability reason when browser geolocation is unsupported", async () => {
     setNavigator(undefined);
 
@@ -167,7 +167,7 @@ describe("web Modern API", () => {
     });
   });
 
-  it("applies Modern API default browser position options", async () => {
+  it("applies default browser position options", async () => {
     const getCurrentPositionMock = vi.fn((success) => {
       success(createPosition());
     });
@@ -187,7 +187,7 @@ describe("web Modern API", () => {
     });
   });
 
-  it("maps Modern Android accuracy presets to browser accuracy", async () => {
+  it("maps Android accuracy presets to browser accuracy", async () => {
     const getCurrentPositionMock = vi.fn((success) => {
       success(createPosition());
     });
@@ -214,7 +214,7 @@ describe("web Modern API", () => {
     });
   });
 
-  it("maps browser error codes to Modern API LocationError codes", async () => {
+  it("maps browser error codes to LocationError codes", async () => {
     setNavigator({
       geolocation: {
         getCurrentPosition: vi.fn((_success, error) => {

--- a/packages/rozenite-devtools-plugin/CHANGELOG.md
+++ b/packages/rozenite-devtools-plugin/CHANGELOG.md
@@ -17,8 +17,8 @@
 
 ### Minor Changes
 
-- d54aa44: Add optional `mocked` and `provider` metadata to root location responses with Android and iOS native mappings.
-  Add `GeolocationConfiguration` as the preferred root API configuration type while preserving `ModernGeolocationConfiguration` as a deprecated compatibility alias.
+- d54aa44: Add optional `mocked` and `provider` metadata to location responses with Android and iOS native mappings.
+  Add `GeolocationConfiguration` as the preferred API configuration type while preserving a deprecated compatibility alias.
   Keep the Compat API response shape unchanged for the drop-in replacement contract.
   Normalize missing native coordinate values to explicit `null` unions and include the same metadata in Rozenite DevTools mock responses.
 

--- a/packages/rozenite-devtools-plugin/README.md
+++ b/packages/rozenite-devtools-plugin/README.md
@@ -4,7 +4,7 @@ Rozenite DevTools Plugin for [react-native-nitro-geolocation](https://github.com
 
 > **⚠️ Prerequisites**: This plugin requires [Rozenite DevTools](https://github.com/rozenite/rozenite) to be set up in your project. Follow the [Rozenite installation guide](https://rozenite.dev/docs/getting-started) to configure DevTools before using this plugin.
 
-> **ℹ️ API Compatibility**: This DevTools plugin only works with the **Modern API** (`react-native-nitro-geolocation`). It does not support the Compat API (`react-native-nitro-geolocation/compat`).
+> **ℹ️ API Compatibility**: This DevTools plugin only works with `react-native-nitro-geolocation`. It does not support the Compat API (`react-native-nitro-geolocation/compat`).
 
 ## Demo
 

--- a/skills/community-migration/SKILL.md
+++ b/skills/community-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: community-migration
-description: Migrate React Native apps from @react-native-community/geolocation to react-native-nitro-geolocation. Use when installing the Nitro packages, running the bundled compat bootstrap codemod, removing @react-native-community/geolocation, then refactoring community-compatible call sites to the Modern API with Promise functions, requestPermission, setConfiguration, useWatchPosition, watchPosition, and unwatch.
+description: Migrate React Native apps from @react-native-community/geolocation to react-native-nitro-geolocation. Use when installing the Nitro packages, running the bundled compat bootstrap codemod, removing @react-native-community/geolocation, then refactoring community-compatible call sites to Promise functions, requestPermission, setConfiguration, useWatchPosition, watchPosition, and unwatch.
 ---
 
 # Community Geolocation Migration
@@ -9,11 +9,11 @@ Use a two-phase migration:
 
 1. Bootstrap safely to `/compat` so the app stops depending on
    `@react-native-community/geolocation`.
-2. Refactor from `/compat` to the Modern API best-practice shape.
+2. Refactor from `/compat` to the recommended API shape.
 
 Do not start by hand-converting every callback call site. First make the
 mechanical package/import migration small and reversible, verify it, then do
-the semantic Modern API refactor.
+the semantic API refactor.
 
 ## Workflow
 
@@ -41,7 +41,7 @@ the semantic Modern API refactor.
    curl -fsSL https://react-native-nitro-geolocation.pages.dev/llms-full.txt
    ```
    Read `llms.txt` first as the docs index. Use `llms-full.txt` only when you
-   need exact API names, option semantics, or examples for the Modern API,
+   need exact API names, option semantics, or examples for the API,
    Compat API, quick start, or platform setup. If the app already pins an older
    `react-native-nitro-geolocation` version, confirm an API exists in
    `node_modules/react-native-nitro-geolocation` or the installed package types
@@ -55,7 +55,7 @@ the semantic Modern API refactor.
 8. Inspect each call site before refactoring. Identify whether it is in a React
    function component, class component, hook, service module, background task, or
    test.
-9. Replace compat imports with named Modern API imports from
+9. Replace compat imports with named imports from
    `react-native-nitro-geolocation`. Remove `Geolocation` default-object usage
    when the migrated file no longer needs it.
 10. Convert one-shot and permission APIs to `async`/`await` or explicit Promise
@@ -71,7 +71,7 @@ the semantic Modern API refactor.
 
 ## Docs Reference
 
-Use these docs endpoints as the source of truth during the Modern refactor:
+Use these docs endpoints as the source of truth during the API refactor:
 
 - `https://react-native-nitro-geolocation.pages.dev/llms.txt` - concise index
   of available docs pages.
@@ -108,7 +108,7 @@ The final migration is not just "no type errors." Prefer this target state:
 - Keep permission, provider/settings, and watch cleanup behavior visible in the
   code. Do not hide prompts or global cleanup in utility functions unless that
   is already the app's architecture.
-- Use typed Modern errors where handling is specific. Match on
+- Use typed errors where handling is specific. Match on
   `LocationErrorCodes` for permission denied, timeout, settings-not-satisfied,
   or provider/setup failures instead of parsing error messages.
 
@@ -127,12 +127,12 @@ Apply these criteria at each call site, in this order:
 5. Prefer battery-aware defaults: only request high accuracy, frequent
    intervals, background updates, or settings dialogs when the old code or app
    feature justifies it.
-6. Prefer type-safe Modern API names at module boundaries: avoid passing a
+6. Prefer type-safe function names at module boundaries: avoid passing a
    `Geolocation` object through app code after refactoring.
 
 Use this API choice table:
 
-| Legacy pattern | Modern target | Choose it when | Avoid it when |
+| Legacy pattern | Target | Choose it when | Avoid it when |
 | --- | --- | --- | --- |
 | `getCurrentPosition(success, error, options)` | `await getCurrentPosition(options)` | A user action or flow needs a fresh position. | The UI can start from cached location only; consider `getLastKnownPosition()`. |
 | Cached/stale startup read via `maximumAge` | `await getLastKnownPosition(options)` | Startup UI, stale-while-refresh, or cache-only flows can tolerate no fresh request. | The feature needs a fresh fix or should prompt provider/settings resolution. |
@@ -140,7 +140,7 @@ Use this API choice table:
 | `setRNConfiguration(config)` | `setConfiguration(config)` | App startup or native bootstrap code sets global location config once. | A screen-level call would repeatedly mutate global config. |
 | `watchPosition` in a function component | `useWatchPosition({ enabled, ...options })` | Position drives React render state and the call can be at hook-safe top level. | The code is a class component, event callback, conditional branch, or service. |
 | `watchPosition` in services/classes/tasks | `watchPosition(...)` + `unwatch(token)` | A non-React lifecycle owns the subscription. | A React function component can express the lifecycle with `enabled`. |
-| `clearWatch(id)` | `unwatch(token)` | Stopping one known Modern watch. | The old code intentionally stopped every watcher; review `stopObserving()`. |
+| `clearWatch(id)` | `unwatch(token)` | Stopping one known watch. | The old code intentionally stopped every watcher; review `stopObserving()`. |
 | `enableHighAccuracy: true` | `accuracy: { android: "high", ios: "best" }` | The feature needs precise location. | Low-power or approximate location is enough. |
 | Android precise flow that can fail due to settings | `getLocationAvailability()` / `requestLocationSettings()` before location request | The UX can ask users to enable provider/settings for navigation or precise location. | Passive/background or approximate flows should not interrupt users. |
 
@@ -158,7 +158,7 @@ to:
 import Geolocation from "react-native-nitro-geolocation/compat";
 ```
 
-After verification, refactor compat imports to named Modern imports:
+After verification, refactor compat imports to named imports:
 
 ```ts
 import {
@@ -235,7 +235,7 @@ setConfiguration({
 });
 ```
 
-Do not migrate `skipPermissionRequests`; Modern API has no equivalent because
+Do not migrate `skipPermissionRequests`; there is no equivalent because
 permission requests must be explicit through `requestPermission()`.
 
 ### watchPosition in React Components
@@ -272,7 +272,7 @@ that reacts to `position` or `error`.
 
 ### watchPosition Outside Hook-Safe Code
 
-Use the low-level Modern watch API outside function component top level:
+Use the low-level watch function outside function component top level:
 
 ```ts
 const token = watchPosition(onPosition, onError, {
@@ -296,7 +296,7 @@ otherwise prefer targeted `unwatch(token)`.
   explicit preset and note the semantic decision.
 - Preserve `timeout`, `maximumAge`, `distanceFilter`, `interval`,
   `fastestInterval`, and `useSignificantChanges` when present.
-- Prefer Modern platform options such as `granularity`,
+- Prefer platform options such as `granularity`,
   `waitForAccurateLocation`, `activityType`, and
   `pausesLocationUpdatesAutomatically` only when the migrated code already has
   an equivalent requirement.

--- a/skills/community-migration/scripts/migrate-to-compat.mjs
+++ b/skills/community-migration/scripts/migrate-to-compat.mjs
@@ -329,7 +329,7 @@ async function main() {
   }
 
   printNextChecks(manager, packageJson);
-  console.log("Next: refactor compat call sites to the Modern API.");
+  console.log("Next: refactor compat call sites to named API functions.");
 }
 
 main().catch((error) => {

--- a/skills/service-migration/SKILL.md
+++ b/skills/service-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: service-migration
-description: Migrate React Native apps directly from react-native-geolocation-service to react-native-nitro-geolocation Modern API without using /compat. Use when replacing react-native-geolocation-service imports, installing Nitro packages, configuring the Android provider, converting callback APIs to Modern Promise/watch APIs, preserving service-specific options such as accuracy and provider metadata, and reporting manual-review sites for settings dialogs, forceRequestLocation, and default option differences.
+description: Migrate React Native apps directly from react-native-geolocation-service to react-native-nitro-geolocation without using /compat. Use when replacing react-native-geolocation-service imports, installing Nitro packages, configuring the Android provider, converting callback APIs to Promise/watch APIs, preserving service-specific options such as accuracy and provider metadata, and reporting manual-review sites for settings dialogs, forceRequestLocation, and default option differences.
 ---
 
 # Geolocation Service Migration
@@ -34,7 +34,7 @@ asks for a compatibility fallback.
    `react-native-geolocation-service` migrations should use
    `locationProvider: "playServices"`. Use `"android"` only when the legacy app
    intentionally used `forceLocationManager: true`.
-7. Rewrite imports directly to named Modern API imports from
+7. Rewrite imports directly to named imports from
    `react-native-nitro-geolocation`.
 8. Convert one-shot location calls to Promise chains first. Use `async`/`await`
    only when the surrounding function is already async or clearly safe to make
@@ -59,7 +59,7 @@ Run inventory first:
 node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --inventory-only
 ```
 
-Dry-run the direct Modern transform:
+Dry-run the direct API transform:
 
 ```bash
 node <skill-dir>/scripts/migrate-geolocation-service.mjs --root <app-root> --dry-run
@@ -84,7 +84,7 @@ app.
 
 - Never import from `react-native-nitro-geolocation/compat`.
 - Never rewrite to `/compat` as an intermediate step.
-- Prefer direct named Modern API imports.
+- Prefer direct named imports.
 - Configure `locationProvider: "playServices"` for normal
   `react-native-geolocation-service` migrations.
 - Use `locationProvider: "android"` only when legacy code used
@@ -101,14 +101,14 @@ app.
 - Do not auto-convert `forceRequestLocation`; report it.
 - Do not introduce React hooks unless the file is a function component or
   custom hook and the call is at hook-safe top level.
-- Use low-level `watchPosition` plus `unwatch` as the first safe Modern target.
+- Use low-level `watchPosition` plus `unwatch` as the first safe target.
 - Replace numeric error-code checks with `LocationErrorCodes` where possible.
 - Do not remove `PermissionsAndroid` code unless it is clearly only for
   location permission and replaced by `requestPermission()`.
 
 ## API Mapping
 
-| `react-native-geolocation-service` | Nitro Modern API | Notes |
+| `react-native-geolocation-service` | `react-native-nitro-geolocation` | Notes |
 | --- | --- | --- |
 | `Geolocation.getCurrentPosition(success, error, options)` | `getCurrentPosition(options)` | Convert to Promise chain first. |
 | `Geolocation.watchPosition(success, error, options)` | `watchPosition(...)` or `useWatchPosition(...)` | Start with low-level API. |
@@ -116,13 +116,13 @@ app.
 | `Geolocation.stopObserving()` | `stopObserving()` | Keep only when global cleanup was intended. |
 | `requestAuthorization("whenInUse" | "always")` | `setConfiguration({ authorizationLevel })` plus `requestPermission()` | Return statuses differ. |
 | `accuracy: { android, ios }` | `accuracy: { android, ios }` | Preserve explicit values. |
-| `enableHighAccuracy` | `accuracy` preset | Prefer Modern `accuracy`. |
+| `enableHighAccuracy` | `accuracy` preset | Prefer `accuracy`. |
 | `showLocationDialog` | `requestLocationSettings()` | Convert explicit `true`; report omitted defaults. |
 | `forceLocationManager` | `setConfiguration({ locationProvider: "android" })` | Global setting, not a call option. |
 | default fused provider intent | `setConfiguration({ locationProvider: "playServices" })` | Do this for normal service migrations. |
 | `forceRequestLocation` | no direct option | Report and preserve intent manually. |
-| `position.mocked` | `GeolocationResponse.mocked` | Available in Modern API. |
-| `position.provider` | `GeolocationResponse.provider` | Available in Modern API. |
+| `position.mocked` | `GeolocationResponse.mocked` | Available in the API. |
+| `position.provider` | `GeolocationResponse.provider` | Available in the API. |
 | error codes `-1`, `1`, `2`, `3`, `4`, `5` | `LocationErrorCodes` | Prefer named constant comparisons. |
 
 ## Transform Patterns
@@ -195,13 +195,13 @@ Always report these instead of guessing:
   explicit `requestLocationSettings()` flow if the app wants the Android
   settings dialog.
 - Omitted `timeout` or `maximumAge` on `getCurrentPosition`. Service defaults
-  were effectively infinite; Nitro Modern defaults are `timeout: 600000` and
+  were effectively infinite; Nitro defaults are `timeout: 600000` and
   `maximumAge: 0`.
 - `forceRequestLocation`. Preserve the fallback behavior explicitly only after
   product/UX review.
 - Mixed `forceLocationManager` usage. Nitro `locationProvider` is global.
-- `requestAuthorization` code that handles `disabled`. Modern permission status
-  does not include `disabled`; use `hasServicesEnabled()` or
+- `requestAuthorization` code that handles `disabled`. `requestPermission()`
+  status does not include `disabled`; use `hasServicesEnabled()` or
   `getProviderStatus()` separately.
 - `PermissionsAndroid` usage unless it is clearly redundant after
   `requestPermission()`.

--- a/skills/service-migration/agents/openai.yaml
+++ b/skills/service-migration/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "RN Geolocation Service Migration"
-  short_description: "Migrate geolocation-service to Nitro Modern API"
-  default_prompt: "Use $service-migration to migrate this React Native app from react-native-geolocation-service directly to react-native-nitro-geolocation Modern API."
+  short_description: "Migrate geolocation-service to Nitro Geolocation"
+  default_prompt: "Use $service-migration to migrate this React Native app from react-native-geolocation-service directly to react-native-nitro-geolocation."
 policy:
   allow_implicit_invocation: true

--- a/skills/service-migration/scripts/migrate-geolocation-service.mjs
+++ b/skills/service-migration/scripts/migrate-geolocation-service.mjs
@@ -553,7 +553,7 @@ function transformOptions(t, optionsNode, { report, file, callName }) {
         report,
         file,
         null,
-        "getCurrentPosition omitted timeout and maximumAge. Legacy service defaults were effectively infinite; Nitro Modern defaults are timeout 600000 and maximumAge 0."
+        "getCurrentPosition omitted timeout and maximumAge. Legacy service defaults were effectively infinite; Nitro defaults are timeout 600000 and maximumAge 0."
       );
     }
     if (callName === "getCurrentPosition" || callName === "watchPosition") {
@@ -642,7 +642,7 @@ function transformOptions(t, optionsNode, { report, file, callName }) {
         report,
         file,
         location(t, property),
-        "forceRequestLocation has no direct Modern option. Preserve the fallback behavior explicitly only after UX/product review."
+        "forceRequestLocation has no direct API option. Preserve the fallback behavior explicitly only after UX/product review."
       );
       continue;
     }
@@ -690,7 +690,7 @@ function transformOptions(t, optionsNode, { report, file, callName }) {
       report,
       file,
       location(t, optionsNode),
-      `getCurrentPosition omitted ${missing}. Legacy service defaults were effectively infinite; Nitro Modern defaults are timeout 600000 and maximumAge 0.`
+      `getCurrentPosition omitted ${missing}. Legacy service defaults were effectively infinite; Nitro defaults are timeout 600000 and maximumAge 0.`
     );
   }
 
@@ -1000,7 +1000,7 @@ function transformSourceFile(
           report,
           rel,
           location(t, path.node),
-          "CommonJS require('react-native-geolocation-service') found. Convert this import manually to named Modern API imports."
+          "CommonJS require('react-native-geolocation-service') found. Convert this import manually to named imports."
         );
       }
     }
@@ -1115,7 +1115,7 @@ function transformSourceFile(
             report,
             rel,
             location(t, path.node),
-            "Legacy requestAuthorization handling references disabled. Modern requestPermission() does not return disabled; use hasServicesEnabled() or getProviderStatus() separately."
+            "Legacy requestAuthorization handling references disabled. requestPermission() does not return disabled; use hasServicesEnabled() or getProviderStatus() separately."
           );
         }
         path.replaceWith(


### PR DESCRIPTION
## Summary

- remove the Modern and Root API labels from first-party source, docs, examples, changelogs, and migration tooling
- rename the API guide route from modern-api to api across current, v1, and v2 documentation
- keep the Compat API and /compat surface unchanged
- rename Android implementation branches after their actual location and permission mechanisms

## Validation

- yarn format:check
- yarn lint
- yarn test:unit (24 files, 196 tests)
- Android testDebugUnitTest
- package, docs, and example targeted typechecks
- yarn workspace docs build
- yarn workspace docs check:versions
- yarn workspace react-native-nitro-geolocation-web-e2e build
- yarn pack:check
- first-party source and rendered documentation terminology scan

## Note

The full yarn typecheck command could not resolve the tsc binary in the Swift Package Manager example workspace locally. All affected workspaces passed their targeted typechecks. The only remaining modern token in tracked files is the upstream React Native jsinspector-modern path recorded in example Podfile locks.