### PR TITLE
fix: stabilize release workspace dependencies

### DIFF
--- a/.changeset/steady-workspace-links.md
+++ b/.changeset/steady-workspace-links.md
@@ -1,0 +1,5 @@
+---
+---
+
+Keep example workspace dependency ranges stable when Changesets versions more
+than one published package.

--- a/examples/v0.81.1/package.json
+++ b/examples/v0.81.1/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@react-native-community/geolocation": "^3.4.0",
-    "@react-native-nitro-geolocation/rozenite-plugin": "workspace: *",
+    "@react-native-nitro-geolocation/rozenite-plugin": "workspace:*",
     "@react-native/new-app-screen": "0.81.1",
     "@react-navigation/bottom-tabs": "^7.9.0",
     "@react-navigation/native": "^7.1.26",

--- a/tests/release-version-sync.test.mjs
+++ b/tests/release-version-sync.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
 import {
   assertSupportedReleaseVersion,
@@ -6,6 +8,25 @@ import {
   syncPodfileLockVersion,
   syncVersionedDocumentation
 } from "../scripts/release-version-sync.mjs";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+test("example workspace dependencies survive Changesets versioning", async () => {
+  const examplePackage = JSON.parse(
+    await readFile(path.join(root, "examples/v0.81.1/package.json"), "utf8")
+  );
+
+  assert.equal(
+    examplePackage.dependencies["react-native-nitro-geolocation"],
+    "workspace:*"
+  );
+  assert.equal(
+    examplePackage.dependencies[
+      "@react-native-nitro-geolocation/rozenite-plugin"
+    ],
+    "workspace:*"
+  );
+});
 
 test("RC bumps update exact documentation versions without changing the channel", () => {
   const source = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,7 +4281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-nitro-geolocation/rozenite-plugin@workspace: *, @react-native-nitro-geolocation/rozenite-plugin@workspace:packages/rozenite-devtools-plugin":
+"@react-native-nitro-geolocation/rozenite-plugin@workspace:*, @react-native-nitro-geolocation/rozenite-plugin@workspace:packages/rozenite-devtools-plugin":
   version: 0.0.0-use.local
   resolution: "@react-native-nitro-geolocation/rozenite-plugin@workspace:packages/rozenite-devtools-plugin"
   dependencies:
@@ -15602,7 +15602,7 @@ __metadata:
     "@react-native-community/cli-platform-android": "npm:20.0.0"
     "@react-native-community/cli-platform-ios": "npm:20.0.0"
     "@react-native-community/geolocation": "npm:^3.4.0"
-    "@react-native-nitro-geolocation/rozenite-plugin": "workspace: *"
+    "@react-native-nitro-geolocation/rozenite-plugin": "workspace:*"
     "@react-native/babel-preset": "npm:0.81.1"
     "@react-native/metro-config": "npm:0.81.1"
     "@react-native/new-app-screen": "npm:0.81.1"


### PR DESCRIPTION
## Summary

- normalize the Rozenite example dependency to `workspace:*`
- keep the Yarn lockfile selector in sync
- add a release regression test for both local workspace dependencies
- include an empty changeset because this only fixes release infrastructure and the example workspace

## Root cause

Changesets rewrote `workspace: *` to the prerelease version in #202, while the committed lockfile still described the workspace selector. Every E2E job then failed during immutable dependency installation, before Maestro ran.

## Validation

- simulated `yarn changeset version` in a clean detached worktree
- confirmed both dependencies remain `workspace:*`
- confirmed `yarn install --immutable` succeeds after versioning
- `yarn test:release` (18/18)
- `yarn format:check`
- `yarn lint`
- `git diff --check`