### PR TITLE
test: report Rozenite E2E case values

### DIFF
--- a/scripts/rozenite-e2e-electron.cjs
+++ b/scripts/rozenite-e2e-electron.cjs
@@ -13,6 +13,15 @@ const run = async () => {
       contextIsolation: false
     }
   });
+  window.webContents.on("console-message", (_event, ...args) => {
+    const message =
+      typeof args[0] === "object" && args[0] !== null
+        ? args[0].message
+        : args[1];
+    if (message?.startsWith("[ROZENITE_E2E_CASE]")) {
+      process.stdout.write(`${message}\n`);
+    }
+  });
   await window.loadURL(url);
   const result = await window.webContents.executeJavaScript(
     "window.runE2E()",

--- a/scripts/rozenite-e2e-harness.html
+++ b/scripts/rozenite-e2e-harness.html
@@ -13,6 +13,7 @@
     <script>
       const panel = document.getElementById("panel");
       let messageCursor = 0;
+      const cases = [];
 
       const delay = (milliseconds) =>
         new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -41,6 +42,33 @@
       const assert = (condition, message) => {
         if (!condition) throw new Error(message);
       };
+
+      const recordCase = ({ name, input, expected, actual, passed }) => {
+        const result = {
+          name,
+          status: passed ? "PASS" : "FAIL",
+          input,
+          expected,
+          actual
+        };
+        console.log(`[ROZENITE_E2E_CASE]${JSON.stringify(result)}`);
+        assert(
+          passed,
+          `${name} failed\nExpected: ${JSON.stringify(expected)}\nActual: ${JSON.stringify(actual)}`
+        );
+        cases.push(result);
+      };
+
+      const positionValue = (position) => ({
+        latitude: position?.coords?.latitude,
+        longitude: position?.coords?.longitude,
+        mocked: position?.mocked
+      });
+
+      const watchValue = (record) => ({
+        updateCount: record?.updates?.length ?? 0,
+        lastPosition: positionValue(record?.updates?.at(-1))
+      });
 
       const panelDocument = () => panel.contentDocument;
       const buttonWithText = (text) =>
@@ -93,26 +121,55 @@
       void pumpMessages();
 
       window.runE2E = async () => {
-        await waitFor(
+        const initialButton = await waitFor(
           () => buttonWithText("Los Angeles, USA"),
           "initial position handshake"
         );
 
         const initial = await api("/current-position");
-        assert(initial.coords.latitude === 34.0522, "initial latitude mismatch");
-        assert(
-          initial.coords.longitude === -118.2437,
-          "initial longitude mismatch"
-        );
-        assert(initial.mocked === true, "initial position is not mocked");
+        const initialExpected = {
+          panelLabel: "Los Angeles, USA",
+          latitude: 34.0522,
+          longitude: -118.2437,
+          mocked: true
+        };
+        const initialActual = {
+          panelLabel: initialButton.textContent.trim(),
+          ...positionValue(initial)
+        };
+        recordCase({
+          name: "Initial position handshake",
+          input: { configuredPreset: "Los Angeles, USA" },
+          expected: initialExpected,
+          actual: initialActual,
+          passed:
+            initialActual.panelLabel === initialExpected.panelLabel &&
+            initialActual.latitude === initialExpected.latitude &&
+            initialActual.longitude === initialExpected.longitude &&
+            initialActual.mocked === initialExpected.mocked
+        });
 
         await selectPreset("Tokyo, Japan");
         const tokyo = await waitFor(async () => {
           const current = await api("/current-position");
           return current.coords.latitude === 35.6762 ? current : null;
         }, "Tokyo position in the app");
-        assert(tokyo.coords.longitude === 139.6503, "Tokyo longitude mismatch");
-        assert(tokyo.mocked === true, "Tokyo position is not mocked");
+        const tokyoExpected = {
+          latitude: 35.6762,
+          longitude: 139.6503,
+          mocked: true
+        };
+        const tokyoActual = positionValue(tokyo);
+        recordCase({
+          name: "Preset reaches getCurrentPosition",
+          input: { selectedPreset: "Tokyo, Japan" },
+          expected: tokyoExpected,
+          actual: tokyoActual,
+          passed:
+            tokyoActual.latitude === tokyoExpected.latitude &&
+            tokyoActual.longitude === tokyoExpected.longitude &&
+            tokyoActual.mocked === tokyoExpected.mocked
+        });
 
         const distanceWatch = await api("/watches", {
           method: "POST",
@@ -129,6 +186,36 @@
           })
         });
 
+        const registeredWatches = await api("/watches");
+        const registeredActual = {
+          createdWatchIds: [distanceWatch.id, limitedWatch.id],
+          activeTokens: registeredWatches.active.map((watch) => watch.token),
+          initialUpdateCounts: registeredWatches.records.map((record) => ({
+            id: record.id,
+            count: record.updates.length
+          }))
+        };
+        const registeredExpected = {
+          createdWatchIds: ["watch-1", "watch-2"],
+          activeTokens: [distanceWatch.token, limitedWatch.token],
+          initialUpdateCounts: [
+            { id: distanceWatch.id, count: 1 },
+            { id: limitedWatch.id, count: 1 }
+          ]
+        };
+        recordCase({
+          name: "Independent iOS and Android watches",
+          input: {
+            ios: { distanceFilter: 1_000 },
+            android: { distanceFilter: 0, interval: 0, maxUpdates: 2 }
+          },
+          expected: registeredExpected,
+          actual: registeredActual,
+          passed:
+            JSON.stringify(registeredActual) ===
+            JSON.stringify(registeredExpected)
+        });
+
         setInput("latitude-input", 35.6772);
         await waitFor(async () => {
           const watches = await api("/watches");
@@ -142,15 +229,56 @@
         const distanceAfterSmallMove = afterSmallMove.records.find(
           (record) => record.id === distanceWatch.id
         );
-        assert(
-          distanceAfterSmallMove.updates.length === 1,
-          "distance-filtered watch received a sub-threshold move"
+        const limitedAfterSmallMove = afterSmallMove.records.find(
+          (record) => record.id === limitedWatch.id
         );
-        assert(
-          afterSmallMove.active.length === 1 &&
-            afterSmallMove.active[0].token === distanceWatch.token,
-          "maxUpdates removed the wrong watch"
-        );
+        const smallMoveInput = {
+          from: { latitude: 35.6762, longitude: 139.6503 },
+          to: { latitude: 35.6772, longitude: 139.6503 },
+          approximateDistanceMeters: 111
+        };
+        const distanceExpected = {
+          distanceFilterMeters: 1_000,
+          updateCount: 1,
+          lastPosition: tokyoExpected
+        };
+        const distanceActual = {
+          distanceFilterMeters: 1_000,
+          ...watchValue(distanceAfterSmallMove)
+        };
+        recordCase({
+          name: "iOS distanceFilter blocks a 111 m move",
+          input: smallMoveInput,
+          expected: distanceExpected,
+          actual: distanceActual,
+          passed:
+            JSON.stringify(distanceActual) === JSON.stringify(distanceExpected)
+        });
+
+        const maxUpdatesExpected = {
+          maxUpdates: 2,
+          updateCount: 2,
+          lastLatitude: 35.6772,
+          remainingActiveTokens: [distanceWatch.token]
+        };
+        const maxUpdatesActual = {
+          maxUpdates: 2,
+          updateCount: limitedAfterSmallMove.updates.length,
+          lastLatitude:
+            limitedAfterSmallMove.updates.at(-1)?.coords?.latitude,
+          remainingActiveTokens: afterSmallMove.active.map(
+            (watch) => watch.token
+          )
+        };
+        recordCase({
+          name: "Android maxUpdates removes only its own watch",
+          input: smallMoveInput,
+          expected: maxUpdatesExpected,
+          actual: maxUpdatesActual,
+          passed:
+            JSON.stringify(maxUpdatesActual) ===
+            JSON.stringify(maxUpdatesExpected)
+        });
 
         await selectPreset("New York, USA");
         await waitFor(async () => {
@@ -162,23 +290,59 @@
         }, "distance-filtered watch update");
 
         const finalPosition = await api("/current-position");
-        assert(
-          finalPosition.coords.latitude === 40.7128 &&
-            finalPosition.coords.longitude === -74.006,
-          "New York position did not reach current-position"
+        const afterLargeMove = await api("/watches");
+        const distanceAfterLargeMove = afterLargeMove.records.find(
+          (record) => record.id === distanceWatch.id
         );
+        const finalExpected = {
+          currentPosition: {
+            latitude: 40.7128,
+            longitude: -74.006,
+            mocked: true
+          },
+          iosWatchUpdateCount: 2,
+          iosWatchLastPosition: {
+            latitude: 40.7128,
+            longitude: -74.006,
+            mocked: true
+          }
+        };
+        const finalActual = {
+          currentPosition: positionValue(finalPosition),
+          iosWatchUpdateCount: distanceAfterLargeMove.updates.length,
+          iosWatchLastPosition: positionValue(
+            distanceAfterLargeMove.updates.at(-1)
+          )
+        };
+        recordCase({
+          name: "Large preset move reaches current position and iOS watch",
+          input: { selectedPreset: "New York, USA" },
+          expected: finalExpected,
+          actual: finalActual,
+          passed:
+            JSON.stringify(finalActual) === JSON.stringify(finalExpected)
+        });
 
         await api(`/watches/${distanceWatch.id}`, { method: "DELETE" });
         const cleaned = await api("/watches");
-        assert(cleaned.active.length === 0, "unwatch left an active watch");
+        recordCase({
+          name: "unwatch cleans up the final active watch",
+          input: { removedWatchId: distanceWatch.id },
+          expected: { activeWatchCount: 0, activeTokens: [] },
+          actual: {
+            activeWatchCount: cleaned.active.length,
+            activeTokens: cleaned.active.map((watch) => watch.token)
+          },
+          passed: cleaned.active.length === 0
+        });
 
         return {
-          initial: "Los Angeles, USA",
-          preset: "Tokyo, Japan",
-          distanceFilter: "passed",
-          maxUpdates: "passed",
-          final: "New York, USA",
-          cleanup: "passed"
+          cases,
+          summary: {
+            passed: cases.filter((testCase) => testCase.status === "PASS")
+              .length,
+            total: cases.length
+          }
         };
       };
     </script>

--- a/scripts/test-rozenite-e2e.mjs
+++ b/scripts/test-rozenite-e2e.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import net from "node:net";
 import path from "node:path";
@@ -10,6 +10,50 @@ const PLUGIN_ID = "@react-native-nitro-geolocation/rozenite-plugin";
 const EXPECTED_RUNTIME_VERSION = "2.2.0";
 const REQUEST_TIMEOUT_MS = 120_000;
 const E2E_TIMEOUT_MS = 30_000;
+
+const printCase = (testCase) => {
+  const icon = testCase.status === "PASS" ? "PASS" : "FAIL";
+  console.log(`\n[${icon}] ${testCase.name}`);
+  console.log(`  INPUT:    ${JSON.stringify(testCase.input)}`);
+  console.log(`  EXPECTED: ${JSON.stringify(testCase.expected)}`);
+  console.log(`  ACTUAL:   ${JSON.stringify(testCase.actual)}`);
+};
+
+const verifyCase = ({ name, input, expected, actual }) => {
+  let error;
+  try {
+    assert.deepEqual(actual, expected);
+  } catch (assertionError) {
+    error = assertionError;
+  }
+  const testCase = {
+    name,
+    status: error ? "FAIL" : "PASS",
+    input,
+    expected,
+    actual
+  };
+  printCase(testCase);
+  if (error) throw error;
+  return testCase;
+};
+
+const writeGitHubSummary = (cases) => {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const passed = cases.filter((testCase) => testCase.status === "PASS").length;
+  const cell = (value) => `\`${JSON.stringify(value).replaceAll("|", "\\|")}\``;
+  const rows = cases
+    .map(
+      (testCase) =>
+        `| ${testCase.status} | ${testCase.name} | ${cell(testCase.input)} | ${cell(testCase.expected)} | ${cell(testCase.actual)} |`
+    )
+    .join("\n");
+  appendFileSync(
+    summaryPath,
+    `## Rozenite behavior E2E\n\n| Result | Case | Input | Expected | Actual |\n| --- | --- | --- | --- | --- |\n${rows}\n\n**${passed}/${cases.length} cases passed.**\n`
+  );
+};
 
 const getAvailablePort = () =>
   new Promise((resolve, reject) => {
@@ -43,10 +87,6 @@ const fetchText = async (url, expectedContentType) => {
     `${url} returned an unexpected content type`
   );
   return response.text();
-};
-
-const assertIncludes = (contents, expected, label) => {
-  assert.ok(contents.includes(expected), `${label} is missing ${expected}`);
 };
 
 const sendJson = (response, status, value) => {
@@ -144,6 +184,7 @@ const closeHttpServer = (server) =>
   });
 
 const run = async () => {
+  const cases = [];
   const repositoryRoot = process.cwd();
   const exampleRoot = path.join(repositoryRoot, "examples/v0.81.1");
   const pluginRoot = path.join(
@@ -285,26 +326,73 @@ const run = async () => {
       `${baseUrl}/rozenite/app/config`
     );
     const rozeniteConfig = await configResponse.json();
-    assert.deepEqual(rozeniteConfig.installedPlugins, [PLUGIN_ID]);
-    assert.equal(rozeniteConfig.runtimeVersion, EXPECTED_RUNTIME_VERSION);
+    cases.push(
+      verifyCase({
+        name: "Rozenite host discovers the plugin",
+        input: { endpoint: "/rozenite/app/config" },
+        expected: {
+          installedPlugins: [PLUGIN_ID],
+          runtimeVersion: EXPECTED_RUNTIME_VERSION
+        },
+        actual: {
+          installedPlugins: rozeniteConfig.installedPlugins,
+          runtimeVersion: rozeniteConfig.runtimeVersion
+        }
+      })
+    );
 
     const pluginBaseUrl = `${baseUrl}/rozenite/plugins/${PLUGIN_ID.replace("/", "_")}`;
     const manifestResponse = await fetchResponse(
       `${pluginBaseUrl}/rozenite.json`
     );
     const manifest = await manifestResponse.json();
-    assert.equal(manifest.name, PLUGIN_ID);
     const panelUrl = `${pluginBaseUrl}${manifest.panels[0].source}`;
     const panelHtml = await fetchText(panelUrl, /text\/html/);
-    assertIncludes(panelHtml, "__ROZENITE_PANEL__", "panel HTML");
+    cases.push(
+      verifyCase({
+        name: "Built DevTools panel is served",
+        input: { manifestUrl: `${pluginBaseUrl}/rozenite.json`, panelUrl },
+        expected: {
+          manifestName: PLUGIN_ID,
+          hasPanelSource: true,
+          hasRozenitePanelBootstrap: true
+        },
+        actual: {
+          manifestName: manifest.name,
+          hasPanelSource: Boolean(manifest.panels[0].source),
+          hasRozenitePanelBootstrap: panelHtml.includes("__ROZENITE_PANEL__")
+        }
+      })
+    );
 
+    const bundleResults = {};
     for (const platform of ["android", "ios"]) {
       const bundle = await fetchText(
         `${baseUrl}/index.bundle?platform=${platform}&dev=true&minify=false&modulesOnly=false&runModule=true`,
         /(?:application|text)\/javascript/
       );
-      assertIncludes(bundle, PLUGIN_ID, `${platform} React Native bundle`);
+      bundleResults[platform] = {
+        containsPluginId: bundle.includes(PLUGIN_ID),
+        sizeBytes: Buffer.byteLength(bundle)
+      };
     }
+    cases.push(
+      verifyCase({
+        name: "React Native bundles include the Rozenite bridge",
+        input: { platforms: ["android", "ios"], dev: true },
+        expected: {
+          androidContainsPluginId: true,
+          iosContainsPluginId: true
+        },
+        actual: {
+          androidContainsPluginId: bundleResults.android.containsPluginId,
+          iosContainsPluginId: bundleResults.ios.containsPluginId
+        }
+      })
+    );
+    console.log(
+      `  BUNDLE SIZES: android=${bundleResults.android.sizeBytes} bytes, ios=${bundleResults.ios.sizeBytes} bytes`
+    );
 
     const rozenitePackage = requireFromPlugin.resolve("rozenite/package.json");
     const requireFromRozenite = createRequire(rozenitePackage);
@@ -314,15 +402,16 @@ const run = async () => {
       path.join(repositoryRoot, "scripts/rozenite-e2e-electron.cjs"),
       `${baseUrl}/rozenite-e2e/`
     );
-    assert.deepEqual(behavior, {
-      initial: "Los Angeles, USA",
-      preset: "Tokyo, Japan",
-      distanceFilter: "passed",
-      maxUpdates: "passed",
-      final: "New York, USA",
-      cleanup: "passed"
-    });
-    console.log(`Rozenite behavior E2E passed: ${JSON.stringify(behavior)}`);
+    assert.equal(behavior.summary.passed, behavior.summary.total);
+    assert.equal(behavior.cases.length, 7);
+    for (const testCase of behavior.cases) {
+      printCase(testCase);
+      cases.push(testCase);
+    }
+    writeGitHubSummary(cases);
+    console.log(
+      `\nRozenite behavior E2E passed: ${cases.length}/${cases.length} cases`
+    );
   } finally {
     watchModule.devtoolsStopObserving();
     disconnect();


### PR DESCRIPTION
## Summary

- print every Rozenite E2E case with its input, expected value, actual value, and pass/fail status
- split the behavior coverage into explicit host, panel, bundle, position, distance-filter, max-updates, and cleanup cases
- include the same 10-case result table in the GitHub Actions Job Summary
- preserve failed browser-case expected/actual values in Electron output

## Validation

- `yarn test:e2e:rozenite` — 10/10 cases passed
- `biome check scripts/test-rozenite-e2e.mjs scripts/rozenite-e2e-electron.cjs`
- `node --check scripts/test-rozenite-e2e.mjs`
- `node --check scripts/rozenite-e2e-electron.cjs`
- `git diff --check`

The manual `/e2e` workflow was not triggered from this PR to avoid unnecessarily occupying both self-hosted mobile runners.