### PR TITLE
fix: harden 2.0 release contracts and stable publishing readiness

### DIFF
--- a/.changeset/ready-locations-release.md
+++ b/.changeset/ready-locations-release.md
@@ -1,0 +1,13 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Harden the 2.0 release candidate before freezing its stable contract:
+
+- Keep iOS permission requests pending until a user decision and remove concurrent lazy watcher initialization.
+- Settle cancelled requests even if native or browser startup/teardown throws; ignore results from stopped watches and prior React hook subscriptions.
+- Implement Android foreground notification color and an optional native stop action scoped to its tracking run.
+- Apply background accuracy/granularity, preserve storage and activity policies across Android restarts, and retain iOS accuracy in persisted configuration.
+- Reject unsafe native numeric options and HTTP retry counts without integer-conversion crashes or retry overflow.
+- RC contract correction: remove the never-implemented iOS deferred-delivery options from the public types and returned configuration. See the eighth item in the 2.0 migration guide.
+- Fix stable documentation promotion, including RC navigation markers, the default 2.x routes, the 1.x archive, and redirects for existing /v2/ links.

--- a/.changeset/ready-locations-release.md
+++ b/.changeset/ready-locations-release.md
@@ -5,9 +5,10 @@
 Harden the 2.0 release candidate before freezing its stable contract:
 
 - Keep iOS permission requests pending until a user decision and remove concurrent lazy watcher initialization.
-- Settle cancelled requests even if native or browser startup/teardown throws; ignore results from stopped watches and prior React hook subscriptions.
+- Settle cancelled requests even if native or browser startup/teardown throws; ignore results from stopped browser watches and prior React hook subscriptions.
 - Implement Android foreground notification color and an optional native stop action scoped to its tracking run.
 - Apply background accuracy/granularity, preserve storage and activity policies across Android restarts, and retain iOS accuracy in persisted configuration.
+- Apply and restore Android geofencing defaults, and preserve a newer run's restart policy when an obsolete notification stop action arrives.
 - Reject unsafe native numeric options and HTTP retry counts without integer-conversion crashes or retry overflow.
 - RC contract correction: remove the never-implemented iOS deferred-delivery options from the public types and returned configuration. See the eighth item in the 2.0 migration guide.
 - Fix stable documentation promotion, including RC navigation markers, the default 2.x routes, the 1.x archive, and redirects for existing /v2/ links.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format-check:
     name: Format Check
@@ -122,7 +126,7 @@ jobs:
           yarn build:all
 
   unit-test:
-    name: Unit Tests
+    name: JavaScript / Release Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -186,7 +190,7 @@ jobs:
           yarn typecheck
 
   unit-tests:
-    name: Unit Tests
+    name: Android Unit / Checksum Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -212,10 +216,6 @@ jobs:
         run: |
           yarn install
 
-      - name: Run TypeScript unit tests
-        run: |
-          yarn test:unit
-
       - name: Run Android unit tests
         run: |
           ./examples/v0.81.1/android/gradlew \
@@ -226,6 +226,20 @@ jobs:
 
       - name: Verify Android prebuilt checksums
         run: scripts/test-android-prebuilt-checksum.sh
+
+  unit-test-gate:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs:
+      - unit-test
+      - unit-tests
+    if: ${{ always() }}
+    steps:
+      - name: Require both test suites to succeed
+        env:
+          JS_RESULT: ${{ needs.unit-test.result }}
+          ANDROID_RESULT: ${{ needs.unit-tests.result }}
+        run: test "$JS_RESULT" = success && test "$ANDROID_RESULT" = success
 
   guardrails:
     name: Dead Code / Package Guardrails

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "docs/**"
+      - "scripts/*release-version*.mjs"
+      - "scripts/check-stable-docs.mjs"
       - "packages/react-native-nitro-geolocation/package.json"
       - "packages/react-native-nitro-geolocation/README.md"
       - ".github/workflows/docs-ci.yml"
@@ -41,3 +43,6 @@ jobs:
         run: |
           yarn build
           yarn check:versions
+
+      - name: Rehearse the stable 2.0 documentation transition
+        run: node scripts/check-stable-docs.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ project.xcworkspace
 # Android/IJ
 .idea
 .gradle
+.kotlin/
 local.properties
 *.cxx
 app/.cxx/*

--- a/docs/docs/background/geofencing.md
+++ b/docs/docs/background/geofencing.md
@@ -35,3 +35,11 @@ place. `removeGeofences()` unregisters the named native regions; call it only
 when the product should stop monitoring them.
 
 `notifyOnDwell` is Android-only. iOS region monitoring supports enter and exit.
+
+On Android, `configureBackgroundLocation({ geofencing: ... })` sets defaults for
+`initialTrigger` and `notificationResponsiveness` (milliseconds). Fields supplied
+in the second argument to `addGeofences(regions, options)` override those defaults
+for that registration; an empty `initialTrigger: []` disables initial triggers.
+Native restoration of persisted regions uses the persisted configuration defaults,
+so put policies that must survive process death/reboot in `geofencing`, not only
+in a per-call override. These two scheduling options are not supported by iOS.

--- a/docs/docs/guide/index.md
+++ b/docs/docs/guide/index.md
@@ -11,7 +11,7 @@ pick one path; you do not need to read every guide before starting.
 | I want to… | Start here | Outcome |
 | --- | --- | --- |
 | Add foreground location to a new app | [Install and get a location](./quick-start.md) | A foreground-only screen that renders coordinates |
-| Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All seven 2.0 breaking changes reviewed and tested |
+| Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All eight 2.0 breaking changes reviewed and tested |
 | Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then optionally adopt direct functions and hooks |
 | Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | Named imports from the package |
 | Use an Expo app | [Expo development builds](./expo-development-build.md) | A custom native build; Expo Go is not supported |

--- a/docs/docs/guide/upgrade-from-v1.md
+++ b/docs/docs/guide/upgrade-from-v1.md
@@ -187,6 +187,7 @@ Before merging the upgrade:
 
 - [ ] No imports of the deprecated 1.x configuration alias remain.
 - [ ] No foreground options still use `enableHighAccuracy`.
+- [ ] No background options still use the inert iOS deferred-delivery fields.
 - [ ] Numeric error comparisons exist only under `/compat` or in explicit legacy
       data migration code.
 - [ ] Every last-known call deliberately chooses module cache or platform cache.

--- a/docs/docs/guide/upgrade-from-v1.md
+++ b/docs/docs/guide/upgrade-from-v1.md
@@ -6,7 +6,7 @@ description: Migrate every React Native Nitro Geolocation 2.0 breaking change wi
 # Upgrade from 1.x to 2.0
 
 Use this guide for an app already running `react-native-nitro-geolocation` 1.x.
-The 2.0 release candidate has **seven** breaking contract changes. Apply them in
+The 2.0 release candidate has **eight** breaking contract changes. Apply them in
 a branch and keep the currently deployed 1.x version available for rollback.
 
 ## Plan the upgrade
@@ -40,6 +40,7 @@ lockfile and native dependency state before attempting API migrations.
 | Removed `enableHighAccuracy` | Foreground current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
 | Unified background events | Background provider/lifecycle listeners and persisted event consumers | Handle the unified discriminated stream | Live plus stored-event tests |
 | Deterministic settings result | Code expecting cancel/unavailable to reject | Branch on `result.outcome` | Satisfied, cancelled, unavailable tests |
+| Removed inert iOS deferred options | Background configuration using `deferredUpdatesDistance` or `deferredUpdatesInterval` | Remove these unused options | Typecheck and configuration snapshots |
 
 ## 1. Use string error codes
 
@@ -168,6 +169,17 @@ reports `satisfied` or `unavailable` without opening an Android-style dialog.
 
 **Verify:** cover every outcome used by the product and keep a catch path for an
 actual request failure.
+
+## 8. Remove retired iOS deferred-delivery options
+
+Remove `ios.deferredUpdatesDistance` and `ios.deferredUpdatesInterval` from
+background configuration. Earlier versions accepted and stored these values but
+never applied them to Core Location. They are excluded from the 2.0 public types
+and configuration snapshots, including snapshots restored from older versions.
+Apple has deprecated the underlying
+[deferred-update API](https://developer.apple.com/documentation/corelocation/cllocationmanager/allowdeferredlocationupdates(untiltraveled:timeout:)).
+Use `accuracy.ios`, `distanceFilter`, and the documented significant-change
+mode to tune acquisition; none promises a fixed background callback schedule.
 
 ## Release gate
 

--- a/docs/docs/v2/background/geofencing.md
+++ b/docs/docs/v2/background/geofencing.md
@@ -35,3 +35,11 @@ place. `removeGeofences()` unregisters the named native regions; call it only
 when the product should stop monitoring them.
 
 `notifyOnDwell` is Android-only. iOS region monitoring supports enter and exit.
+
+On Android, `configureBackgroundLocation({ geofencing: ... })` sets defaults for
+`initialTrigger` and `notificationResponsiveness` (milliseconds). Fields supplied
+in the second argument to `addGeofences(regions, options)` override those defaults
+for that registration; an empty `initialTrigger: []` disables initial triggers.
+Native restoration of persisted regions uses the persisted configuration defaults,
+so put policies that must survive process death/reboot in `geofencing`, not only
+in a per-call override. These two scheduling options are not supported by iOS.

--- a/docs/docs/v2/guide/index.md
+++ b/docs/docs/v2/guide/index.md
@@ -11,7 +11,7 @@ pick one path; you do not need to read every guide before starting.
 | I want to… | Start here | Outcome |
 | --- | --- | --- |
 | Add foreground location to a new app | [Install and get a location](./quick-start.md) | A foreground-only screen that renders coordinates |
-| Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All seven 2.0 breaking changes reviewed and tested |
+| Upgrade Nitro Geolocation 1.x | [Upgrade from 1.x](./upgrade-from-v1.md) | All eight 2.0 breaking changes reviewed and tested |
 | Replace `@react-native-community/geolocation` | [Community migration](./community-migration.md) | `/compat` first, then optionally adopt direct functions and hooks |
 | Replace `react-native-geolocation-service` | [Service migration](./service-migration.md) | Named imports from the package |
 | Use an Expo app | [Expo development builds](./expo-development-build.md) | A custom native build; Expo Go is not supported |

--- a/docs/docs/v2/guide/upgrade-from-v1.md
+++ b/docs/docs/v2/guide/upgrade-from-v1.md
@@ -187,6 +187,7 @@ Before merging the upgrade:
 
 - [ ] No imports of the deprecated 1.x configuration alias remain.
 - [ ] No foreground options still use `enableHighAccuracy`.
+- [ ] No background options still use the inert iOS deferred-delivery fields.
 - [ ] Numeric error comparisons exist only under `/compat` or in explicit legacy
       data migration code.
 - [ ] Every last-known call deliberately chooses module cache or platform cache.

--- a/docs/docs/v2/guide/upgrade-from-v1.md
+++ b/docs/docs/v2/guide/upgrade-from-v1.md
@@ -6,7 +6,7 @@ description: Migrate every React Native Nitro Geolocation 2.0 breaking change wi
 # Upgrade from 1.x to 2.0
 
 Use this guide for an app already running `react-native-nitro-geolocation` 1.x.
-The 2.0 release candidate has **seven** breaking contract changes. Apply them in
+The 2.0 release candidate has **eight** breaking contract changes. Apply them in
 a branch and keep the currently deployed 1.x version available for rollback.
 
 ## Plan the upgrade
@@ -40,6 +40,7 @@ lockfile and native dependency state before attempting API migrations.
 | Removed `enableHighAccuracy` | Foreground current/watch/settings options | Use platform `accuracy` presets | Approximate and precise flows |
 | Unified background events | Background provider/lifecycle listeners and persisted event consumers | Handle the unified discriminated stream | Live plus stored-event tests |
 | Deterministic settings result | Code expecting cancel/unavailable to reject | Branch on `result.outcome` | Satisfied, cancelled, unavailable tests |
+| Removed inert iOS deferred options | Background configuration using `deferredUpdatesDistance` or `deferredUpdatesInterval` | Remove these unused options | Typecheck and configuration snapshots |
 
 ## 1. Use string error codes
 
@@ -168,6 +169,17 @@ reports `satisfied` or `unavailable` without opening an Android-style dialog.
 
 **Verify:** cover every outcome used by the product and keep a catch path for an
 actual request failure.
+
+## 8. Remove retired iOS deferred-delivery options
+
+Remove `ios.deferredUpdatesDistance` and `ios.deferredUpdatesInterval` from
+background configuration. Earlier versions accepted and stored these values but
+never applied them to Core Location. They are excluded from the 2.0 public types
+and configuration snapshots, including snapshots restored from older versions.
+Apple has deprecated the underlying
+[deferred-update API](https://developer.apple.com/documentation/corelocation/cllocationmanager/allowdeferredlocationupdates(untiltraveled:timeout:)).
+Use `accuracy.ios`, `distanceFilter`, and the documented significant-change
+mode to tune acquisition; none promises a fixed background callback schedule.
 
 ## Release gate
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "scripts": {
-    "build": "rspress build",
+    "build": "rspress build && node scripts/finalize-version-routes.mjs",
     "check:versions": "node scripts/check-version-sources.mjs && node scripts/check-version-routes.mjs",
     "dev": "rspress dev",
     "preview": "rspress preview",

--- a/docs/release-audit-2.0.0.md
+++ b/docs/release-audit-2.0.0.md
@@ -57,7 +57,9 @@ Completed locally during implementation:
 - Baseline: 202 JavaScript tests and 18 release/SwiftPM contract tests.
 - Updated JavaScript, React lifecycle, and browser contracts: 213 tests passing.
 - Release/SwiftPM contracts: 20 tests passing.
-- Android JVM/Robolectric suite: 102 tests passing; arm64 Release APK builds pass.
+- Android JVM/Robolectric suite: final counts are recorded in the PR validation
+  ledger; arm64 Release APK builds pass. Numeric regressions include nonfinite,
+  fractional, subnormal, and huge storage caps with cold-store reconstruction.
 - iOS Swift lifecycle, permission, watch delivery, and numeric contracts: passing.
 - iOS CocoaPods source Release simulator build: passing.
 - Complete workspace typecheck, package build, dead-code checks, package dry-run,

--- a/docs/release-audit-2.0.0.md
+++ b/docs/release-audit-2.0.0.md
@@ -19,6 +19,7 @@ promise that every device, OS policy, or application integration is defect-free.
 | Numeric options | iOS numeric-to-integer conversions could trap; Android retries could overflow into zero attempts | Validate foreground numbers and retry counts, bound storage conversions; Swift/JVM contracts |
 | Public contract | iOS deferred delivery options were stored but never implemented | Remove them from the 2.0 public facade and snapshots, retain internal serialization compatibility, document the RC breaking correction and type-test it |
 | GA documentation | Versioning skipped navigation JSON, left RC prose, and retained 1.x as default | Rehearse a real 2.0 build in an isolated copy; verify current routes, legacy archive, and Cloudflare redirects |
+| CI decision | Two distinct jobs published the same `Unit Tests` name, allowing summary views to show success while Android was still running | Unique suite names and one compatibility-preserving aggregate gate; regression tests exercise success, failure, cancellation, and skip combinations |
 | Toolchain security | Production trees contained 117 advisory/deprecation records; an expanded development sweep found another critical XML-parser issue | Compatible refreshes leave 42 production-tree / 43 all-environment records, zero critical; [remaining upstream/toolchain risks](./release-audit-dependencies-2.0.0.md) are explicitly not marked fixed |
 
 ## Roadmap and compatibility review
@@ -50,13 +51,25 @@ native contract scripts, and the consumer E2E suites.
   RN 0.81.1 / Nitro 0.35.10 reference stack. RN 0.87 SwiftPM with Nitro 0.37.1
   remains experimental; no broader test coverage is implied.
 
+## Repository-control preflight
+
+Read-only GitHub checks during this audit found no legacy protection on `main`,
+a `main` ruleset with enforcement disabled, and no configured environments.
+The promotion workflow names `npm-latest`, but a YAML environment name alone
+does not supply required reviewers or deployment restrictions. Configure these
+repository controls before relying on automatic merge/approval gates.
+
+The repository has an `NPM_TOKEN` secret name. Its value, validity, scope, and
+expiry were not inspected or verified by publication. No repository protection,
+environment, or secret setting was changed by this PR.
+
 ## Verification ledger
 
 Completed locally during implementation:
 
 - Baseline: 202 JavaScript tests and 18 release/SwiftPM contract tests.
 - Updated JavaScript, React lifecycle, and browser contracts: 213 tests passing.
-- Release/SwiftPM contracts: 20 tests passing.
+- Release/SwiftPM/CI-gate contracts: 21 tests passing.
 - Android JVM/Robolectric suite: final counts are recorded in the PR validation
   ledger; arm64 Release APK builds pass. Numeric regressions include nonfinite,
   fractional, subnormal, and huge storage caps with cold-store reconstruction.
@@ -83,6 +96,8 @@ Completed locally during implementation:
 ## Release gates after merging
 
 1. Complete PR checks and the recorded E2E runs; inspect any failed scenarios.
+   Enable the intended required checks/repository rules and configure protection
+   for the `npm-latest` environment if approval-gated promotion is required.
 2. Exit Changesets prerelease mode and generate the exact `2.0.0` version commit
    with `yarn release:version`. Review the resulting package/docs/lockfile diff.
 3. Publish through the repository release workflow. Stable packages are staged

--- a/docs/release-audit-2.0.0.md
+++ b/docs/release-audit-2.0.0.md
@@ -19,7 +19,7 @@ promise that every device, OS policy, or application integration is defect-free.
 | Numeric options | iOS numeric-to-integer conversions could trap; Android retries could overflow into zero attempts | Validate foreground numbers and retry counts, bound storage conversions; Swift/JVM contracts |
 | Public contract | iOS deferred delivery options were stored but never implemented | Remove them from the 2.0 public facade and snapshots, retain internal serialization compatibility, document the RC breaking correction and type-test it |
 | GA documentation | Versioning skipped navigation JSON, left RC prose, and retained 1.x as default | Rehearse a real 2.0 build in an isolated copy; verify current routes, legacy archive, and Cloudflare redirects |
-| Toolchain security | Workspace lockfile contained 117 advisory/deprecation records, including two critical | Compatible refreshes reduce this to 42 / zero critical; [remaining upstream/toolchain risks](./release-audit-dependencies-2.0.0.md) are explicitly not marked fixed |
+| Toolchain security | Production trees contained 117 advisory/deprecation records; an expanded development sweep found another critical XML-parser issue | Compatible refreshes leave 42 production-tree / 43 all-environment records, zero critical; [remaining upstream/toolchain risks](./release-audit-dependencies-2.0.0.md) are explicitly not marked fixed |
 
 ## Roadmap and compatibility review
 
@@ -93,6 +93,6 @@ Completed locally during implementation:
    reduced/approximate permissions, and real heading/provider selection remain
    device acceptance gates. Simulator success does not replace these checks.
 6. Review the separate dependency audit before treating the contributor/CI
-   environment as security-cleared; its remaining 42 records are not suppressed.
+   environment as security-cleared; its remaining 43 records are not suppressed.
 
 No npm publication or `latest` promotion is performed by this audit PR.

--- a/docs/release-audit-2.0.0.md
+++ b/docs/release-audit-2.0.0.md
@@ -12,12 +12,14 @@ promise that every device, OS policy, or application integration is defect-free.
 | iOS provider observation | Lazy watcher initialization could run on JS and main threads | Eager immutable watcher instance |
 | Cancellation | Startup throws left abort listeners active; teardown throws left promises pending | Native/browser regression tests reproduce both failures and verify settlement plus late-result suppression |
 | React and web watch lifecycle | Queued callbacks updated stopped/replaced subscriptions; synchronous StrictMode replay lost a result | Real React renderer lifecycle tests and browser ownership/cleanup tests |
-| Android foreground notification | `notificationColor` and `stopActionTitle` were ignored | Native action with immutable, generation-specific intent; Robolectric verifies color, stale action isolation, and stopping without promotion/restart |
+| Android foreground notification | `notificationColor` and `stopActionTitle` were ignored | Native action with immutable, generation-specific intent; Robolectric verifies color, stale action isolation, preserving a newer run's restart policy, and stopping without promotion/restart |
 | Background acquisition | iOS ignored requested accuracy; Android ignored requested granularity | Honor the configured native acquisition settings; Android request contract tests |
 | Background persistence | Android conflated absent and explicit-zero storage caps, changed default stop-on-still after restart; iOS omitted accuracy when restoring | Preserve policies; Android cold-store reconstruction tests; source Release builds |
+| Geofencing defaults | Android ignored configured geofencing defaults and lost them across restart | Apply defaults with per-field registration overrides, persist them, and use them for native restoration; JVM round-trip/override contract |
 | Numeric options | iOS numeric-to-integer conversions could trap; Android retries could overflow into zero attempts | Validate foreground numbers and retry counts, bound storage conversions; Swift/JVM contracts |
 | Public contract | iOS deferred delivery options were stored but never implemented | Remove them from the 2.0 public facade and snapshots, retain internal serialization compatibility, document the RC breaking correction and type-test it |
 | GA documentation | Versioning skipped navigation JSON, left RC prose, and retained 1.x as default | Rehearse a real 2.0 build in an isolated copy; verify current routes, legacy archive, and Cloudflare redirects |
+| Toolchain security | Workspace lockfile contained 117 advisory/deprecation records, including two critical | Compatible refreshes reduce this to 42 / zero critical; [remaining upstream/toolchain risks](./release-audit-dependencies-2.0.0.md) are explicitly not marked fixed |
 
 ## Roadmap and compatibility review
 
@@ -53,16 +55,28 @@ native contract scripts, and the consumer E2E suites.
 Completed locally during implementation:
 
 - Baseline: 202 JavaScript tests and 18 release/SwiftPM contract tests.
-- Updated JavaScript, React lifecycle, and release contracts: passing (final
-  counts recorded below after the last verification pass).
-- Android JVM/Robolectric suite and arm64 Release APK build: passing.
+- Updated JavaScript, React lifecycle, and browser contracts: 213 tests passing.
+- Release/SwiftPM contracts: 20 tests passing.
+- Android JVM/Robolectric suite: 102 tests passing; arm64 Release APK builds pass.
 - iOS Swift lifecycle, permission, watch delivery, and numeric contracts: passing.
 - iOS CocoaPods source Release simulator build: passing.
 - Complete workspace typecheck, package build, dead-code checks, package dry-run,
   source-size checks, and install doctor: passing during implementation.
 - iOS prebuilt checksum tests: 4 tests / 12 assertions, passing.
 - Isolated 2.0 documentation transition: 42 mirrored sources and 24 routes pass.
-- Native E2E and Rozenite E2E: running; update this ledger before final handoff.
+- Actual Changesets 3 rehearsal in a detached temporary worktree: `pre exit`,
+  `version`, source synchronization, real docs build, source/route checks, and
+  npm package dry-run pass. It produces exactly `2.0.0` (583 package files).
+- Android prebuilt checksums: valid downloads/cache reuse, tampered cache,
+  checksum mismatch, and invalid-checksum fallback tests pass.
+- Rozenite behavior E2E: 10/10 cases passing, including after dependency refresh.
+- Native E2E uses the RN 0.81.1 source Release application on an Android API 34
+  arm64 emulator and an iOS 26.5 simulator. Full native suites, final-build
+  background configuration checks, background long-run/reboot, GPS-offline,
+  web fallback, and no-Headless-JS regression results are tracked in the
+  [PR #208 validation ledger](https://github.com/jingjing2222/react-native-nitro-geolocation/pull/208).
+  The PR ledger and checks are the authority for their final pass/fail state;
+  this document does not mark an unfinished run as passed.
 
 ## Release gates after merging
 
@@ -76,5 +90,7 @@ Completed locally during implementation:
 5. Physical-device background delivery, OEM restrictions, battery behavior,
    reduced/approximate permissions, and real heading/provider selection remain
    device acceptance gates. Simulator success does not replace these checks.
+6. Review the separate dependency audit before treating the contributor/CI
+   environment as security-cleared; its remaining 42 records are not suppressed.
 
 No npm publication or `latest` promotion is performed by this audit PR.

--- a/docs/release-audit-2.0.0.md
+++ b/docs/release-audit-2.0.0.md
@@ -1,0 +1,80 @@
+# 2.0.0 release audit
+
+Baseline: `879a562` (main, package `2.0.0-rc.5`). Audit date: 2026-09-09.
+This report records concrete checks and remaining release gates; it does not
+promise that every device, OS policy, or application integration is defect-free.
+
+## Corrections found during this audit
+
+| Area | Defect | Correction and evidence |
+| --- | --- | --- |
+| iOS first authorization | Initial `notDetermined` delegate notification consumed pending permission callbacks | Main-thread permission queue retains them until a decision; Swift contract covers initial notification, concurrent callers, and reentrancy |
+| iOS provider observation | Lazy watcher initialization could run on JS and main threads | Eager immutable watcher instance |
+| Cancellation | Startup throws left abort listeners active; teardown throws left promises pending | Native/browser regression tests reproduce both failures and verify settlement plus late-result suppression |
+| React and web watch lifecycle | Queued callbacks updated stopped/replaced subscriptions; synchronous StrictMode replay lost a result | Real React renderer lifecycle tests and browser ownership/cleanup tests |
+| Android foreground notification | `notificationColor` and `stopActionTitle` were ignored | Native action with immutable, generation-specific intent; Robolectric verifies color, stale action isolation, and stopping without promotion/restart |
+| Background acquisition | iOS ignored requested accuracy; Android ignored requested granularity | Honor the configured native acquisition settings; Android request contract tests |
+| Background persistence | Android conflated absent and explicit-zero storage caps, changed default stop-on-still after restart; iOS omitted accuracy when restoring | Preserve policies; Android cold-store reconstruction tests; source Release builds |
+| Numeric options | iOS numeric-to-integer conversions could trap; Android retries could overflow into zero attempts | Validate foreground numbers and retry counts, bound storage conversions; Swift/JVM contracts |
+| Public contract | iOS deferred delivery options were stored but never implemented | Remove them from the 2.0 public facade and snapshots, retain internal serialization compatibility, document the RC breaking correction and type-test it |
+| GA documentation | Versioning skipped navigation JSON, left RC prose, and retained 1.x as default | Rehearse a real 2.0 build in an isolated copy; verify current routes, legacy archive, and Cloudflare redirects |
+
+## Roadmap and compatibility review
+
+[Roadmap #98](https://github.com/jingjing2222/react-native-nitro-geolocation/issues/98)
+was compared with exported APIs, implementation, type contracts, unit tests,
+native contract scripts, and the consumer E2E suites.
+
+- Readiness, detailed permissions, deterministic settings, cancellation, provider
+  observation, watch introspection, quality metadata, compat metadata, install
+  doctor, Expo plugin, lifecycle events, and unified background events are present.
+- The seven previously documented 2.0 changes remain intact. This audit adds the
+  removal of inert deferred-delivery options as the eighth migration item.
+- `/compat` retains numeric errors and `enableHighAccuracy`; the main API uses
+  string errors and explicit accuracy. Sync cache and async platform-cache APIs
+  remain distinct, and provider tokens remain outside position/heading snapshots.
+- [#206](https://github.com/jingjing2222/react-native-nitro-geolocation/issues/206)
+  requests a 1.4.3 crash backport. 2.x already confines foreground mutable state to
+  main; this PR additionally fixes first-decision handling and watcher creation.
+  A separate 1.x backport is not part of this 2.0 PR.
+- [#195](https://github.com/jingjing2222/react-native-nitro-geolocation/issues/195)
+  requests authorization change events. `watchProviderStatus` observes provider
+  readiness, not detailed permission scope. An explicit permission subscription
+  can be added compatibly in 2.x; it is not an implemented roadmap guarantee.
+- [#207](https://github.com/jingjing2222/react-native-nitro-geolocation/issues/207)
+  requests arbitrary notification actions. This PR fixes the existing stop action;
+  arbitrary actions and JS dispatch remain a separate additive feature.
+- Native peer ranges declare more combinations than the continuously tested
+  RN 0.81.1 / Nitro 0.35.10 reference stack. RN 0.87 SwiftPM with Nitro 0.37.1
+  remains experimental; no broader test coverage is implied.
+
+## Verification ledger
+
+Completed locally during implementation:
+
+- Baseline: 202 JavaScript tests and 18 release/SwiftPM contract tests.
+- Updated JavaScript, React lifecycle, and release contracts: passing (final
+  counts recorded below after the last verification pass).
+- Android JVM/Robolectric suite and arm64 Release APK build: passing.
+- iOS Swift lifecycle, permission, watch delivery, and numeric contracts: passing.
+- iOS CocoaPods source Release simulator build: passing.
+- Complete workspace typecheck, package build, dead-code checks, package dry-run,
+  source-size checks, and install doctor: passing during implementation.
+- iOS prebuilt checksum tests: 4 tests / 12 assertions, passing.
+- Isolated 2.0 documentation transition: 42 mirrored sources and 24 routes pass.
+- Native E2E and Rozenite E2E: running; update this ledger before final handoff.
+
+## Release gates after merging
+
+1. Complete PR checks and the recorded E2E runs; inspect any failed scenarios.
+2. Exit Changesets prerelease mode and generate the exact `2.0.0` version commit
+   with `yarn release:version`. Review the resulting package/docs/lockfile diff.
+3. Publish through the repository release workflow. Stable packages are staged
+   under `ga-candidate`, not sent directly to `latest`.
+4. Build and verify matching 2.0.0 Android, CocoaPods iOS, and SwiftPM release
+   assets and checksums, then run the `promote-latest` workflow for `2.0.0`.
+5. Physical-device background delivery, OEM restrictions, battery behavior,
+   reduced/approximate permissions, and real heading/provider selection remain
+   device acceptance gates. Simulator success does not replace these checks.
+
+No npm publication or `latest` promotion is performed by this audit PR.

--- a/docs/release-audit-dependencies-2.0.0.md
+++ b/docs/release-audit-dependencies-2.0.0.md
@@ -1,0 +1,50 @@
+# 2.0.0 dependency audit
+
+Checked 2026-09-09 with:
+
+```sh
+yarn npm audit --all --recursive --environment production --json
+```
+
+`--all` matters: the private root has no production dependencies, so auditing
+only the root produces a misleading empty result. This command covers all
+workspace dependency trees, including examples, documentation, and development
+tools, not just the published geolocation package.
+
+## Remediation
+
+The initial result contained 117 advisory/deprecation records (2 critical,
+58 high, 48 moderate, 9 low). Re-resolving affected packages within existing
+ranges, plus narrowly scoped same-major overrides for Ajv, Lodash, and Minimatch,
+reduced this to 42 records (0 critical, 10 high, 26 moderate, 6 low).
+The lockfile also refreshes the documentation router through its existing 7.x
+range. No React Native, React, Nitro, or Electron major was changed.
+
+This fixes the reported critical archive-parser and shell-quoting advisories,
+and the reported vulnerable versions of Babel, brace expansion, Browserslist,
+Ajv, Lodash, Minimatch, Nano ID, PostCSS, React Router, tar, Vite, ws, YAML, and
+other eligible transitive dependencies. This is a dated registry snapshot, not
+a guarantee against future advisories.
+
+## Remaining records and exposure boundary
+
+| Package | Records | Why it remains / boundary |
+| --- | ---: | --- |
+| Electron 33.4.11 | 33 | Supplied by `@rozenite/electron-app`; even its 2.4.0 release still declares Electron 33. Moving to a supported Electron major is a separate upstream/integration migration. Used for developer tooling, not bundled into the geolocation runtime. Do not use this audit as approval to load untrusted content in that application. |
+| extract-zip 2.0.1 | 1 | Electron installation dependency; the registry's latest release is still affected and the advisory lists no patched release. Only install verified artifacts from trusted sources. |
+| image-size 1.2.1 | 2 | Metro asset parser; the latest 2.0.2 is also affected, with no patched release in the advisories. Do not process untrusted image fixtures in build infrastructure. |
+| decode-uri-component 0.2.2 | 1 | Example navigation's `query-string` dependency. The fixed 0.5 line is ESM while this dependency path uses CommonJS; forcing that cross-version change is not a compatible lockfile refresh. |
+| uuid 7.0.3 | 1 | Xcode-project tooling dependency; fixing the advisory requires a newer major and upstream compatibility review. |
+| boolean, glob, inflight, rimraf | 4 | Registry deprecation/support notices in the toolchain. These are retained in the total rather than hidden as successful checks. |
+
+Primary advisory references: [extract-zip](https://github.com/advisories/GHSA-jmr9-qjv8-65gv),
+[image-size ICNS](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr),
+[image-size JXL/HEIF](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq),
+[decode-uri-component](https://github.com/advisories/GHSA-vcc3-ghjq-m6fr),
+[uuid](https://github.com/advisories/GHSA-w5hq-g745-h8pq).
+
+The published `react-native-nitro-geolocation` manifest has peer dependencies
+but no `dependencies`. These workspace lockfile overrides do not pin or secure
+a consuming application's React Native/toolchain tree. Consumers must audit
+their own lockfiles. The remaining warnings are not asserted to be harmless or
+fixed; a zero-warning workspace security gate remains unmet.

--- a/docs/release-audit-dependencies-2.0.0.md
+++ b/docs/release-audit-dependencies-2.0.0.md
@@ -4,6 +4,7 @@ Checked 2026-09-09 with:
 
 ```sh
 yarn npm audit --all --recursive --environment production --json
+yarn npm audit --all --recursive --json
 ```
 
 `--all` matters: the private root has no production dependencies, so auditing
@@ -18,7 +19,13 @@ The initial result contained 117 advisory/deprecation records (2 critical,
 ranges, plus narrowly scoped same-major overrides for Ajv, Lodash, and Minimatch,
 reduced this to 42 records (0 critical, 10 high, 26 moderate, 6 low).
 The lockfile also refreshes the documentation router through its existing 7.x
-range. No React Native, React, Nitro, or Electron major was changed.
+range. A subsequent all-environment sweep (including development-only roots)
+found 62 records, including one additional critical XML-parser advisory.
+Compatible development-tool updates reduce the final all-environment result to
+43 records (0 critical, 10 high, 27 moderate, 6 low). This also updates the pinned
+web E2E Vite server to 8.0.16 and refreshes Babel's SystemJS transform, body-parser,
+fast-xml-parser, Joi, launch-editor, path-to-regexp, and qs. No React Native,
+React, Nitro, or Electron major was changed.
 
 This fixes the reported critical archive-parser and shell-quoting advisories,
 and the reported vulnerable versions of Babel, brace expansion, Browserslist,
@@ -35,13 +42,15 @@ a guarantee against future advisories.
 | image-size 1.2.1 | 2 | Metro asset parser; the latest 2.0.2 is also affected, with no patched release in the advisories. Do not process untrusted image fixtures in build infrastructure. |
 | decode-uri-component 0.2.2 | 1 | Example navigation's `query-string` dependency. The fixed 0.5 line is ESM while this dependency path uses CommonJS; forcing that cross-version change is not a compatible lockfile refresh. |
 | uuid 7.0.3 | 1 | Xcode-project tooling dependency; fixing the advisory requires a newer major and upstream compatibility review. |
+| fast-xml-parser 4.5.7 | 1 | The Android CLI's 4.x parser is updated past its critical advisory. A separate moderate advisory still requires 5.7.0 or later; that major migration needs upstream CLI compatibility review. |
 | boolean, glob, inflight, rimraf | 4 | Registry deprecation/support notices in the toolchain. These are retained in the total rather than hidden as successful checks. |
 
 Primary advisory references: [extract-zip](https://github.com/advisories/GHSA-jmr9-qjv8-65gv),
 [image-size ICNS](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr),
 [image-size JXL/HEIF](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq),
 [decode-uri-component](https://github.com/advisories/GHSA-vcc3-ghjq-m6fr),
-[uuid](https://github.com/advisories/GHSA-w5hq-g745-h8pq).
+[uuid](https://github.com/advisories/GHSA-w5hq-g745-h8pq),
+[remaining XML-parser issue](https://github.com/advisories/GHSA-gh4j-gqv2-49f6).
 
 The published `react-native-nitro-geolocation` manifest has peer dependencies
 but no `dependencies`. These workspace lockfile overrides do not pin or secure

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -1,5 +1,17 @@
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { type RspressPlugin, defineConfig } from "@rspress/core";
+
+const packageVersion: string = JSON.parse(
+  readFileSync(
+    path.join(
+      __dirname,
+      "../packages/react-native-nitro-geolocation/package.json"
+    ),
+    "utf8"
+  )
+).version;
+const isReleaseCandidate = packageVersion.includes("-rc.");
 
 const v2OnlyRoutes = [
   "background/location-lifecycle",
@@ -44,13 +56,13 @@ export default defineConfig({
   logo: "/logo.png",
   logoText: "React Native Nitro Geolocation",
   multiVersion: {
-    default: "v1",
+    default: isReleaseCandidate ? "v1" : "v2",
     versions: ["v1", "v2"]
   },
   route: {
     exclude: ["./index.md", "./guide/**", "./background/**"]
   },
-  plugins: [versionFallbacks],
+  plugins: isReleaseCandidate ? [versionFallbacks] : [],
   head: [
     [
       "meta",

--- a/docs/scripts/check-version-routes.mjs
+++ b/docs/scripts/check-version-routes.mjs
@@ -12,6 +12,7 @@ const packageJsonPath = path.resolve(
 );
 const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
 const isReleaseCandidate = /-rc\.\d+$/.test(packageJson.version);
+const currentPrefix = isReleaseCandidate ? "v2/" : "";
 const requiredRoutes = [
   "index.html",
   "guide/api.html",
@@ -35,7 +36,9 @@ const requiredRoutes = [
   "guide/v2-error-migration.html",
   "guide/v2-unified-background-events.html",
   "guide/watch-observability.html"
-];
+].map((route) => (isReleaseCandidate ? route : route.replace(/^v2\//, "")));
+if (!isReleaseCandidate)
+  requiredRoutes.push("v1/index.html", "v1/guide/api.html");
 
 await Promise.all(
   requiredRoutes.map(async (route) => {
@@ -47,12 +50,15 @@ await Promise.all(
   })
 );
 
-const v2Home = await readFile(path.join(buildRoot, "v2/index.html"), "utf8");
+const v2Home = await readFile(
+  path.join(buildRoot, `${currentPrefix}index.html`),
+  "utf8"
+);
 const requiredV2Links = [
   "/v2/guide/quick-start.html",
   "/v2/guide/upgrade-from-v1.html",
   "/v2/background/overview.html"
-];
+].map((href) => (isReleaseCandidate ? href : href.replace("/v2/", "/")));
 
 for (const href of requiredV2Links) {
   if (!v2Home.includes(`href="${href}"`)) {
@@ -61,7 +67,7 @@ for (const href of requiredV2Links) {
 }
 
 const v2Guide = await readFile(
-  path.join(buildRoot, "v2/guide/index.html"),
+  path.join(buildRoot, `${currentPrefix}guide/index.html`),
   "utf8"
 );
 const requiredDecisionLinks = [
@@ -73,7 +79,7 @@ const requiredDecisionLinks = [
   "/v2/background/overview.html",
   "/v2/guide/release-readiness.html",
   "/v2/guide/troubleshooting.html"
-];
+].map((href) => (isReleaseCandidate ? href : href.replace("/v2/", "/")));
 
 for (const href of requiredDecisionLinks) {
   if (!v2Guide.includes(`href="${href}"`)) {
@@ -81,7 +87,10 @@ for (const href of requiredDecisionLinks) {
   }
 }
 
-const v2Api = await readFile(path.join(buildRoot, "v2/guide/api.html"), "utf8");
+const v2Api = await readFile(
+  path.join(buildRoot, `${currentPrefix}guide/api.html`),
+  "utf8"
+);
 
 if (isReleaseCandidate && !v2Api.includes(">2.0 RC<")) {
   throw new Error("A deep v2 page does not expose the persistent RC marker.");
@@ -92,7 +101,9 @@ if (!isReleaseCandidate && v2Api.includes(">2.0 RC<")) {
 }
 
 if (
-  !v2Api.includes('href="https://react-native-nitro-geolocation.pages.dev/"')
+  !v2Api.includes(
+    `href="https://react-native-nitro-geolocation.pages.dev/${isReleaseCandidate ? "" : "v1/"}"`
+  )
 ) {
   throw new Error("A deep v2 page does not expose the stable 1.x docs link.");
 }
@@ -100,6 +111,7 @@ if (
 const readme = await readFile(packageReadme, "utf8");
 
 if (
+  isReleaseCandidate &&
   /react-native-nitro-geolocation\.pages\.dev\/(?:guide|background)\//.test(
     readme
   )

--- a/docs/scripts/finalize-version-routes.mjs
+++ b/docs/scripts/finalize-version-routes.mjs
@@ -1,0 +1,17 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const manifest = JSON.parse(
+  await readFile(
+    new URL(
+      "../../packages/react-native-nitro-geolocation/package.json",
+      import.meta.url
+    ),
+    "utf8"
+  )
+);
+// Cloudflare Pages keeps links to the RC documentation usable after 2.x becomes
+// the default documentation version. RC builds still serve those routes directly.
+await writeFile(
+  new URL("../doc_build/_redirects", import.meta.url),
+  manifest.version.includes("-rc.") ? "" : "/v2/ / 301\n/v2/* /:splat 301\n"
+);

--- a/examples/v0.81.1/.maestro/geocoding.yaml
+++ b/examples/v0.81.1/.maestro/geocoding.yaml
@@ -5,6 +5,7 @@ appId: nitrogeolocation.example
 
 - launchApp:
     clearState: true
+    stopApp: false # clearState already stops the app; avoid a second asynchronous task removal.
     permissions:
       all: allow
 

--- a/examples/v0.81.1/.maestro/permission-details.yaml
+++ b/examples/v0.81.1/.maestro/permission-details.yaml
@@ -5,6 +5,7 @@ appId: nitrogeolocation.example
 
 - launchApp:
     clearState: true
+    stopApp: false # clearState already stops the app; avoid a second asynchronous task removal.
     permissions:
       all: unset
 - runFlow:
@@ -74,6 +75,7 @@ appId: nitrogeolocation.example
 
 - launchApp:
     clearState: true
+    stopApp: false
     permissions:
       all: allow
 - runFlow:
@@ -117,6 +119,7 @@ appId: nitrogeolocation.example
     commands:
       - launchApp:
           clearState: true
+          stopApp: false
           permissions:
             all: deny
             android.permission.ACCESS_COARSE_LOCATION: allow
@@ -150,6 +153,7 @@ appId: nitrogeolocation.example
 
 - launchApp:
     clearState: true
+    stopApp: false
     permissions:
       all: deny
 - runFlow:

--- a/examples/v0.81.1/ios/Podfile.lock
+++ b/examples/v0.81.1/ios/Podfile.lock
@@ -2767,7 +2767,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroGeolocation: b55ed115c860dfbd4ddc20a9e4f70b142a486b99
+  NitroGeolocation: 07a622101316239be51d68030a2084594f7ff4c2
   NitroModules: b5c5baefa71a65c40e129876a8b7943a9aef6aa5
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077

--- a/examples/v0.81.1/src/screens/backgroundE2EOptions.ts
+++ b/examples/v0.81.1/src/screens/backgroundE2EOptions.ts
@@ -9,12 +9,14 @@ export const backgroundE2EOptions = {
     Platform.OS === "android"
       ? ("activityAware" as const)
       : ("continuous" as const),
+  accuracy: { android: "balanced" as const, ios: "nearestTenMeters" as const },
+  granularity: "permission" as const,
   interval: 10_000,
   fastestInterval: 5_000,
   distanceFilter: 25,
   persist: true,
-  maxStoredLocations: 10_000,
-  maxStoredEvents: 10_000,
+  maxStoredLocations: 0,
+  maxStoredEvents: 0,
   stopOnTerminate: false,
   startOnBoot: true,
   android: {
@@ -22,12 +24,18 @@ export const backgroundE2EOptions = {
       notificationTitle: "Background tracking active",
       notificationText: "Recording location updates for E2E validation",
       notificationChannelId: "nitro-background-location-e2e",
-      notificationChannelName: "Nitro Background Location E2E"
+      notificationChannelName: "Nitro Background Location E2E",
+      notificationColor: "#123456",
+      stopActionTitle: "Stop E2E tracking"
     }
   },
   ios: {
     pausesLocationUpdatesAutomatically: false,
     showsBackgroundLocationIndicator: true
+  },
+  geofencing: {
+    initialTrigger: ["enter" as const],
+    notificationResponsiveness: 2000
   },
   activityRecognition: {
     enabled: Platform.OS === "android",
@@ -46,6 +54,9 @@ export const assertBackgroundE2EConfiguration = async () => {
   const expected = backgroundE2EOptions;
   const commonMatches =
     configuration.trackingMode === expected.trackingMode &&
+    configuration.accuracy?.android === expected.accuracy.android &&
+    configuration.accuracy?.ios === expected.accuracy.ios &&
+    configuration.granularity === expected.granularity &&
     configuration.interval === expected.interval &&
     configuration.fastestInterval === expected.fastestInterval &&
     configuration.distanceFilter === expected.distanceFilter &&
@@ -60,6 +71,12 @@ export const assertBackgroundE2EConfiguration = async () => {
           expected.android.foregroundService.notificationTitle &&
         configuration.android.foregroundService.notificationText ===
           expected.android.foregroundService.notificationText &&
+        configuration.android.foregroundService.notificationColor ===
+          expected.android.foregroundService.notificationColor &&
+        configuration.android.foregroundService.stopActionTitle ===
+          expected.android.foregroundService.stopActionTitle &&
+        configuration.geofencing?.initialTrigger?.join(",") === "enter" &&
+        configuration.geofencing.notificationResponsiveness === 2000 &&
         configuration.activityRecognition?.enabled === true
       : configuration.ios?.pausesLocationUpdatesAutomatically === false &&
         configuration.ios.showsBackgroundLocationIndicator === true;

--- a/examples/web-e2e/package.json
+++ b/examples/web-e2e/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "5.9.3",
-    "vite": "8.0.10"
+    "vite": "8.0.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "docs"
   ],
   "resolutions": {
+    "ajv@npm:~8.12.0": "npm:8.18.0",
+    "ajv@npm:~8.13.0": "npm:8.18.0",
+    "lodash@npm:~4.17.15": "npm:4.18.1",
+    "minimatch@npm:10.0.3": "npm:10.2.6",
     "brace-expansion@npm:5.0.8": "npm:5.0.9"
   },
   "homepage": "react-native-nitro-geolocation.pages.dev",

--- a/packages/react-native-nitro-geolocation/README.md
+++ b/packages/react-native-nitro-geolocation/README.md
@@ -267,7 +267,7 @@ for setup, presets, troubleshooting, and the demo.
 Use the docs site for the detailed flows:
 
 - [Quick Start](https://react-native-nitro-geolocation.pages.dev/v2/guide/quick-start) - install with minimum foreground permissions and render coordinates.
-- [Upgrade from 1.x](https://react-native-nitro-geolocation.pages.dev/v2/guide/upgrade-from-v1) - migrate all seven breaking contracts with rollback gates.
+- [Upgrade from 1.x](https://react-native-nitro-geolocation.pages.dev/v2/guide/upgrade-from-v1) - migrate all eight breaking contracts with rollback gates.
 - [Release Readiness](https://react-native-nitro-geolocation.pages.dev/v2/guide/release-readiness) - RC policy, tested reference stack, known limits, and ship checklist.
 - [API](https://react-native-nitro-geolocation.pages.dev/v2/guide/api) - accuracy presets, watches, Android settings, cached reads, geocoding, heading, and iOS accuracy authorization.
 - [Compat API](https://react-native-nitro-geolocation.pages.dev/v2/guide/compat-api) - callback compatibility and documented boundaries.

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundHttpSync.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundHttpSync.kt
@@ -8,16 +8,24 @@ import java.net.HttpURLConnection
 import java.net.URL
 import kotlin.random.Random
 
+internal fun httpSyncAttemptCount(retry: Boolean?, maxRetries: Double?): Int? {
+    if (retry != true) return 1
+    val retries = maxRetries ?: 3.0
+    if (!retries.isFinite() || retries < 0 || retries >= Int.MAX_VALUE ||
+        retries != kotlin.math.floor(retries)) return null
+    return retries.toInt() + 1
+}
+
 internal class AndroidBackgroundHttpSync {
     fun uploadLocationsWithRetry(
         sync: BackgroundHttpSyncOptions,
         locations: Array<StoredBackgroundLocation>
     ): BackgroundHttpSyncResult {
-        val maxAttempts = if (sync.retry == true) {
-            (sync.maxRetries?.toInt()?.takeIf { it >= 0 } ?: 3) + 1
-        } else {
-            1
-        }
+        val maxAttempts = httpSyncAttemptCount(sync.retry, sync.maxRetries)
+            ?: return BackgroundHttpSyncResult(
+                false, null, emptyArray(), locations.map { it.id }.toTypedArray(),
+                "maxRetries must be an integer between 0 and 2147483646."
+            )
         var lastStatus: Int? = null
         var lastError: String? = null
 

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundLocationRequest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidBackgroundLocationRequest.kt
@@ -1,0 +1,15 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.google.android.gms.location.LocationRequest
+import com.margelo.nitro.nitrogeolocation.AndroidGranularity
+import com.margelo.nitro.nitrogeolocation.BackgroundLocationOptions
+import com.margelo.nitro.nitrogeolocation.gmsGranularity
+
+internal fun buildBackgroundLocationRequest(options: BackgroundLocationOptions): LocationRequest =
+    LocationRequest.Builder(resolvePriority(options), options.interval?.toLong() ?: 10_000L)
+        .setMinUpdateIntervalMillis(options.fastestInterval?.toLong() ?: 5_000L)
+        .setMinUpdateDistanceMeters((options.distanceFilter ?: 0.0).toFloat())
+        .setGranularity((options.granularity ?: AndroidGranularity.PERMISSION).gmsGranularity())
+        .setWaitForAccurateLocation(options.waitForAccurateLocation == true)
+        .setMaxUpdateDelayMillis(options.maxUpdateDelay?.toLong() ?: 0L)
+        .build()

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidGeofencingOptions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/AndroidGeofencingOptions.kt
@@ -1,0 +1,28 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import com.margelo.nitro.nitrogeolocation.GeofenceTransition
+import com.margelo.nitro.nitrogeolocation.GeofencingOptions
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun resolveGeofencingOptions(
+    defaults: GeofencingOptions?, overrides: GeofencingOptions?
+): GeofencingOptions? = if (defaults == null && overrides == null) null else GeofencingOptions(
+    overrides?.initialTrigger ?: defaults?.initialTrigger,
+    overrides?.notificationResponsiveness ?: defaults?.notificationResponsiveness
+)
+
+internal fun geofencingOptionsJson(options: GeofencingOptions): String = JSONObject().apply {
+    options.initialTrigger?.let { put("initialTrigger", JSONArray(it.map { transition -> transition.name })) }
+    options.notificationResponsiveness?.let { put("notificationResponsiveness", it) }
+}.toString()
+
+internal fun geofencingOptionsFromJson(value: String): GeofencingOptions? = runCatching {
+    val json = JSONObject(value)
+    val triggers = json.optJSONArray("initialTrigger")?.let { array ->
+        (0 until array.length()).map { GeofenceTransition.valueOf(array.getString(it)) }.toTypedArray()
+    }
+    GeofencingOptions(triggers, if (json.has("notificationResponsiveness")) {
+        json.getDouble("notificationResponsiveness")
+    } else null)
+}.getOrNull()

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisions.kt
@@ -59,19 +59,19 @@ internal fun backoffBaseDelayMs(attempt: Int, baseMs: Long, maxMs: Long): Long {
  *    original code gave for any non-positive value
  *  - explicit > 0 → that cap
  */
-internal fun resolveMaxStored(configured: Int?, default: Int): Int {
+internal fun resolveMaxStored(configured: Double?, default: Int): Int {
     return when {
-        configured == null -> default
+        configured == null || !configured.isFinite() -> default
         configured <= 0 -> 0
-        else -> configured
+        else -> configured.toInt().coerceAtLeast(1)
     }
 }
 
 internal fun maxStoredLocations(options: BackgroundLocationOptions?): Int =
-    resolveMaxStored(options?.maxStoredLocations?.toInt(), DEFAULT_MAX_STORED_LOCATIONS)
+    resolveMaxStored(options?.maxStoredLocations, DEFAULT_MAX_STORED_LOCATIONS)
 
 internal fun maxStoredEvents(options: BackgroundLocationOptions?): Int =
-    resolveMaxStored(options?.maxStoredEvents?.toInt(), DEFAULT_MAX_STORED_EVENTS)
+    resolveMaxStored(options?.maxStoredEvents, DEFAULT_MAX_STORED_EVENTS)
 
 /**
  * Headless JS is the fallback path when no in-process JS listener received the native event. If a

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
@@ -32,12 +32,14 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
             .putFloat("maxUpdateDelay", (options.maxUpdateDelay ?: 0.0).toFloat())
             .putBoolean("waitForAccurateLocation", options.waitForAccurateLocation == true)
             .putBoolean("persist", options.persist != false)
+            .putBoolean("maxStoredLocationsConfigured", options.maxStoredLocations != null)
+            .putBoolean("maxStoredEventsConfigured", options.maxStoredEvents != null)
             .putFloat("maxStoredLocations", (options.maxStoredLocations ?: 0.0).toFloat())
             .putFloat("maxStoredEvents", (options.maxStoredEvents ?: 0.0).toFloat())
             .putBoolean("activityConfigured", options.activityRecognition != null)
             .putBoolean("activityEnabled", options.activityRecognition?.enabled == true)
             .putFloat("activityInterval", (options.activityRecognition?.interval ?: 10_000.0).toFloat())
-            .putBoolean("activityStopOnStill", options.activityRecognition?.stopOnStill == true)
+            .putBoolean("activityStopOnStill", options.activityRecognition?.stopOnStill != false)
             .putFloat(
                 "activityMinimumConfidence",
                 (options.activityRecognition?.minimumConfidence ?: 0.0).toFloat()
@@ -131,8 +133,8 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
             prefs.getFloat("maxUpdateDelay", 0f).toDouble(),
             prefs.getBoolean("waitForAccurateLocation", false),
             prefs.getBoolean("persist", true),
-            prefs.getFloat("maxStoredLocations", 0f).toDouble().takeIf { it > 0 },
-            prefs.getFloat("maxStoredEvents", 0f).toDouble().takeIf { it > 0 },
+            restoreStorageLimit("maxStoredLocations"),
+            restoreStorageLimit("maxStoredEvents"),
             prefs.getBoolean("stopOnTerminate", true),
             prefs.getBoolean("startOnBoot", false),
             AndroidBackgroundLocationOptions(
@@ -148,5 +150,13 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
             activityRecognition,
             sync
         )
+    }
+
+    private fun restoreStorageLimit(key: String): Double? {
+        val value = prefs.getFloat(key, 0f).toDouble()
+        // Old releases did not distinguish an omitted cap from explicit zero.
+        return if (prefs.contains("${key}Configured")) {
+            value.takeIf { prefs.getBoolean("${key}Configured", false) }
+        } else value.takeIf { it > 0 }
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
@@ -53,6 +53,7 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
             .putString("notificationIcon", service?.notificationIcon)
             .putString("notificationColor", service?.notificationColor)
             .putString("stopActionTitle", service?.stopActionTitle)
+            .putString("geofencing", options.geofencing?.let(::geofencingOptionsJson))
             .putString("syncUrl", options.sync?.url)
             .putString("syncMethod", options.sync?.method?.name)
             .putString("syncHeaders", options.sync?.headers?.let(::stringMapToJson))
@@ -146,7 +147,7 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
                 prefs.getBoolean("androidRequestIgnoreBatteryOptimizations", false)
             ),
             null,
-            null,
+            prefs.getString("geofencing", null)?.let(::geofencingOptionsFromJson),
             activityRecognition,
             sync
         )

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigStore.kt
@@ -34,6 +34,8 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
             .putBoolean("persist", options.persist != false)
             .putBoolean("maxStoredLocationsConfigured", options.maxStoredLocations != null)
             .putBoolean("maxStoredEventsConfigured", options.maxStoredEvents != null)
+            .putString("maxStoredLocationsValue", options.maxStoredLocations?.toString())
+            .putString("maxStoredEventsValue", options.maxStoredEvents?.toString())
             .putFloat("maxStoredLocations", (options.maxStoredLocations ?: 0.0).toFloat())
             .putFloat("maxStoredEvents", (options.maxStoredEvents ?: 0.0).toFloat())
             .putBoolean("activityConfigured", options.activityRecognition != null)
@@ -154,6 +156,9 @@ internal class NitroBackgroundConfigStore(private val prefs: SharedPreferences) 
     }
 
     private fun restoreStorageLimit(key: String): Double? {
+        // SharedPreferences floats can underflow a positive limit to the unbounded
+        // sentinel or overflow a large finite limit to infinity across a restart.
+        prefs.getString("${key}Value", null)?.toDoubleOrNull()?.let { return it }
         val value = prefs.getFloat(key, 0f).toDouble()
         // Old releases did not distinguish an omitted cap from explicit zero.
         return if (prefs.contains("${key}Configured")) {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundGeofenceCoordinator.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundGeofenceCoordinator.kt
@@ -21,7 +21,8 @@ internal class NitroBackgroundGeofenceCoordinator(
     private val backgroundPermission: () -> BackgroundPermissionStatus,
     private val currentRunGeneration: () -> Long,
     private val activeServiceGeneration: () -> Long?,
-    private val reportError: (String, Throwable, Long?) -> Unit
+    private val reportError: (String, Throwable, Long?) -> Unit,
+    private val defaultOptions: () -> GeofencingOptions?
 ) {
     private val commandLock = ReentrantLock()
     private val restoreExecutor = Executors.newSingleThreadExecutor()
@@ -31,7 +32,7 @@ internal class NitroBackgroundGeofenceCoordinator(
             throw SecurityException("Background location permission is required to register geofences")
         }
         if (regions.isEmpty()) return
-        register(regions, options, currentRunGeneration())
+        register(regions, resolveGeofencingOptions(defaultOptions(), options), currentRunGeneration())
         store.saveGeofences(regions)
     }
 
@@ -68,7 +69,7 @@ internal class NitroBackgroundGeofenceCoordinator(
                     activeServiceGeneration() == expectedServiceGeneration) {
                     val regions = store.getGeofences()
                     if (regions.isNotEmpty()) {
-                        register(regions, null, currentRunGeneration())
+                        register(regions, defaultOptions(), currentRunGeneration())
                     }
                 }
             } finally {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -13,7 +13,6 @@ import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.ActivityRecognition
 import com.google.android.gms.location.ActivityRecognitionResult
 import com.google.android.gms.location.GeofencingEvent
-import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.margelo.nitro.nitrogeolocation.*
 import java.util.concurrent.CompletableFuture
@@ -378,15 +377,7 @@ class NitroBackgroundLocationController private constructor(
                 return
             }
             NitroGeoLog.d("startNativeLocationUpdates(): FUSED provider, registering broadcast PendingIntent")
-            val request = LocationRequest.Builder(
-                resolvePriority(current),
-                current.interval?.toLong() ?: 10_000L
-            )
-                .setMinUpdateIntervalMillis(current.fastestInterval?.toLong() ?: 5_000L)
-                .setMinUpdateDistanceMeters((current.distanceFilter ?: 0.0).toFloat())
-                .setWaitForAccurateLocation(current.waitForAccurateLocation == true)
-                .setMaxUpdateDelayMillis(current.maxUpdateDelay?.toLong() ?: 0L)
-                .build()
+            val request = buildBackgroundLocationRequest(current)
             val callback = pendingIntents.location(callbackGeneration, registration.generation)
 
             removeLegacyLocationUpdates()

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationController.kt
@@ -56,7 +56,8 @@ class NitroBackgroundLocationController private constructor(
             permissions::backgroundPermission,
             { runGeneration },
             ::activeServiceGeneration,
-            ::recordError
+            ::recordError,
+            { getConfigOrNull()?.geofencing }
         )
     }
     private val activityCoordinator by lazy {

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
@@ -17,8 +17,13 @@ class NitroBackgroundLocationService : Service() {
         if (intent?.action == ACTION_STOP_BACKGROUND_LOCATION) {
             // A delayed action from an older notification must not stop a newer run.
             requestedGeneration?.let(controller::stopFromService)
-            if (controller.runningServiceGeneration() == null) stopSelf(startId)
-            return START_NOT_STICKY
+            val stillRunning = controller.runningServiceGeneration() != null
+            if (!stillRunning) stopSelf(startId)
+            // Android uses the result of the latest command for restart policy,
+            // including ignored commands from an obsolete notification.
+            return if (stillRunning && controller.getConfigOrNull()?.stopOnTerminate == false) {
+                START_STICKY
+            } else START_NOT_STICKY
         }
         val foregroundService = intent?.backgroundNotificationOptions()
             ?: persistedBackgroundNotificationOptions(applicationContext)

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundLocationService.kt
@@ -14,11 +14,24 @@ class NitroBackgroundLocationService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val requestedGeneration = intent?.backgroundServiceGeneration()
+        if (intent?.action == ACTION_STOP_BACKGROUND_LOCATION) {
+            // A delayed action from an older notification must not stop a newer run.
+            requestedGeneration?.let(controller::stopFromService)
+            if (controller.runningServiceGeneration() == null) stopSelf(startId)
+            return START_NOT_STICKY
+        }
         val foregroundService = intent?.backgroundNotificationOptions()
             ?: persistedBackgroundNotificationOptions(applicationContext)
             ?: fallbackBackgroundNotificationOptions()
         try {
-            val notification = NitroBackgroundNotificationFactory.create(this, foregroundService)
+            // Read the durable generation directly before promotion: controller lifecycle
+            // locks can be held by the worker waiting for this service to start.
+            val notificationGeneration = requestedGeneration
+                ?: getSharedPreferences(BACKGROUND_LOCATION_PREFS, MODE_PRIVATE)
+                    .getLong(PREF_SERVICE_GENERATION, 0L)
+            val notification = NitroBackgroundNotificationFactory.create(
+                this, foregroundService, notificationGeneration
+            )
             val notificationId = foregroundService.notificationId?.toInt() ?: 9471
             NitroGeoLog.d("Service.onStartCommand(): startForeground id=$notificationId type=location")
             ServiceCompat.startForeground(

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationFactory.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationFactory.kt
@@ -3,13 +3,21 @@ package com.margelo.nitro.nitrogeolocation.background
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.margelo.nitro.nitrogeolocation.AndroidForegroundServiceOptions
 
 object NitroBackgroundNotificationFactory {
-    fun create(context: Context, options: AndroidForegroundServiceOptions): Notification {
+    fun create(
+        context: Context,
+        options: AndroidForegroundServiceOptions,
+        serviceGeneration: Long
+    ): Notification {
         val channelId = options.notificationChannelId ?: "nitro-background-location"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = context.getSystemService(NotificationManager::class.java)
@@ -26,12 +34,28 @@ object NitroBackgroundNotificationFactory {
             context.resources.getIdentifier(name, "drawable", context.packageName)
         }?.takeIf { it != 0 } ?: android.R.drawable.ic_menu_mylocation
 
-        return NotificationCompat.Builder(context, channelId)
+        val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(icon)
             .setContentTitle(options.notificationTitle)
             .setContentText(options.notificationText)
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
-            .build()
+        options.notificationColor?.let { color ->
+            runCatching { Color.parseColor(color) }.getOrNull()?.let(builder::setColor)
+        }
+        options.stopActionTitle?.takeIf { it.isNotBlank() }?.let { title ->
+            val stopIntent = Intent(context, NitroBackgroundLocationService::class.java)
+                .setAction(ACTION_STOP_BACKGROUND_LOCATION)
+                .setData(Uri.parse(pendingIntentIdentityUri("stop", serviceGeneration)))
+                .putExtra(EXTRA_SERVICE_GENERATION, serviceGeneration)
+            val stopAction = PendingIntent.getService(
+                context,
+                1004,
+                stopIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            builder.addAction(android.R.drawable.ic_menu_close_clear_cancel, title, stopAction)
+        }
+        return builder.build()
     }
 }

--- a/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntent.kt
+++ b/packages/react-native-nitro-geolocation/android/src/main/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundServiceIntent.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.content.Intent
 import com.margelo.nitro.nitrogeolocation.AndroidForegroundServiceOptions
 
+internal const val ACTION_STOP_BACKGROUND_LOCATION =
+    "com.margelo.nitro.nitrogeolocation.background.STOP"
+
 private const val EXTRA_NOTIFICATION_ID = "nitro.background.notificationId"
 private const val EXTRA_NOTIFICATION_TITLE = "nitro.background.notificationTitle"
 private const val EXTRA_NOTIFICATION_TEXT = "nitro.background.notificationText"

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/BackgroundDecisionsTest.kt
@@ -58,7 +58,7 @@ class BackgroundDecisionsTest {
 
     @Test
     fun resolveMaxStoredUsesConfiguredPositiveValue() {
-        assertEquals(500, resolveMaxStored(500, 10_000))
+        assertEquals(500, resolveMaxStored(500.0, 10_000))
     }
 
     @Test
@@ -69,8 +69,18 @@ class BackgroundDecisionsTest {
     @Test
     fun resolveMaxStoredTreatsNonPositiveAsUnbounded() {
         // 0 is the library's explicit unbounded opt-out (pruneRows treats <= 0 as no-prune).
-        assertEquals(0, resolveMaxStored(0, 10_000))
-        assertEquals(0, resolveMaxStored(-5, 10_000))
+        assertEquals(0, resolveMaxStored(0.0, 10_000))
+        assertEquals(0, resolveMaxStored(-5.0, 10_000))
+    }
+
+    @Test
+    fun invalidOrFractionalStorageLimitsCannotDisableTheSafetyCap() {
+        for (invalid in listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            assertEquals(10_000, resolveMaxStored(invalid, 10_000))
+        }
+        assertEquals(1, resolveMaxStored(0.25, 10_000))
+        assertEquals(1, resolveMaxStored(Double.MIN_VALUE, 10_000))
+        assertEquals(Int.MAX_VALUE, resolveMaxStored(Double.MAX_VALUE, 10_000))
     }
 
     @Test

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
@@ -54,6 +54,23 @@ class NitroBackgroundConfigurationTest {
     }
 
     @Test
+    fun configuredGeofencingDefaultsSurviveRestartAndAllowPerFieldOverrides() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("config-test", Context.MODE_PRIVATE)
+        val defaults = GeofencingOptions(arrayOf(GeofenceTransition.EXIT), 12000.0)
+        NitroBackgroundConfigStore(prefs).persist(options().copy(geofencing = defaults))
+        val restored = NitroBackgroundConfigStore(prefs).restore()!!.geofencing!!
+        assertArrayEquals(defaults.initialTrigger, restored.initialTrigger)
+        assertEquals(defaults.notificationResponsiveness, restored.notificationResponsiveness)
+        val overridden = resolveGeofencingOptions(restored, GeofencingOptions(emptyArray(), null))!!
+        assertTrue(overridden.initialTrigger!!.isEmpty())
+        assertEquals(12000.0, overridden.notificationResponsiveness)
+        assertNull(resolveGeofencingOptions(null, null))
+        NitroBackgroundConfigStore(prefs).persist(options())
+        assertNull(NitroBackgroundConfigStore(prefs).restore()!!.geofencing)
+    }
+
+    @Test
     fun retryCountsCannotOverflowOrSilentlySkipEveryUpload() {
         assertEquals(4, httpSyncAttemptCount(true, null))
         assertEquals(1, httpSyncAttemptCount(true, 0.0))

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
@@ -1,0 +1,65 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.location.Granularity
+import com.margelo.nitro.nitrogeolocation.*
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundConfigurationTest {
+    private fun options(limit: Double? = null) = BackgroundLocationOptions(
+        trackingMode = BackgroundTrackingMode.ACTIVITYAWARE,
+        accuracy = null, granularity = AndroidGranularity.COARSE,
+        interval = null, fastestInterval = null, distanceFilter = null,
+        maxUpdateDelay = null, waitForAccurateLocation = null, persist = null,
+        maxStoredLocations = limit, maxStoredEvents = limit,
+        stopOnTerminate = null, startOnBoot = null,
+        android = AndroidBackgroundLocationOptions(null,
+            AndroidForegroundServiceOptions(null, "Tracking", "Active", null, null, null, null, null, null),
+            null, null),
+        ios = null, geofencing = null,
+        activityRecognition = ActivityRecognitionOptions(true, null, null, null), sync = null
+    )
+
+    @Test
+    fun storageLimitsAndActivityDefaultsSurviveProcessRestart() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("config-test", Context.MODE_PRIVATE)
+        for (limit in listOf(null, 0.0, -1.0, 200.0)) {
+            val original = options(limit)
+            NitroBackgroundConfigStore(prefs).persist(original)
+            val restored = NitroBackgroundConfigStore(prefs).restore()!!
+            assertEquals(limit, restored.maxStoredLocations)
+            assertEquals(limit, restored.maxStoredEvents)
+            assertEquals(maxStoredLocations(original), maxStoredLocations(restored))
+            val still = DetectedActivity(DetectedActivityType.STILL, 100.0, 0.0)
+            assertEquals(activityTrackingAction(original, still, true), activityTrackingAction(restored, still, true))
+        }
+        // Preserve the old fallback for pre-2.0 settings without presence metadata.
+        prefs.edit().remove("maxStoredLocationsConfigured").putFloat("maxStoredLocations", 0f).commit()
+        assertNull(NitroBackgroundConfigStore(prefs).restore()!!.maxStoredLocations)
+    }
+
+    @Test
+    fun backgroundRequestHonorsExplicitCoarseGranularity() {
+        assertEquals(Granularity.GRANULARITY_COARSE, buildBackgroundLocationRequest(options()).granularity)
+        assertEquals(Granularity.GRANULARITY_PERMISSION_LEVEL,
+            buildBackgroundLocationRequest(options().copy(granularity = null)).granularity)
+    }
+
+    @Test
+    fun retryCountsCannotOverflowOrSilentlySkipEveryUpload() {
+        assertEquals(4, httpSyncAttemptCount(true, null))
+        assertEquals(1, httpSyncAttemptCount(true, 0.0))
+        assertEquals(1, httpSyncAttemptCount(false, Double.NaN))
+        for (invalid in listOf(Double.NaN, Double.POSITIVE_INFINITY, -1.0, 0.5, Int.MAX_VALUE.toDouble(), Double.MAX_VALUE)) {
+            assertNull(httpSyncAttemptCount(true, invalid))
+        }
+    }
+}

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundConfigurationTest.kt
@@ -31,7 +31,7 @@ class NitroBackgroundConfigurationTest {
     fun storageLimitsAndActivityDefaultsSurviveProcessRestart() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val prefs = context.getSharedPreferences("config-test", Context.MODE_PRIVATE)
-        for (limit in listOf(null, 0.0, -1.0, 200.0)) {
+        for (limit in listOf(null, 0.0, -1.0, 200.0, 0.25, Double.MIN_VALUE, Double.MAX_VALUE, Double.NaN, Double.POSITIVE_INFINITY)) {
             val original = options(limit)
             NitroBackgroundConfigStore(prefs).persist(original)
             val restored = NitroBackgroundConfigStore(prefs).restore()!!
@@ -42,7 +42,8 @@ class NitroBackgroundConfigurationTest {
             assertEquals(activityTrackingAction(original, still, true), activityTrackingAction(restored, still, true))
         }
         // Preserve the old fallback for pre-2.0 settings without presence metadata.
-        prefs.edit().remove("maxStoredLocationsConfigured").putFloat("maxStoredLocations", 0f).commit()
+        prefs.edit().remove("maxStoredLocationsConfigured").remove("maxStoredLocationsValue")
+            .putFloat("maxStoredLocations", 0f).commit()
         assertNull(NitroBackgroundConfigStore(prefs).restore()!!.maxStoredLocations)
     }
 

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationTest.kt
@@ -49,13 +49,16 @@ class NitroBackgroundNotificationTest {
     @Test
     fun nativeStopActionStopsOnlyTheMatchingDurableRunWithoutPromotingOrRestarting() {
         val prefs = context.getSharedPreferences(BACKGROUND_LOCATION_PREFS, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean("running", true).putLong(PREF_SERVICE_GENERATION, 9L).commit()
+        prefs.edit().putBoolean("running", true).putLong(PREF_SERVICE_GENERATION, 9L)
+            .putBoolean("configured", true).putBoolean("stopOnTerminate", false)
+            .putString("notificationTitle", "Tracking").putString("notificationText", "Active")
+            .commit()
         val service = Robolectric.buildService(NitroBackgroundLocationService::class.java).create().get()
         fun stopIntent(generation: Long) = Intent(context, NitroBackgroundLocationService::class.java)
             .setAction(ACTION_STOP_BACKGROUND_LOCATION)
             .putExtra(EXTRA_SERVICE_GENERATION, generation)
 
-        assertEquals(Service.START_NOT_STICKY, service.onStartCommand(stopIntent(8L), 0, 1))
+        assertEquals(Service.START_STICKY, service.onStartCommand(stopIntent(8L), 0, 1))
         assertTrue(prefs.getBoolean("running", false))
         assertEquals(Service.START_NOT_STICKY, service.onStartCommand(stopIntent(9L), 0, 2))
         assertFalse(prefs.getBoolean("running", true))

--- a/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationTest.kt
+++ b/packages/react-native-nitro-geolocation/android/src/test/java/com/margelo/nitro/nitrogeolocation/background/NitroBackgroundNotificationTest.kt
@@ -1,0 +1,64 @@
+package com.margelo.nitro.nitrogeolocation.background
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import com.margelo.nitro.nitrogeolocation.AndroidForegroundServiceOptions
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NitroBackgroundNotificationTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun options(color: String? = null, stop: String? = null) =
+        AndroidForegroundServiceOptions(null, "Tracking", "Active", null, null, null, null, color, stop)
+
+    @Test
+    fun notificationAppliesColorAndGenerationScopedImmutableStopAction() {
+        val notification = NitroBackgroundNotificationFactory.create(context, options("#123456", "Stop"), 9L)
+        assertEquals(Color.rgb(0x12, 0x34, 0x56), notification.color)
+        val action = notification.actions.single()
+        assertEquals("Stop", action.title)
+        assertTrue(action.actionIntent.isImmutable)
+        val intent = shadowOf(action.actionIntent).savedIntent
+        assertEquals(ACTION_STOP_BACKGROUND_LOCATION, intent.action)
+        assertEquals(9L, intent.backgroundServiceGeneration())
+        assertEquals(NitroBackgroundLocationService::class.java.name, intent.component?.className)
+        val newer = NitroBackgroundNotificationFactory.create(context, options(stop = "Stop"), 10L)
+        assertNotEquals(action.actionIntent, newer.actions.single().actionIntent)
+    }
+
+    @Test
+    fun omittedOrBlankActionsAndInvalidColorsDoNotBreakTracking() {
+        for (title in listOf(null, " ")) {
+            val notification = NitroBackgroundNotificationFactory.create(context, options("bad-color", title), 9L)
+            assertTrue(notification.actions.isNullOrEmpty())
+            assertEquals(0, notification.color)
+        }
+    }
+
+    @Test
+    fun nativeStopActionStopsOnlyTheMatchingDurableRunWithoutPromotingOrRestarting() {
+        val prefs = context.getSharedPreferences(BACKGROUND_LOCATION_PREFS, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean("running", true).putLong(PREF_SERVICE_GENERATION, 9L).commit()
+        val service = Robolectric.buildService(NitroBackgroundLocationService::class.java).create().get()
+        fun stopIntent(generation: Long) = Intent(context, NitroBackgroundLocationService::class.java)
+            .setAction(ACTION_STOP_BACKGROUND_LOCATION)
+            .putExtra(EXTRA_SERVICE_GENERATION, generation)
+
+        assertEquals(Service.START_NOT_STICKY, service.onStartCommand(stopIntent(8L), 0, 1))
+        assertTrue(prefs.getBoolean("running", false))
+        assertEquals(Service.START_NOT_STICKY, service.onStartCommand(stopIntent(9L), 0, 2))
+        assertFalse(prefs.getBoolean("running", true))
+        assertNull(shadowOf(service).lastForegroundNotification)
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundHttpSync.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundHttpSync.swift
@@ -5,12 +5,16 @@ final class IOSBackgroundHttpSync {
         locations: [StoredBackgroundLocation],
         sync: BackgroundHttpSyncOptions
     ) -> BackgroundHttpSyncResult {
-        if sync.batch == false {
-            return uploadSingleLocationsWithRetry(locations: locations, sync: sync)
+        guard let maxAttempts = iosHttpSyncAttemptCount(retry: sync.retry, maxRetries: sync.maxRetries) else {
+            return BackgroundHttpSyncResult(
+                success: false, statusCode: nil, syncedLocationIds: [],
+                failedLocationIds: locations.map(\.id),
+                error: "maxRetries must be an integer between 0 and 2147483646."
+            )
         }
-        let maxAttempts = sync.retry == true
-            ? Int(sync.maxRetries ?? 3) + 1
-            : 1
+        if sync.batch == false {
+            return uploadSingleLocationsWithRetry(locations: locations, sync: sync, maxAttempts: maxAttempts)
+        }
         var lastResult: BackgroundHttpSyncResult?
         for attempt in 0..<max(maxAttempts, 1) {
             let result = upload(locations: locations, sync: sync)
@@ -33,11 +37,9 @@ final class IOSBackgroundHttpSync {
 
     private func uploadSingleLocationsWithRetry(
         locations: [StoredBackgroundLocation],
-        sync: BackgroundHttpSyncOptions
+        sync: BackgroundHttpSyncOptions,
+        maxAttempts: Int
     ) -> BackgroundHttpSyncResult {
-        let maxAttempts = sync.retry == true
-            ? Int(sync.maxRetries ?? 3) + 1
-            : 1
         var synced: [String] = []
         var failed: [String] = []
         var lastStatusCode: Double?

--- a/packages/react-native-nitro-geolocation/ios/IOSBackgroundSerialization.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSBackgroundSerialization.swift
@@ -388,6 +388,13 @@ internal func httpSyncResultDictionary(_ result: BackgroundHttpSyncResult) -> [S
 internal func backgroundOptionsDictionary(_ options: BackgroundLocationOptions) -> [String: Any] {
     var dictionary: [String: Any] = [:]
     dictionary["trackingMode"] = options.trackingMode?.stringValue
+    if let accuracy = options.accuracy {
+        var value: [String: Any] = [:]
+        value["android"] = accuracy.android?.stringValue
+        value["ios"] = accuracy.ios?.stringValue
+        dictionary["accuracy"] = value
+    }
+    dictionary["granularity"] = options.granularity?.stringValue
     dictionary["interval"] = options.interval
     dictionary["fastestInterval"] = options.fastestInterval
     dictionary["distanceFilter"] = options.distanceFilter
@@ -407,8 +414,13 @@ internal func backgroundOptionsDictionary(_ options: BackgroundLocationOptions) 
 internal func makeBackgroundOptions(_ dictionary: [String: Any]) -> BackgroundLocationOptions {
     return BackgroundLocationOptions(
         trackingMode: (dictionary["trackingMode"] as? String).flatMap(BackgroundTrackingMode.init(fromString:)),
-        accuracy: nil,
-        granularity: nil,
+        accuracy: (dictionary["accuracy"] as? [String: Any]).map { value in
+            LocationAccuracyOptions(
+                android: (value["android"] as? String).flatMap(AndroidAccuracyPreset.init(fromString:)),
+                ios: (value["ios"] as? String).flatMap(IOSAccuracyPreset.init(fromString:))
+            )
+        },
+        granularity: (dictionary["granularity"] as? String).flatMap(AndroidGranularity.init(fromString:)),
         interval: dictionary["interval"] as? Double,
         fastestInterval: dictionary["fastestInterval"] as? Double,
         distanceFilter: dictionary["distanceFilter"] as? Double,

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationOptions.swift
@@ -40,7 +40,16 @@ struct ParsedOptions {
         return parse(from: options, defaultMaximumAge: Double.infinity)
     }
 
-    private static func resolveAccuracy(preset: IOSAccuracyPreset?) -> CLLocationAccuracy {
+    static func validationError(from options: LocationRequestOptions) -> LocationError? {
+        guard let message = validateIOSLocationNumbers(
+            timeout: options.timeout ?? DEFAULT_TIMEOUT,
+            maximumAge: options.maximumAge ?? DEFAULT_MAXIMUM_AGE,
+            distanceFilter: options.distanceFilter ?? 0
+        ) else { return nil }
+        return createLocationError(code: INTERNAL_ERROR, message: message)
+    }
+
+    static func resolveAccuracy(preset: IOSAccuracyPreset?) -> CLLocationAccuracy {
         guard let preset else {
             return kCLLocationAccuracyHundredMeters
         }

--- a/packages/react-native-nitro-geolocation/ios/IOSNumericOptions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSNumericOptions.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+func validateIOSLocationNumbers(timeout: Double, maximumAge: Double, distanceFilter: Double) -> String? {
+    if !timeout.isFinite || timeout < 0 {
+        return "timeout must be a finite number greater than or equal to 0."
+    }
+    if maximumAge.isNaN || maximumAge < 0 {
+        return "maximumAge must be greater than or equal to 0."
+    }
+    if !distanceFilter.isFinite || distanceFilter < 0 {
+        return "distanceFilter must be a finite number greater than or equal to 0."
+    }
+    return nil
+}
+
+func iosHttpSyncAttemptCount(retry: Bool?, maxRetries: Double?) -> Int? {
+    guard retry == true else { return 1 }
+    let retries = maxRetries ?? 3
+    guard retries.isFinite, retries >= 0, retries.rounded(.down) == retries,
+          retries < Double(Int32.max) else { return nil }
+    return Int(retries) + 1
+}
+
+func iosStorageLimit(_ configured: Double?, defaultValue: Int) -> Int? {
+    guard let configured else { return defaultValue }
+    guard configured.isFinite else { return defaultValue }
+    if configured <= 0 { return nil }
+    // Positive fractions must never truncate to zero and unexpectedly erase all rows.
+    return max(1, Int(min(configured, Double(Int32.max))))
+}

--- a/packages/react-native-nitro-geolocation/ios/IOSPermissionRequestQueue.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSPermissionRequestQueue.swift
@@ -1,0 +1,21 @@
+import CoreLocation
+import Foundation
+
+/// Main-thread-owned permission requests. Core Location's initial delegate
+/// notification is not a user decision and must not consume pending requests.
+final class IOSPermissionRequestQueue {
+    private var callbacks: [(CLAuthorizationStatus) -> Void] = []
+
+    func append(_ callback: @escaping (CLAuthorizationStatus) -> Void) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        callbacks.append(callback)
+    }
+
+    func resolve(_ status: CLAuthorizationStatus) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard status != .notDetermined else { return }
+        let pending = callbacks
+        callbacks.removeAll()
+        pending.forEach { $0(status) }
+    }
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroBackgroundLocation.swift
@@ -701,7 +701,9 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
                 options.ios?.pausesLocationUpdatesAutomatically ?? false
             manager.showsBackgroundLocationIndicator =
                 options.ios?.showsBackgroundLocationIndicator ?? false
-            manager.desiredAccuracy = kCLLocationAccuracyBest
+            manager.desiredAccuracy = options.accuracy?.ios.map {
+                ParsedOptions.resolveAccuracy(preset: $0)
+            } ?? kCLLocationAccuracyBest
             manager.distanceFilter = options.distanceFilter ?? kCLDistanceFilterNone
             manager.activityType = mapActivityType(options.ios?.activityType)
             if options.trackingMode == .significantchanges ||
@@ -808,9 +810,7 @@ class NitroBackgroundLocation: HybridNitroBackgroundLocationSpec {
     private static let defaultMaxStoredRows = 10_000
 
     private func resolveMaxStored(_ configured: Double?, default def: Int) -> Int? {
-        guard let configured = configured else { return def }
-        if configured <= 0 { return nil }
-        return Int(configured)
+        return iosStorageLimit(configured, defaultValue: def)
     }
 
     func appendStoredEvent(

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -50,6 +50,10 @@ extension NitroGeolocation {
         error: ((LocationError) -> Void)?
     ) -> String {
         let token = UUID().uuidString
+        if let validationError = ParsedOptions.validationError(from: options) {
+            error?(validationError)
+            return token
+        }
         let subscription = WatchSubscription(
             success: success,
             error: error,
@@ -98,6 +102,6 @@ internal func isCachedLocationValid(_ location: CLLocation, options: ParsedOptio
         return true
     }
 
-    let age = Date().timeIntervalSince(location.timestamp) * 1000
+    let age = max(0, Date().timeIntervalSince(location.timestamp) * 1000)
     return age < options.maximumAge
 }

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -192,6 +192,10 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     ) {
         dispatchPrecondition(condition: .onQueue(.main))
 
+        if let validationError = ParsedOptions.validationError(from: options) {
+            error?(validationError)
+            return
+        }
         // Check permission
         let status = CLLocationManager.authorizationStatus()
         if status == .denied || status == .restricted {
@@ -257,6 +261,10 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
         error: ((LocationError) -> Void)?
     ) throws -> Void {
         let parsedOptions = ParsedOptions.parseLastKnown(from: options)
+        if let validationError = ParsedOptions.validationError(from: options) {
+            error?(validationError)
+            return
+        }
         runLocationOperationOnMain {
             let status = CLLocationManager.authorizationStatus()
             if status == .denied || status == .restricted {

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation.swift
@@ -19,8 +19,8 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     private var locationManagerDelegate: LocationManagerDelegate?
     private var lastLocation: CLLocation?
     private var usingSignificantChanges: Bool = false
-    lazy var providerStatusWatcher = IOSProviderStatusWatcher()
-    private var pendingPermissionResolvers: [(PermissionStatus) -> Void] = []
+    let providerStatusWatcher = IOSProviderStatusWatcher()
+    private let pendingPermissionResolvers = IOSPermissionRequestQueue()
 
     // getCurrentPosition promise resolvers with timeout
     internal var pendingPositionRequests: [String: PositionRequest] = [:]
@@ -65,7 +65,9 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
                 return
             }
 
-            self.pendingPermissionResolvers.append(success)
+            self.pendingPermissionResolvers.append { status in
+                success(mapCLAuthorizationStatus(status))
+            }
             self.requestSystemPermission(for: self.determineAuthorizationLevel())
         }
     }
@@ -413,16 +415,11 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
     }
 
     func handleAuthorizationChange(_ manager: CLLocationManager) {
+        dispatchPrecondition(condition: .onQueue(.main))
         let status = getCurrentAuthorizationStatus(from: manager)
-        let mappedStatus = mapCLAuthorizationStatus(status)
-
-        // Snapshot state before invoking JS callbacks because they can re-enter this instance.
-        let resolvers = pendingPermissionResolvers
-        pendingPermissionResolvers.removeAll()
+        pendingPermissionResolvers.resolve(status)
+        // Callbacks can re-enter and stop watches, so inspect ownership after resolving.
         let shouldStartMonitoring = !pendingPositionRequests.isEmpty || !watchSubscriptions.isEmpty
-        for resolver in resolvers {
-            resolver(mappedStatus)
-        }
 
         // If authorized, start monitoring
         if shouldStartMonitoring && (status == .authorizedAlways || status == .authorizedWhenInUse) {

--- a/packages/react-native-nitro-geolocation/package.json
+++ b/packages/react-native-nitro-geolocation/package.json
@@ -111,11 +111,12 @@
     "@react-native/babel-preset": "0.81.1",
     "@tsconfig/react-native": "^3.0.7",
     "@types/react": "^19.1.0",
-    "@types/react-test-renderer": "^18.0.0",
+    "@types/react-test-renderer": "^19.1.0",
     "expo": "^57.0.0",
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-nitro-modules": "0.35.10",
+    "react-test-renderer": "19.1.0",
     "typescript": "5.9.3",
     "vitest": "4.1.5"
   },

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.test.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.test.ts
@@ -41,7 +41,7 @@ const position = {
 };
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   devtools.enabled = false;
   clearLastKnownPositionCache();
 });
@@ -145,5 +145,38 @@ describe("getCurrentPosition cancellation", () => {
     await expect(request).rejects.toBe(reason);
     await Promise.resolve();
     expect(readLastKnownPosition()).toBeUndefined();
+  });
+
+  it("removes abort handling and ignores callbacks after native startup throws", async () => {
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const failure = new Error("native startup failed");
+    let deliver: (value: typeof position) => void = () => {};
+    native.getCurrentPositionCancellable.mockImplementation((_id, success) => {
+      deliver = success;
+      throw failure;
+    });
+
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).rejects.toBe(failure);
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    deliver(position);
+    expect(readLastKnownPosition()).toBeUndefined();
+    controller.abort();
+    expect(native.cancelCurrentPositionRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects with the abort reason even when native cancellation throws", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user cancelled");
+    native.cancelCurrentPositionRequest.mockImplementation(() => {
+      throw new Error("native teardown failed");
+    });
+    const request = getCurrentPosition({ signal: controller.signal });
+    const rejected = expect(request).rejects.toBe(reason);
+
+    controller.abort(reason);
+    await rejected;
   });
 });

--- a/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/api/getCurrentPosition.ts
@@ -119,17 +119,25 @@ export function getCurrentPosition(
     };
     const handleAbort = () => {
       finish(() => {
-        NitroGeolocationHybridObject.cancelCurrentPositionRequest(requestId);
+        try {
+          NitroGeolocationHybridObject.cancelCurrentPositionRequest(requestId);
+        } catch {
+          // Cancellation still settles with the caller's reason if native teardown fails.
+        }
         reject(getAbortReason(signal));
       });
     };
 
     signal.addEventListener("abort", handleAbort, { once: true });
-    NitroGeolocationHybridObject.getCurrentPositionCancellable(
-      requestId,
-      (position) => finish(() => resolve(rememberCurrentPosition(position))),
-      nativeOptions,
-      (error) => finish(() => reject(error))
-    );
+    try {
+      NitroGeolocationHybridObject.getCurrentPositionCancellable(
+        requestId,
+        (position) => finish(() => resolve(rememberCurrentPosition(position))),
+        nativeOptions,
+        (error) => finish(() => reject(error))
+      );
+    } catch (error) {
+      finish(() => reject(error));
+    }
   });
 }

--- a/packages/react-native-nitro-geolocation/src/background/options.test.ts
+++ b/packages/react-native-nitro-geolocation/src/background/options.test.ts
@@ -10,6 +10,21 @@ const foregroundService = {
 };
 
 describe("background option boundary", () => {
+  it("does not expose retired deferred options restored from older native configurations", () => {
+    const native = {
+      ios: {
+        useSignificantChanges: true,
+        deferredUpdatesDistance: 500,
+        deferredUpdatesInterval: 30
+      }
+    };
+    expect(fromNativeBackgroundLocationOptions(native)).toEqual({
+      ios: { useSignificantChanges: true }
+    });
+    expect(toNativeBackgroundLocationOptions(native)).toEqual({
+      ios: { useSignificantChanges: true }
+    });
+  });
   it("maps the public Android provider to the Nitro-safe spelling", () => {
     expect(
       toNativeBackgroundLocationOptions({

--- a/packages/react-native-nitro-geolocation/src/background/options.ts
+++ b/packages/react-native-nitro-geolocation/src/background/options.ts
@@ -1,10 +1,23 @@
 import type { BackgroundLocationOptions } from "./publicTypes";
 import type { BackgroundLocationOptions as NativeBackgroundLocationOptions } from "./types";
 
+function publicIOSOptions(ios: NativeBackgroundLocationOptions["ios"]) {
+  if (!ios) return ios;
+  const {
+    deferredUpdatesDistance: _distance,
+    deferredUpdatesInterval: _interval,
+    ...supported
+  } = ios;
+  return supported;
+}
+
 export function toNativeBackgroundLocationOptions(
   options: BackgroundLocationOptions
 ): NativeBackgroundLocationOptions {
-  const { android, ...sharedOptions } = options;
+  const { android, ...rest } = options;
+  const sharedOptions = rest.ios
+    ? { ...rest, ios: publicIOSOptions(rest.ios) }
+    : rest;
   if (!android) {
     return sharedOptions;
   }
@@ -28,7 +41,10 @@ export function fromNativeBackgroundLocationOptions(
     return undefined;
   }
 
-  const { android, ...sharedOptions } = options;
+  const { android, ...rest } = options;
+  const sharedOptions = rest.ios
+    ? { ...rest, ios: publicIOSOptions(rest.ios) }
+    : rest;
   if (!android) {
     return sharedOptions;
   }

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -113,6 +113,7 @@ export interface BackgroundLocationOptions {
   startOnBoot?: boolean;
   android?: AndroidBackgroundLocationOptions;
   ios?: IOSBackgroundLocationOptions;
+  /** Android defaults for new registrations and persisted-region restoration. */
   geofencing?: GeofencingOptions;
   activityRecognition?: ActivityRecognitionOptions;
   sync?: BackgroundHttpSyncOptions;

--- a/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
+++ b/packages/react-native-nitro-geolocation/src/background/publicTypes.ts
@@ -16,7 +16,7 @@ import type {
   DetectedActivity,
   GeofenceEvent,
   GeofencingOptions,
-  IOSBackgroundLocationOptions
+  IOSBackgroundLocationOptions as NativeIOSBackgroundLocationOptions
 } from "./types";
 
 // Keep the `/background` entry point self-contained: consumers should be able
@@ -72,7 +72,6 @@ export type {
   GetStoredBackgroundEventsOptions,
   GetStoredBackgroundLocationsOptions,
   IOSBackgroundActivityType,
-  IOSBackgroundLocationOptions,
   IOSBackgroundLocationStatus,
   LocationLifecycleEvent,
   LocationLifecycleState,
@@ -81,6 +80,12 @@ export type {
 
 /** Android provider selection exposed by the public background API. */
 export type AndroidBackgroundProvider = "auto" | "playServices" | "android";
+
+/** Supported iOS controls; Core Location's retired deferred-update API is excluded. */
+export type IOSBackgroundLocationOptions = Omit<
+  NativeIOSBackgroundLocationOptions,
+  "deferredUpdatesDistance" | "deferredUpdatesInterval"
+>;
 
 export interface AndroidBackgroundLocationOptions {
   locationProvider?: AndroidBackgroundProvider;

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -101,6 +101,7 @@ export interface BackgroundLocationOptions {
   startOnBoot?: boolean;
   android?: AndroidBackgroundLocationOptions;
   ios?: IOSBackgroundLocationOptions;
+  /** Android defaults for new registrations and persisted-region restoration. */
   geofencing?: GeofencingOptions;
   activityRecognition?: ActivityRecognitionOptions;
   sync?: BackgroundHttpSyncOptions;
@@ -266,7 +267,9 @@ export interface GeofenceRegion {
 }
 
 export interface GeofencingOptions {
+  /** Android-only initial transitions. An empty array disables initial triggers. */
   initialTrigger?: GeofenceTransition[];
+  /** Android-only notification responsiveness in milliseconds. */
   notificationResponsiveness?: number;
 }
 

--- a/packages/react-native-nitro-geolocation/src/background/types.ts
+++ b/packages/react-native-nitro-geolocation/src/background/types.ts
@@ -126,7 +126,9 @@ export interface AndroidForegroundServiceOptions {
   notificationChannelName?: string;
   notificationChannelDescription?: string;
   notificationIcon?: string;
+  /** Android notification accent color, for example `#336699`. Invalid colors are ignored. */
   notificationColor?: string;
+  /** Adds a native action that stops this tracking run. Omit to hide the action. */
   stopActionTitle?: string;
 }
 

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.test.tsx
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.test.tsx
@@ -1,0 +1,99 @@
+import { StrictMode } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GeolocationResponse } from "../publicTypes";
+import type { LocationError } from "../utils/errors";
+import type { UseWatchPositionOptions, UseWatchPositionResult } from "./types";
+
+const watches = vi.hoisted(() => ({
+  watchPosition: vi.fn(),
+  unwatch: vi.fn()
+}));
+vi.mock("../api", () => watches);
+vi.mock("../web/watch", () => watches);
+import { useWatchPosition as nativeHook } from "./useWatchPosition";
+import { useWatchPosition as webHook } from "../web/useWatchPosition";
+
+const position: GeolocationResponse = {
+  coords: {
+    latitude: 1,
+    longitude: 2,
+    accuracy: 3,
+    altitude: null,
+    altitudeAccuracy: null,
+    heading: null,
+    speed: null
+  },
+  timestamp: 123
+};
+let root: ReactTestRenderer | undefined;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  watches.watchPosition.mockReturnValue("watch-token");
+});
+afterEach(async () => {
+  if (root) await act(() => root?.unmount());
+  root = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe.each([
+  ["native", nativeHook],
+  ["web", webHook]
+] as const)("%s hook lifecycle", (_name, useWatch) => {
+  let state: UseWatchPositionResult;
+  function Consumer({ enabled }: UseWatchPositionOptions) {
+    state = useWatch({ enabled });
+    return null;
+  }
+
+  it("ignores queued positions and errors after disabling and after restarting", async () => {
+    await act(() => {
+      root = create(<Consumer enabled />);
+    });
+    const [success, error] = watches.watchPosition.mock.calls[0] as [
+      (value: GeolocationResponse) => void,
+      (value: LocationError) => void
+    ];
+    await act(() => {
+      root?.update(<Consumer enabled={false} />);
+    });
+    await act(() => {
+      success(position);
+      error({ code: "timeout", message: "old request" });
+    });
+    expect(state!).toEqual({ position: null, error: null, isWatching: false });
+    expect(watches.unwatch).toHaveBeenCalledWith("watch-token");
+    await act(() => {
+      root?.update(<Consumer enabled />);
+    });
+    await act(() => {
+      success(position);
+    });
+    expect(state!.position).toBeNull();
+    await act(() => {
+      watches.watchPosition.mock.calls[1][0](position);
+    });
+    expect(state!.position).toBe(position);
+  });
+
+  it("accepts synchronous results when StrictMode replays subscription setup", async () => {
+    let count = 0;
+    watches.watchPosition.mockImplementation((success) => {
+      success({ ...position, timestamp: ++count });
+      return `watch-${count}`;
+    });
+    await act(() => {
+      root = create(
+        <StrictMode>
+          <Consumer enabled />
+        </StrictMode>
+      );
+    });
+    expect(count).toBeGreaterThan(1);
+    expect(state!.position?.timestamp).toBe(count);
+    expect(state!.isWatching).toBe(true);
+  });
+});

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.test.tsx
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from "react";
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { type ReactTestRenderer, act, create } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GeolocationResponse } from "../publicTypes";
 import type { LocationError } from "../utils/errors";
@@ -11,8 +11,8 @@ const watches = vi.hoisted(() => ({
 }));
 vi.mock("../api", () => watches);
 vi.mock("../web/watch", () => watches);
-import { useWatchPosition as nativeHook } from "./useWatchPosition";
 import { useWatchPosition as webHook } from "../web/useWatchPosition";
+import { useWatchPosition as nativeHook } from "./useWatchPosition";
 
 const position: GeolocationResponse = {
   coords: {

--- a/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/hooks/useWatchPosition.ts
@@ -43,8 +43,6 @@ export function useWatchPosition(
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);
 
-  // Track if component is mounted to prevent state updates after unmount
-  const isMountedRef = useRef(true);
   const hasErrorRef = useRef(false);
 
   // Store latest options in ref to avoid unnecessary re-subscriptions
@@ -69,10 +67,11 @@ export function useWatchPosition(
     hasErrorRef.current = false;
     setError(null);
 
+    let active = true;
     const token = watchPosition(
       (result: GeolocationResponse) => {
         // Success callback
-        if (!isMountedRef.current) return;
+        if (!active) return;
         setPosition(result);
         if (hasErrorRef.current) {
           hasErrorRef.current = false;
@@ -81,7 +80,7 @@ export function useWatchPosition(
       },
       (err: LocationError) => {
         // Error callback
-        if (!isMountedRef.current) return;
+        if (!active) return;
         hasErrorRef.current = true;
         setError(err);
       },
@@ -90,17 +89,10 @@ export function useWatchPosition(
 
     // Cleanup function
     return () => {
+      active = false;
       unwatch(token);
     };
   }, [enabled]); // Only re-subscribe when enabled changes
-
-  // Track mount status
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   return {
     position,

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -64,6 +64,47 @@ afterEach(() => {
 });
 
 describe("web API", () => {
+  it("cleans up abort listeners and ignores late callbacks when browser startup throws", async () => {
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const failure = new Error("browser startup failed");
+    let deliver: (position: ReturnType<typeof createPosition>) => void =
+      () => {};
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        clearWatch: vi.fn(),
+        watchPosition: vi.fn((success) => {
+          deliver = success;
+          throw failure;
+        })
+      }
+    });
+    await expect(
+      getCurrentPosition({ signal: controller.signal })
+    ).rejects.toBe(failure);
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    deliver(createPosition());
+    expect(getLastKnownPosition()).toBeUndefined();
+  });
+
+  it("settles cancellation even if clearing the browser watch throws", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancel");
+    setNavigator({
+      geolocation: {
+        getCurrentPosition: vi.fn(),
+        watchPosition: vi.fn(() => 42),
+        clearWatch: vi.fn(() => {
+          throw new Error("teardown failed");
+        })
+      }
+    });
+    const request = getCurrentPosition({ signal: controller.signal });
+    controller.abort(reason);
+    await expect(request).rejects.toBe(reason);
+  });
+
   it("uses a stable availability reason when browser geolocation is unsupported", async () => {
     setNavigator(undefined);
 

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -1020,10 +1020,13 @@ describe("web API", () => {
       timeout: 600000,
       maximumAge: 0
     });
-    expect(getActiveWatches()).toEqual([
-      { token: firstToken, kind: "position" },
-      { token: secondToken, kind: "position" }
-    ]);
+    // Tokens are opaque and snapshots are lexically sorted, not insertion-ordered
+    // (for example, web-10 sorts before web-9 under shuffled test execution).
+    expect(getActiveWatches()).toEqual(
+      [firstToken, secondToken]
+        .sort((first, second) => first.localeCompare(second))
+        .map((token) => ({ token, kind: "position" }))
+    );
     unwatch(firstToken);
     expect(clearWatch).toHaveBeenCalledWith(10);
     expect(getActiveWatches()).toEqual([

--- a/packages/react-native-nitro-geolocation/src/web/index.test.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.test.ts
@@ -64,6 +64,46 @@ afterEach(() => {
 });
 
 describe("web API", () => {
+  it("ignores queued callbacks after unwatch and clears the original browser provider", () => {
+    const browser = {
+      getCurrentPosition: vi.fn(),
+      watchPosition: vi.fn(() => 7),
+      clearWatch: vi.fn()
+    };
+    setNavigator({ geolocation: browser });
+    const success = vi.fn();
+    const error = vi.fn();
+    const token = watchPosition(success, error);
+    const [deliver, fail] = browser.watchPosition.mock.calls[0] as unknown as [
+      (value: ReturnType<typeof createPosition>) => void,
+      (value: { code: number; message: string }) => void
+    ];
+    setNavigator(undefined);
+    unwatch(token);
+    deliver(createPosition());
+    fail({ code: 1, message: "old denial" });
+    expect(browser.clearWatch).toHaveBeenCalledWith(7);
+    expect(success).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(getLastKnownPosition()).toBeUndefined();
+    expect(getActiveWatches()).toEqual([]);
+  });
+
+  it("cleans up when a synchronous initial callback stops every watch", () => {
+    const browser = {
+      getCurrentPosition: vi.fn(),
+      watchPosition: vi.fn((success) => {
+        success(createPosition());
+        return 7;
+      }),
+      clearWatch: vi.fn()
+    };
+    setNavigator({ geolocation: browser });
+    watchPosition(() => stopObserving());
+    expect(browser.clearWatch).toHaveBeenCalledExactlyOnceWith(7);
+    expect(getActiveWatches()).toEqual([]);
+  });
+
   it("cleans up abort listeners and ignores late callbacks when browser startup throws", async () => {
     const controller = new AbortController();
     const removeListener = vi.spyOn(controller.signal, "removeEventListener");

--- a/packages/react-native-nitro-geolocation/src/web/index.ts
+++ b/packages/react-native-nitro-geolocation/src/web/index.ts
@@ -328,7 +328,11 @@ export function getCurrentPosition(
         return;
       }
       didClearWatch = true;
-      geolocation.clearWatch(requestWatch.id);
+      try {
+        geolocation.clearWatch(requestWatch.id);
+      } catch {
+        // Browser teardown must not prevent the one-shot request from settling.
+      }
     };
     const finish = (callback: () => void) => {
       if (settled) return;
@@ -340,11 +344,15 @@ export function getCurrentPosition(
     const handleAbort = () => finish(() => reject(getAbortReason(signal)));
 
     signal.addEventListener("abort", handleAbort, { once: true });
-    requestWatch.id = geolocation.watchPosition(
-      (position) => finish(() => resolve(observePosition(position))),
-      (error) => finish(() => reject(observeError(error))),
-      toPositionOptions(options)
-    );
+    try {
+      requestWatch.id = geolocation.watchPosition(
+        (position) => finish(() => resolve(observePosition(position))),
+        (error) => finish(() => reject(observeError(error))),
+        toPositionOptions(options)
+      );
+    } catch (error) {
+      finish(() => reject(error));
+    }
     if (shouldClearWatch) {
       clearRequestWatch();
     }

--- a/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
+++ b/packages/react-native-nitro-geolocation/src/web/useWatchPosition.ts
@@ -13,7 +13,6 @@ export function useWatchPosition(
   const [position, setPosition] = useState<GeolocationResponse | null>(null);
   const [isWatching, setIsWatching] = useState(false);
   const [error, setError] = useState<LocationError | null>(null);
-  const isMountedRef = useRef(true);
   const hasErrorRef = useRef(false);
   const optionsRef = useRef(options);
   const enabled = options?.enabled ?? false;
@@ -21,13 +20,6 @@ export function useWatchPosition(
   useEffect(() => {
     optionsRef.current = options;
   }, [options]);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     if (!enabled) {
@@ -38,9 +30,10 @@ export function useWatchPosition(
     setIsWatching(true);
     hasErrorRef.current = false;
     setError(null);
+    let active = true;
     const token = watchPosition(
       (nextPosition) => {
-        if (!isMountedRef.current) {
+        if (!active) {
           return;
         }
         setPosition(nextPosition);
@@ -50,7 +43,7 @@ export function useWatchPosition(
         }
       },
       (nextError) => {
-        if (!isMountedRef.current) {
+        if (!active) {
           return;
         }
         hasErrorRef.current = true;
@@ -59,6 +52,7 @@ export function useWatchPosition(
       optionsRef.current
     );
     return () => {
+      active = false;
       unwatch(token);
     };
   }, [enabled]);

--- a/packages/react-native-nitro-geolocation/src/web/watch.ts
+++ b/packages/react-native-nitro-geolocation/src/web/watch.ts
@@ -27,7 +27,13 @@ import {
   rememberWebPermissionGrant
 } from "./permissionEvidence";
 
-const activeWatches = new Map<string, number>();
+const activeWatches = new Map<
+  string,
+  {
+    id?: number;
+    geolocation: NonNullable<ReturnType<typeof getGeolocation>>;
+  }
+>();
 type ProviderStatusSubscription = {
   success: (status: LocationProviderStatus) => void;
   lastStatus?: LocationProviderStatus;
@@ -136,48 +142,60 @@ export function watchPosition(
   const requestedAt = Date.now();
   const distanceFilter = options?.distanceFilter ?? 0;
   const maximumAge = options?.maximumAge ?? 0;
-  const watchId = geolocation.watchPosition(
-    (position) => {
-      const observedAt = Date.now();
-      rememberWebPermissionGrant(observedAt);
-      rememberWebPermissionDetailsEvidence("granted", observedAt);
-      if (
-        distanceFilter > 0 &&
-        lastEmittedLatitude !== undefined &&
-        lastEmittedLongitude !== undefined &&
-        distanceMeters(
-          lastEmittedLatitude,
-          lastEmittedLongitude,
-          position.coords.latitude,
-          position.coords.longitude
-        ) < distanceFilter
-      ) {
-        return;
-      }
-      const normalizedPosition = normalizePosition(position);
-      normalizedPosition.metadata = buildLocationMetadata(normalizedPosition, {
-        source: "watchPosition",
-        maximumAge,
-        requestedAt,
-        observedAt
-      });
-      lastEmittedLatitude = position.coords.latitude;
-      lastEmittedLongitude = position.coords.longitude;
-      success(rememberPosition(normalizedPosition));
-    },
-    (browserError) => {
-      const mappedError = mapBrowserError(browserError);
-      if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
+  const subscription = { geolocation, id: undefined as number | undefined };
+  activeWatches.set(token, subscription);
+  try {
+    subscription.id = geolocation.watchPosition(
+      (position) => {
+        if (!activeWatches.has(token)) return;
         const observedAt = Date.now();
-        rememberWebPermissionDenial(observedAt);
-        rememberWebPermissionDetailsEvidence("denied", observedAt);
-      }
-      error?.(mappedError);
-    },
-    toPositionOptions(options)
-  );
-
-  activeWatches.set(token, watchId);
+        rememberWebPermissionGrant(observedAt);
+        rememberWebPermissionDetailsEvidence("granted", observedAt);
+        if (
+          distanceFilter > 0 &&
+          lastEmittedLatitude !== undefined &&
+          lastEmittedLongitude !== undefined &&
+          distanceMeters(
+            lastEmittedLatitude,
+            lastEmittedLongitude,
+            position.coords.latitude,
+            position.coords.longitude
+          ) < distanceFilter
+        ) {
+          return;
+        }
+        const normalizedPosition = normalizePosition(position);
+        normalizedPosition.metadata = buildLocationMetadata(
+          normalizedPosition,
+          {
+            source: "watchPosition",
+            maximumAge,
+            requestedAt,
+            observedAt
+          }
+        );
+        lastEmittedLatitude = position.coords.latitude;
+        lastEmittedLongitude = position.coords.longitude;
+        success(rememberPosition(normalizedPosition));
+      },
+      (browserError) => {
+        if (!activeWatches.has(token)) return;
+        const mappedError = mapBrowserError(browserError);
+        if (mappedError.code === LocationErrorCodes.PERMISSION_DENIED) {
+          const observedAt = Date.now();
+          rememberWebPermissionDenial(observedAt);
+          rememberWebPermissionDetailsEvidence("denied", observedAt);
+        }
+        error?.(mappedError);
+      },
+      toPositionOptions(options)
+    );
+    // A synchronous callback can call stopObserving before the browser returns its ID.
+    if (!activeWatches.has(token)) geolocation.clearWatch(subscription.id);
+  } catch (error) {
+    activeWatches.delete(token);
+    throw error;
+  }
   return token;
 }
 
@@ -201,13 +219,15 @@ export function unwatch(token: string): void {
     return;
   }
 
-  const watchId = activeWatches.get(token);
-  if (watchId === undefined) {
+  const subscription = activeWatches.get(token);
+  if (!subscription) {
     return;
   }
 
-  getGeolocation()?.clearWatch(watchId);
   activeWatches.delete(token);
+  if (subscription.id !== undefined) {
+    subscription.geolocation.clearWatch(subscription.id);
+  }
 }
 
 export function getActiveWatches(): ActiveWatch[] {

--- a/packages/react-native-nitro-geolocation/type-tests/public-api.ts
+++ b/packages/react-native-nitro-geolocation/type-tests/public-api.ts
@@ -43,6 +43,7 @@ import type {
   LocationProviderUsed as BackgroundLocationProviderUsed,
   NullableDouble as BackgroundNullableDouble,
   PermissionStatus as BackgroundPermissionStatus,
+  IOSBackgroundLocationOptions,
   StartActivityRecognitionOptions
 } from "../src/background";
 import type {
@@ -61,6 +62,12 @@ import type {
 } from "../src/compat";
 import type { CompatGeolocationConfiguration } from "../src/publicTypes";
 import type { LocationAvailability as NativeLocationAvailability } from "../src/types";
+
+const unsupportedDeferredOptions: IOSBackgroundLocationOptions = {
+  // @ts-expect-error Deferred delivery was never implemented and is not a 2.0 contract.
+  deferredUpdatesDistance: 100
+};
+void unsupportedDeferredOptions;
 
 // @ts-expect-error Nitro's nullable bridge envelope is not a public API type.
 import type { BackgroundEventEnvelope } from "../src/background";

--- a/scripts/check-stable-docs.mjs
+++ b/scripts/check-stable-docs.mjs
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const fixture = await mkdtemp(path.join(os.tmpdir(), "nitro-stable-docs-"));
+try {
+  await mkdir(path.join(fixture, "scripts"), { recursive: true });
+  await cp(path.join(root, "docs"), path.join(fixture, "docs"), {
+    recursive: true,
+    filter: (source) =>
+      !["node_modules", "doc_build", ".rspress"].includes(path.basename(source))
+  });
+  for (const file of ["sync-release-version.mjs", "release-version-sync.mjs"]) {
+    await cp(
+      path.join(root, "scripts", file),
+      path.join(fixture, "scripts", file)
+    );
+  }
+  const packagePath = "packages/react-native-nitro-geolocation";
+  await mkdir(path.join(fixture, packagePath), { recursive: true });
+  const manifest = JSON.parse(
+    await readFile(path.join(root, packagePath, "package.json"), "utf8")
+  );
+  manifest.version = "2.0.0";
+  await writeFile(
+    path.join(fixture, packagePath, "package.json"),
+    JSON.stringify(manifest)
+  );
+  await cp(
+    path.join(root, packagePath, "README.md"),
+    path.join(fixture, packagePath, "README.md")
+  );
+  await mkdir(path.join(fixture, "examples/v0.81.1/ios"), { recursive: true });
+  await cp(
+    path.join(root, "examples/v0.81.1/ios/Podfile.lock"),
+    path.join(fixture, "examples/v0.81.1/ios/Podfile.lock")
+  );
+  await symlink(
+    path.join(root, "node_modules"),
+    path.join(fixture, "node_modules"),
+    "dir"
+  );
+  await symlink(
+    path.join(root, "docs/node_modules"),
+    path.join(fixture, "docs/node_modules"),
+    "dir"
+  );
+  const run = (script, cwd = fixture) =>
+    execFileSync(process.execPath, [script], { cwd, stdio: "inherit" });
+  run(path.join(fixture, "scripts/sync-release-version.mjs"));
+  execFileSync(
+    process.execPath,
+    [
+      path.join(root, "docs/node_modules/@rspress/core/bin/rspress.js"),
+      "build"
+    ],
+    {
+      cwd: path.join(fixture, "docs"),
+      stdio: "inherit"
+    }
+  );
+  for (const script of [
+    "finalize-version-routes.mjs",
+    "check-version-sources.mjs",
+    "check-version-routes.mjs"
+  ]) {
+    run(path.join(fixture, "docs/scripts", script));
+  }
+  const redirects = await readFile(
+    path.join(fixture, "docs/doc_build/_redirects"),
+    "utf8"
+  );
+  if (!redirects.includes("/v2/* /:splat 301"))
+    throw new Error("RC documentation redirects are missing");
+  console.log(
+    "Stable 2.0 documentation transition passed in an isolated copy."
+  );
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}

--- a/scripts/release-version-sync.mjs
+++ b/scripts/release-version-sync.mjs
@@ -22,10 +22,52 @@ export const syncVersionedDocumentation = (text, version, previousVersion) => {
         "react-native-nitro-geolocation@rc",
         "react-native-nitro-geolocation"
       )
-      .replaceAll("2.0 RC", "2.0");
+      .replaceAll("2.0 RC", "2.0")
+      .replace(
+        /React Native Nitro Geolocation 2\.0 is currently a \*\*release candidate\*\*\.[\s\S]*?(?=Pin the repository)/,
+        "React Native Nitro Geolocation 2.0 is the stable release line. Validate the\nexact devices, native dependencies, and features your application ships.\n\n## Release policy\n\n- Stable 2.x releases preserve the documented public contracts; incompatible\n  changes require a new major version.\n- Pin exact dependency versions and retain your application's release evidence.\n- The default site documents 2.x. The 1.x snapshot remains under `/v1/`.\n- A stable package is staged under `ga-candidate` until matching native release\n  artifacts pass verification and the release is promoted to `latest`.\n\n"
+      )
+      .replace(
+        /> \*\*2\.0 release candidate:\*\*[\s\S]*?\[unversioned documentation\]\(https:\/\/react-native-nitro-geolocation\.pages\.dev\/\)\./,
+        "> **2.0:** this README documents the stable 2.x contracts. Use the\n> [2.x documentation](https://react-native-nitro-geolocation.pages.dev/) or\n> the [1.x archive](https://react-native-nitro-geolocation.pages.dev/v1/)."
+      )
+      .replaceAll("2.0 release candidate", "2.0 release")
+      .replaceAll(
+        "release-candidate documentation; pin the RC before evaluating it",
+        "2.x documentation; pin exact versions when validating your application"
+      )
+      .replaceAll("release-candidate issues", "release issues")
+      .replaceAll("RC stability policy", "release policy")
+      .replaceAll("RC-policy", "release-policy")
+      .replaceAll("RC policy", "release policy")
+      .replaceAll("Evaluate the RC for release", "Evaluate release readiness")
+      .replaceAll("RC expectations", "Release expectations")
+      .replaceAll("Install an exact RC", "Install an exact version")
+      .replaceAll(
+        "Pin the RC rather than following a moving tag",
+        "Pin an exact version rather than following a moving tag"
+      )
+      .replaceAll("/v2/", "/");
   }
 
   return synchronized;
+};
+
+export const syncVersionedNavigation = (text, version) => {
+  assertSupportedReleaseVersion(version);
+  if (version.includes("-rc.")) return text;
+  const navigation = JSON.parse(text);
+  for (const item of navigation) {
+    if (item.text === "2.0 RC") {
+      item.text = "2.0";
+      item.tag = undefined;
+    }
+    if (item.text === "1.x stable") {
+      item.text = "1.x archive";
+      item.link = "https://react-native-nitro-geolocation.pages.dev/v1/";
+    }
+  }
+  return `${JSON.stringify(navigation, null, 2)}\n`;
 };
 
 export const readPodfileLockVersion = (text) => {

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -3,7 +3,8 @@ import path from "node:path";
 import {
   readPodfileLockVersion,
   syncPodfileLockVersion,
-  syncVersionedDocumentation
+  syncVersionedDocumentation,
+  syncVersionedNavigation
 } from "./release-version-sync.mjs";
 
 const rootDir = path.resolve(import.meta.dirname, "..");
@@ -61,6 +62,16 @@ for (const file of documentationFiles) {
     version,
     previousVersion
   );
+  if (synchronized !== current) {
+    await writeFile(file, synchronized);
+    updatedFiles += 1;
+  }
+}
+
+for (const relativePath of ["_nav.json", "v2/_nav.json"]) {
+  const file = path.join(docsDir, relativePath);
+  const current = await readFile(file, "utf8");
+  const synchronized = syncVersionedNavigation(current, version);
   if (synchronized !== current) {
     await writeFile(file, synchronized);
     updatedFiles += 1;

--- a/scripts/test-ios-location-lifecycle.sh
+++ b/scripts/test-ios-location-lifecycle.sh
@@ -32,3 +32,11 @@ xcrun swiftc \
   -o "$test_dir/ios-permission-request-contract"
 
 "$test_dir/ios-permission-request-contract"
+
+xcrun swiftc \
+  -parse-as-library \
+  "$repo_root/packages/react-native-nitro-geolocation/ios/IOSNumericOptions.swift" \
+  "$repo_root/tests/ios/IOSNumericOptionsContract.swift" \
+  -o "$test_dir/ios-numeric-options-contract"
+
+"$test_dir/ios-numeric-options-contract"

--- a/scripts/test-ios-location-lifecycle.sh
+++ b/scripts/test-ios-location-lifecycle.sh
@@ -24,3 +24,11 @@ xcrun swiftc \
   -o "$test_dir/ios-location-lifecycle-contract"
 
 "$test_dir/ios-location-lifecycle-contract"
+
+xcrun swiftc \
+  -parse-as-library \
+  "$repo_root/packages/react-native-nitro-geolocation/ios/IOSPermissionRequestQueue.swift" \
+  "$repo_root/tests/ios/IOSPermissionRequestQueueContract.swift" \
+  -o "$test_dir/ios-permission-request-contract"
+
+"$test_dir/ios-permission-request-contract"

--- a/tests/ios/IOSNumericOptionsContract.swift
+++ b/tests/ios/IOSNumericOptionsContract.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@main
+struct IOSNumericOptionsContract {
+    static func main() {
+        for invalid in [Double.nan, Double.infinity, -Double.infinity, -1] {
+            precondition(validateIOSLocationNumbers(timeout: invalid, maximumAge: 0, distanceFilter: 0) != nil)
+            precondition(validateIOSLocationNumbers(timeout: 0, maximumAge: 0, distanceFilter: invalid) != nil)
+        }
+        precondition(validateIOSLocationNumbers(timeout: 0, maximumAge: .infinity, distanceFilter: 0) == nil)
+        precondition(validateIOSLocationNumbers(timeout: 0, maximumAge: .nan, distanceFilter: 0) != nil)
+        precondition(iosHttpSyncAttemptCount(retry: true, maxRetries: nil) == 4)
+        precondition(iosHttpSyncAttemptCount(retry: true, maxRetries: 0) == 1)
+        for invalid in [Double.nan, Double.infinity, -1, 0.5, Double(Int32.max), Double.greatestFiniteMagnitude] {
+            precondition(iosHttpSyncAttemptCount(retry: true, maxRetries: invalid) == nil)
+        }
+        precondition(iosStorageLimit(0, defaultValue: 10_000) == nil)
+        precondition(iosStorageLimit(.nan, defaultValue: 10_000) == 10_000)
+        precondition(iosStorageLimit(.infinity, defaultValue: 10_000) == 10_000)
+        precondition(iosStorageLimit(Double.greatestFiniteMagnitude, defaultValue: 10_000) == Int(Int32.max))
+        precondition(iosStorageLimit(0.5, defaultValue: 10_000) == 1)
+        print("iOS numeric options contract passed")
+    }
+}

--- a/tests/ios/IOSPermissionRequestQueueContract.swift
+++ b/tests/ios/IOSPermissionRequestQueueContract.swift
@@ -1,0 +1,29 @@
+import CoreLocation
+import Foundation
+
+@main
+struct IOSPermissionRequestQueueContract {
+    static func main() {
+        let queue = IOSPermissionRequestQueue()
+        var received: [CLAuthorizationStatus] = []
+        queue.append { received.append($0) }
+        queue.append { received.append($0) }
+        queue.resolve(.notDetermined)
+        precondition(received.isEmpty, "Initial manager callback must not resolve a permission prompt")
+        queue.resolve(.authorizedAlways)
+        precondition(received == [.authorizedAlways, .authorizedAlways])
+        queue.resolve(.authorizedAlways)
+        precondition(received.count == 2, "Each request must resolve only once")
+
+        queue.append { status in
+            received.append(status)
+            queue.append { received.append($0) }
+        }
+        queue.resolve(.denied)
+        precondition(received.last == .denied && received.count == 3)
+        queue.resolve(.restricted)
+        precondition(received.last == .restricted && received.count == 4,
+                     "A reentrant request must survive the current delivery")
+        print("iOS permission request queue contract passed")
+    }
+}

--- a/tests/release-version-sync.test.mjs
+++ b/tests/release-version-sync.test.mjs
@@ -6,7 +6,8 @@ import {
   assertSupportedReleaseVersion,
   readPodfileLockVersion,
   syncPodfileLockVersion,
-  syncVersionedDocumentation
+  syncVersionedDocumentation,
+  syncVersionedNavigation
 } from "../scripts/release-version-sync.mjs";
 
 const root = path.resolve(import.meta.dirname, "..");
@@ -92,4 +93,41 @@ test("the scoped 2.x synchronizer rejects unrelated versions", () => {
     () => assertSupportedReleaseVersion("3.0.0"),
     /does not support/
   );
+});
+
+test("stable navigation drops RC markers and links to the versioned 1.x archive", async () => {
+  const source = await readFile(
+    path.join(root, "docs/docs/v2/_nav.json"),
+    "utf8"
+  );
+  assert.equal(syncVersionedNavigation(source, "2.0.0-rc.6"), source);
+  const stable = syncVersionedNavigation(source, "2.0.0");
+  assert.ok(!stable.includes('"RC"'));
+  assert.ok(!stable.includes("2.0 RC"));
+  assert.ok(
+    stable.includes("https://react-native-nitro-geolocation.pages.dev/v1/")
+  );
+  assert.equal(syncVersionedNavigation(stable, "2.0.0"), stable);
+});
+
+test("stable synchronization updates actual readiness policy and package README", async () => {
+  const version = JSON.parse(
+    await readFile(
+      path.join(root, "packages/react-native-nitro-geolocation/package.json"),
+      "utf8"
+    )
+  ).version;
+  for (const file of [
+    "docs/docs/v2/guide/release-readiness.md",
+    "packages/react-native-nitro-geolocation/README.md"
+  ]) {
+    const source = await readFile(path.join(root, file), "utf8");
+    const stable = syncVersionedDocumentation(source, "2.0.0", version);
+    assert.ok(!stable.includes("**release candidate**"));
+    assert.ok(!stable.includes("README documents RC contracts"));
+    assert.ok(!stable.includes("@rc"));
+    assert.ok(!stable.includes("/v2/"));
+    assert.ok(stable.includes("/v1/"));
+    assert.equal(syncVersionedDocumentation(stable, "2.0.0", "2.0.0"), stable);
+  }
 });

--- a/tests/release-workflow.test.mjs
+++ b/tests/release-workflow.test.mjs
@@ -1,9 +1,40 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
 const root = path.resolve(import.meta.dirname, "..");
+
+test("the legacy Unit Tests check cannot hide a pending or failed native suite", async () => {
+  const workflow = await readFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "utf8"
+  );
+  const names = [...workflow.matchAll(/^ {4}name: (.+)$/gm)].map(
+    (match) => match[1]
+  );
+  assert.equal(new Set(names).size, names.length);
+  const gate = workflow.slice(
+    workflow.indexOf("  unit-test-gate:"),
+    workflow.indexOf("  guardrails:")
+  );
+  assert.match(gate, /needs:\n {6}- unit-test\n {6}- unit-tests/);
+  assert.match(gate, /if: \$\{\{ always\(\) \}\}/);
+  const command = gate.match(/^ {8}run: (.+)$/m)?.[1];
+  assert.ok(command);
+  for (const js of ["success", "failure", "cancelled", "skipped"]) {
+    for (const android of ["success", "failure", "cancelled", "skipped"]) {
+      const result = spawnSync("bash", ["-c", command], {
+        env: { ...process.env, JS_RESULT: js, ANDROID_RESULT: android }
+      });
+      assert.equal(
+        result.status === 0,
+        js === "success" && android === "success"
+      );
+    }
+  }
+});
 
 test("the iOS release consumer builds its JS workspace dependency", async () => {
   const workflow = await readFile(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,29 +6542,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.15
-  resolution: "@types/prop-types@npm:15.7.15"
-  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
+"@types/react-test-renderer@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "@types/react-test-renderer@npm:19.1.0"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/799654e430df10aeaf267d71507fb64ec151359ead7e3774111bfd4abce7e0911dba461811195c06c22a6d17496ea92537d3185320ff4112fe29954cad1b9152
   languageName: node
   linkType: hard
 
-"@types/react-test-renderer@npm:^18.0.0":
-  version: 18.3.1
-  resolution: "@types/react-test-renderer@npm:18.3.1"
+"@types/react@npm:*, @types/react@npm:^19.2.0":
+  version: 19.2.18
+  resolution: "@types/react@npm:19.2.18"
   dependencies:
-    "@types/react": "npm:^18"
-  checksum: 10c0/9fc8467ff1a3f14be6cc3498a75fc788d2c92c0fffa7bf21269ed5d9d82db9195bf2178ddc42ea16a0836995c1b77601c6be8abb27bd1864668c418c6d0e5a3b
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18":
-  version: 18.3.25
-  resolution: "@types/react@npm:18.3.25"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/ef4fad7c845ce44cb454e47e826d1b04ff5081bccdac06d0260fc6e47de730268f8f9ff2ffc5085ee793d7466493c1175b2309b3d71c20916efefac0fd7612f1
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/d04216172b4b4362b310017c210dfbe019fb4f4e7dffd0313e70b3acb3051d5c3e76e7e84e3cf4c6a3c824993ffadfe3949e589a6398a09d4200e7670e2962de
   languageName: node
   linkType: hard
 
@@ -6574,15 +6566,6 @@ __metadata:
   dependencies:
     csstype: "npm:^3.0.2"
   checksum: 10c0/3d781f715f15f308b601d74142fae77c65679c318a3bb0a319df898f39095e738ba7ed7061cec971b19b6d33969ef9cd50fec92b034024ef3fcc25bb9a2eb3d0
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^19.2.0":
-  version: 19.2.18
-  resolution: "@types/react@npm:19.2.18"
-  dependencies:
-    csstype: "npm:^3.2.2"
-  checksum: 10c0/d04216172b4b4362b310017c210dfbe019fb4f4e7dffd0313e70b3acb3051d5c3e76e7e84e3cf4c6a3c824993ffadfe3949e589a6398a09d4200e7670e2962de
   languageName: node
   linkType: hard
 
@@ -15291,11 +15274,12 @@ __metadata:
     "@react-native/babel-preset": "npm:0.81.1"
     "@tsconfig/react-native": "npm:^3.0.7"
     "@types/react": "npm:^19.1.0"
-    "@types/react-test-renderer": "npm:^18.0.0"
+    "@types/react-test-renderer": "npm:^19.1.0"
     expo: "npm:^57.0.0"
     react: "npm:19.1.0"
     react-native: "npm:0.81.1"
     react-native-nitro-modules: "npm:0.35.10"
+    react-test-renderer: "npm:19.1.0"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.5"
   peerDependencies:
@@ -15610,6 +15594,18 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/83dc99158ff4c6513f2df358ca0e9920ba836672e491824ff9cf8d2218049db2859fafce147834f5c990cfe516cfdeefb5ffc3f49f917c0b30c2b22697ed96b7
+  languageName: node
+  linkType: hard
+
+"react-test-renderer@npm:19.1.0":
+  version: 19.1.0
+  resolution: "react-test-renderer@npm:19.1.0"
+  dependencies:
+    react-is: "npm:^19.1.0"
+    scheduler: "npm:^0.26.0"
+  peerDependencies:
+    react: ^19.1.0
+  checksum: 10c0/34ed4a37ba8b0beb96c048de6ff28574f018a18dd1042c24f8f46142d48eb5b27f82ff7c2823d082932fd3983c5a3529ab8cc8f15191d4306df0082f9f84678f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,16 +1198,16 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-modules-systemjs@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.27.1"
+  version: 7.29.8
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.8"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.27.1"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.8"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/f16fca62d144d9cbf558e7b5f83e13bb6d0f21fdeff3024b0cecd42ffdec0b4151461da42bd0963512783ece31aafa5ffe03446b4869220ddd095b24d414e2b5
+  checksum: 10c0/18167443bae93f485a43a1acdba9e53ac143043b93553d2ca1178030b68d4c1a7d5f5e717198aa8d73f39f33c023090af2270da774484105307e0fada5654687
   languageName: node
   linkType: hard
 
@@ -1835,7 +1835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.29.7":
+"@babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.29.7, @babel/traverse@npm:^7.29.8":
   version: 7.29.8
   resolution: "@babel/traverse@npm:7.29.8"
   dependencies:
@@ -3649,10 +3649,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.127.0":
-  version: 0.127.0
-  resolution: "@oxc-project/types@npm:0.127.0"
-  checksum: 10c0/52c0947ac64a9ca119fe971f947e784a35ecd14a072fa3f542a58a5f6c42010b53f2bf92731e39b9899b83c990a9517bbd29d1e5a5b7b489e52616685c6a9278
+"@oxc-project/types@npm:=0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-project/types@npm:0.133.0"
+  checksum: 10c0/70c57ba58644f7ec217b670c301801f4d06995f4ccdba6b2bd106ea3e5ee49d616573e6ef8d55530b87571a960696543687f3850e87ad173d3f88965c30cdd63
   languageName: node
   linkType: hard
 
@@ -5043,9 +5043,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.17"
+"@rolldown/binding-android-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -5057,9 +5057,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17"
+"@rolldown/binding-darwin-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -5071,9 +5071,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17"
+"@rolldown/binding-darwin-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5085,9 +5085,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17"
+"@rolldown/binding-freebsd-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -5099,9 +5099,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5113,9 +5113,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -5127,9 +5127,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -5141,9 +5141,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -5155,9 +5155,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -5169,9 +5169,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -5183,9 +5183,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17"
+"@rolldown/binding-linux-x64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -5197,9 +5197,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17"
+"@rolldown/binding-openharmony-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -5211,9 +5211,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17"
+"@rolldown/binding-wasm32-wasi@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.3"
   dependencies:
     "@emnapi/core": "npm:1.10.0"
     "@emnapi/runtime": "npm:1.10.0"
@@ -5222,9 +5222,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -5236,9 +5236,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17"
+"@rolldown/binding-win32-x64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5254,13 +5254,6 @@ __metadata:
   version: 1.0.0-beta.27
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.27"
   checksum: 10c0/9658f235b345201d4f6bfb1f32da9754ca164f892d1cb68154fe5f53c1df42bd675ecd409836dff46884a7847d6c00bdc38af870f7c81e05bba5c2645eb4ab9c
-  languageName: node
-  linkType: hard
-
-"@rolldown/pluginutils@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.17"
-  checksum: 10c0/5e840b20cc531910c093c1ca36e550952cf4936465a50d89f0a98fc9d0dfd7d319d06a10a5f4376209d89e9bf4d60af6cc8363ebf0dcc5e60842f7fef438b2f0
   languageName: node
   linkType: hard
 
@@ -7586,43 +7579,26 @@ __metadata:
   linkType: hard
 
 "body-parser@npm:^1.20.3":
-  version: 1.20.3
-  resolution: "body-parser@npm:1.20.3"
+  version: 1.20.8
+  resolution: "body-parser@npm:1.20.8"
   dependencies:
-    bytes: "npm:3.1.2"
+    bytes: "npm:~3.1.2"
     content-type: "npm:~1.0.5"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.13.0"
-    raw-body: "npm:2.5.2"
+    destroy: "npm:~1.2.0"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    on-finished: "npm:~2.4.1"
+    qs: "npm:~6.16.0"
+    raw-body: "npm:~2.5.3"
     type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/0a9a93b7518f222885498dcecaad528cf010dd109b071bf471c93def4bfe30958b83e03496eb9c1ad4896db543d999bb62be1a3087294162a88cfa1b42c16310
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/7edc8c4762d52ff685af081b1d5ccad860edcec662c25893be452b16042fd55b9c9869a194bd282e0ad936c34eb07866b2b33f0cc02ff916597058fd229c13d2
   languageName: node
   linkType: hard
 
-"body-parser@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "body-parser@npm:2.2.1"
-  dependencies:
-    bytes: "npm:^3.1.2"
-    content-type: "npm:^1.0.5"
-    debug: "npm:^4.4.3"
-    http-errors: "npm:^2.0.0"
-    iconv-lite: "npm:^0.7.0"
-    on-finished: "npm:^2.4.1"
-    qs: "npm:^6.14.0"
-    raw-body: "npm:^3.0.1"
-    type-is: "npm:^2.0.1"
-  checksum: 10c0/ce9608cff4114a908c09e8f57c7b358cd6fef66100320d01244d4c141448d7a6710c4051cc9d6191f8c6b3c7fa0f5b040c7aa1b6bbeb5462e27e668e64cb15bd
-  languageName: node
-  linkType: hard
-
-"body-parser@npm:^2.2.2":
+"body-parser@npm:^2.2.1, body-parser@npm:^2.2.2":
   version: 2.3.0
   resolution: "body-parser@npm:2.3.0"
   dependencies:
@@ -8581,7 +8557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destroy@npm:1.2.0":
+"destroy@npm:1.2.0, destroy@npm:~1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10c0/bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
@@ -9538,13 +9514,13 @@ __metadata:
   linkType: hard
 
 "fast-xml-parser@npm:^4.4.1":
-  version: 4.5.3
-  resolution: "fast-xml-parser@npm:4.5.3"
+  version: 4.5.7
+  resolution: "fast-xml-parser@npm:4.5.7"
   dependencies:
-    strnum: "npm:^1.1.1"
+    strnum: "npm:^1.0.5"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/bf9ccadacfadc95f6e3f0e7882a380a7f219cf0a6f96575149f02cb62bf44c3b7f0daee75b8ff3847bcfd7fbcb201e402c71045936c265cf6d94b141ec4e9327
+  checksum: 10c0/5fccf3f53d6b2b83143d73089f04ef5db5343422891193cf10d92d3eb856007b7337818494109e46f6fa47b31b9716be15c4b275ff87a0aeb6f7315aa2edc181
   languageName: node
   linkType: hard
 
@@ -10659,15 +10635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -10677,21 +10644,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "iconv-lite@npm:0.7.0"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/2382400469071c55b6746c531eed5fa4d033e5db6690b7331fb2a5f59a30d7a9782932e92253db26df33c1cf46fa200a3fbe524a2a7c62037c762283f188ec2f
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.7.2":
   version: 0.7.3
   resolution: "iconv-lite@npm:0.7.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/be2fd2414f7e94be3a63063fa0ad5919c16bc7b6e00c77eea0765ced6db405739f38dd51016583058fba25cc1d0106ba30b83fbb7a7e32f824d4db76f23d8d33
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:~0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
 
@@ -11307,15 +11274,15 @@ __metadata:
   linkType: hard
 
 "joi@npm:^17.2.1":
-  version: 17.13.3
-  resolution: "joi@npm:17.13.3"
+  version: 17.13.7
+  resolution: "joi@npm:17.13.7"
   dependencies:
     "@hapi/hoek": "npm:^9.3.0"
     "@hapi/topo": "npm:^5.1.0"
     "@sideway/address": "npm:^4.1.5"
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
-  checksum: 10c0/9262aef1da3f1bec5b03caf50c46368899fe03b8ff26cbe3d53af4584dd1049079fc97230bbf1500b6149db7cc765b9ee45f0deb24bb6fc3fa06229d7148c17f
+  checksum: 10c0/631b917001611631d4ed1007f307aabe36c0471617187f77298784c21264213b879c0f2ccd871fafbb0325c62012d4e3b77c60abbd67cc7a4f2d583f17f24568
   languageName: node
   linkType: hard
 
@@ -11505,23 +11472,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launch-editor@npm:^2.14.1":
+"launch-editor@npm:^2.14.1, launch-editor@npm:^2.9.1":
   version: 2.14.1
   resolution: "launch-editor@npm:2.14.1"
   dependencies:
     picocolors: "npm:^1.1.1"
     shell-quote: "npm:^1.8.4"
   checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
-  languageName: node
-  linkType: hard
-
-"launch-editor@npm:^2.9.1":
-  version: 2.11.1
-  resolution: "launch-editor@npm:2.11.1"
-  dependencies:
-    picocolors: "npm:^1.1.1"
-    shell-quote: "npm:^1.8.3"
-  checksum: 10c0/b1aad04eef3a675aa35e82498bedaaeb790b9a02834a9cff79987dd7c6f5d92fd8f79ff7a8a4cd61681e0d462069de30d0bc65b41a936a7e3d700a4fdac1090e
   languageName: node
   linkType: hard
 
@@ -14629,9 +14586,9 @@ __metadata:
   linkType: hard
 
 "path-to-regexp@npm:^8.0.0":
-  version: 8.3.0
-  resolution: "path-to-regexp@npm:8.3.0"
-  checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 10c0/05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf
   languageName: node
   linkType: hard
 
@@ -14740,7 +14697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10, postcss@npm:^8.5.14, postcss@npm:^8.5.26, postcss@npm:^8.5.6":
+"postcss@npm:^8.5.14, postcss@npm:^8.5.15, postcss@npm:^8.5.26, postcss@npm:^8.5.6":
   version: 8.5.28
   resolution: "postcss@npm:8.5.28"
   dependencies:
@@ -14855,31 +14812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.13.0":
-  version: 6.13.0
-  resolution: "qs@npm:6.13.0"
-  dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.14.0":
-  version: 6.14.0
-  resolution: "qs@npm:6.14.0"
-  dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/8ea5d91bf34f440598ee389d4a7d95820e3b837d3fd9f433871f7924801becaa0cd3b3b4628d49a7784d06a8aea9bc4554d2b6d8d584e2d221dc06238a42909c
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.15.2":
-  version: 6.15.3
-  resolution: "qs@npm:6.15.3"
+"qs@npm:^6.14.0, qs@npm:^6.15.2, qs@npm:~6.16.0":
+  version: 6.16.0
+  resolution: "qs@npm:6.16.0"
   dependencies:
     es-define-property: "npm:^1.0.1"
     side-channel: "npm:^1.1.1"
-  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
+  checksum: 10c0/eb3e31992fbd70e31a1791e571ed817d70975de7d3bfcbbbec93d77d1dd305877e9e8fdbcc62303c228ee5c3606685622cd6231c042dbc4790bb4e7c65fcbe18
   languageName: node
   linkType: hard
 
@@ -14932,19 +14871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:2.5.2":
-  version: 2.5.2
-  resolution: "raw-body@npm:2.5.2"
-  dependencies:
-    bytes: "npm:3.1.2"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
-  languageName: node
-  linkType: hard
-
-"raw-body@npm:^3.0.1, raw-body@npm:^3.0.2":
+"raw-body@npm:^3.0.2":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -14953,6 +14880,18 @@ __metadata:
     iconv-lite: "npm:~0.7.0"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:~2.5.3":
+  version: 2.5.3
+  resolution: "raw-body@npm:2.5.3"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/449844344fc90547fb994383a494b83300e4f22199f146a79f68d78a199a8f2a923ea9fd29c3be979bfd50291a3884733619ffc15ba02a32e703b612f8d3f74a
   languageName: node
   linkType: hard
 
@@ -15143,7 +15082,7 @@ __metadata:
   dependencies:
     react-native-nitro-geolocation: "workspace:*"
     typescript: "npm:5.9.3"
-    vite: "npm:8.0.10"
+    vite: "npm:8.0.16"
   languageName: unknown
   linkType: soft
 
@@ -15978,27 +15917,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "rolldown@npm:1.0.0-rc.17"
+"rolldown@npm:1.0.3":
+  version: 1.0.3
+  resolution: "rolldown@npm:1.0.3"
   dependencies:
-    "@oxc-project/types": "npm:=0.127.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.17"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.17"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.17"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.17"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.17"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.17"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.17"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.17"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.17"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.17"
+    "@oxc-project/types": "npm:=0.133.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-x64": "npm:1.0.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
       optional: true
@@ -16031,8 +15970,8 @@ __metadata:
     "@rolldown/binding-win32-x64-msvc":
       optional: true
   bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/bb99abc62ece4e34edd06d2b8eb9ffb7194dc2f0465a4329bb106cbde3006a10f1575e3580b198b793341109a2109581aed623c537c12b0c3a4ba0d72169b2fb
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/5f9dd47b7abf203b16bc600db68542f245e974c800e59ff50b76157d1dada1403657690435b036fabca88e93d13a67c31abe5cfaa6f61ce33717f61720204cdf
   languageName: node
   linkType: hard
 
@@ -16501,7 +16440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.3, shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.4":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
@@ -16521,16 +16460,6 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
   checksum: 10c0/09ee2d608bd5f735e9bb96ee3bbd24a3fb581ad9e7ee954adf8f0fb6cb7a955dda69b67c607935305a0215074706af15c437f259aa06d11c3cb53a3d45f8f0ab
-  languageName: node
-  linkType: hard
-
-"side-channel-list@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "side-channel-list@npm:1.0.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10c0/644f4ac893456c9490ff388bf78aea9d333d5e5bfc64cfb84be8f04bf31ddc111a8d4b83b85d7e7e8a7b845bc185a9ad02c052d20e086983cf59f0be517d9b3d
   languageName: node
   linkType: hard
 
@@ -16566,19 +16495,6 @@ __metadata:
     object-inspect: "npm:^1.13.3"
     side-channel-map: "npm:^1.0.1"
   checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "side-channel@npm:1.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-    side-channel-list: "npm:^1.0.0"
-    side-channel-map: "npm:^1.0.1"
-    side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
   languageName: node
   linkType: hard
 
@@ -16955,7 +16871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.1.1":
+"strnum@npm:^1.0.5":
   version: 1.1.2
   resolution: "strnum@npm:1.1.2"
   checksum: 10c0/a0fce2498fa3c64ce64a40dada41beb91cabe3caefa910e467dc0518ef2ebd7e4d10f8c2202a6104f1410254cae245066c0e94e2521fb4061a5cb41831952392
@@ -17660,7 +17576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
+"unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
@@ -17805,19 +17721,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:8.0.10":
-  version: 8.0.10
-  resolution: "vite@npm:8.0.10"
+"vite@npm:8.0.16":
+  version: 8.0.16
+  resolution: "vite@npm:8.0.16"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
     picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.10"
-    rolldown: "npm:1.0.0-rc.17"
-    tinyglobby: "npm:^0.2.16"
+    postcss: "npm:^8.5.15"
+    rolldown: "npm:1.0.3"
+    tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.0
+    "@vitejs/devtools": ^0.1.18
     esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
@@ -17858,7 +17774,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/92188b82654f856dbe562a1b679de695bb6ca18c0f43c4c276f84a869fb78e22dedb7c2df83b5617d6afdca979c059d654b5f61a0936a45f49917f352b9325ca
+  checksum: 10c0/d75be3fbe2f63e6a8145325970338afaf0dd4d96ba9175c13f9a286fd5f95afc489401b693e4fa6c0899a4dd0e137be91cdf9401a40a635563911ad5036e3467
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,30 +57,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.25.2":
-  version: 7.28.4
-  resolution: "@babel/core@npm:7.28.4"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.3"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helpers": "npm:^7.28.4"
-    "@babel/parser": "npm:^7.28.4"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.4"
-    "@babel/types": "npm:^7.28.4"
-    "@jridgewell/remapping": "npm:^2.3.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/ef5a6c3c6bf40d3589b5593f8118cfe2602ce737412629fb6e26d595be2fcbaae0807b43027a5c42ec4fba5b895ff65891f2503b5918c8a3ea3542ab44d4c278
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.20.0":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.20.0, @babel/core@npm:^7.25.2, @babel/core@npm:^7.28.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -100,29 +77,6 @@ __metadata:
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
   checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.28.0":
-  version: 7.28.5
-  resolution: "@babel/core@npm:7.28.5"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.5"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helpers": "npm:^7.28.4"
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
-    "@jridgewell/remapping": "npm:^2.3.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/535f82238027621da6bdffbdbe896ebad3558b311d6f8abc680637a9859b96edbf929ab010757055381570b29cf66c4a295b5618318d27a4273c0e2033925e72
   languageName: node
   linkType: hard
 
@@ -149,19 +103,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/0ff58bcf04f8803dcc29479b547b43b9b0b828ec1ee0668e92d79f9e90f388c28589056637c5ff2fd7bcf8d153c990d29c448d449d852bf9d1bc64753ca462bc
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/generator@npm:7.28.5"
-  dependencies:
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
-    "@jridgewell/gen-mapping": "npm:^0.3.12"
-    "@jridgewell/trace-mapping": "npm:^0.3.28"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/9f219fe1d5431b6919f1a5c60db8d5d34fe546c0d8f5a8511b32f847569234ffc8032beb9e7404649a143f54e15224ecb53a3d11b6bb85c3203e573d91fca752
   languageName: node
   linkType: hard
 
@@ -325,7 +266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.3":
+"@babel/helper-module-transforms@npm:^7.27.1":
   version: 7.28.3
   resolution: "@babel/helper-module-transforms@npm:7.28.3"
   dependencies:
@@ -499,16 +440,6 @@ __metadata:
     "@babel/traverse": "npm:^7.28.3"
     "@babel/types": "npm:^7.28.2"
   checksum: 10c0/aecb8a457efd893dc3c6378ab9221d06197573fb2fe64afabe7923e7732607d59b07f4c5603909877d69bea3ee87025f4b1d8e4f0403ae0a07b14e9ce0bf355a
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/helpers@npm:7.28.4"
-  dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.4"
-  checksum: 10c0/aaa5fb8098926dfed5f223adf2c5e4c7fbba4b911b73dfec2d7d3083f8ba694d201a206db673da2d9b3ae8c01793e795767654558c450c8c14b4c2175b4fcb44
   languageName: node
   linkType: hard
 
@@ -1904,21 +1835,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/traverse@npm:7.28.5"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.5"
-    "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.5"
-    debug: "npm:^4.3.1"
-  checksum: 10c0/f6c4a595993ae2b73f2d4cd9c062f2e232174d293edd4abe1d715bd6281da8d99e47c65857e8d0917d9384c65972f4acdebc6749a7c40a8fcc38b3c7fb3e706f
-  languageName: node
-  linkType: hard
-
 "@babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.29.7":
   version: 7.29.8
   resolution: "@babel/traverse@npm:7.29.8"
@@ -3103,22 +3019,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3753,6 +3653,13 @@ __metadata:
   version: 0.127.0
   resolution: "@oxc-project/types@npm:0.127.0"
   checksum: 10c0/52c0947ac64a9ca119fe971f947e784a35ecd14a072fa3f542a58a5f6c42010b53f2bf92731e39b9899b83c990a9517bbd29d1e5a5b7b489e52616685c6a9278
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.148.0":
+  version: 0.148.0
+  resolution: "@oxc-project/types@npm:0.148.0"
+  checksum: 10c0/23700196086ec996dcaf8cb494d0d378257a4f6f8ac4dfa0ee732bdf9a8a519da535cb33c8654ee6ea771872ae5801f9963c9d402767a4d13c2fa128cf7c42d2
   languageName: node
   linkType: hard
 
@@ -5129,9 +5036,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm-eabi@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-android-arm-eabi@npm:1.2.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.17"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -5143,9 +5064,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-arm64@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5157,9 +5092,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-freebsd-x64@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5171,9 +5120,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.7"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -5185,9 +5148,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.7"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.7"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -5199,6 +5176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-gnu@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.7"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17"
@@ -5206,9 +5190,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.7"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -5231,9 +5229,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17":
   version: 1.0.0-rc.17
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5249,6 +5261,13 @@ __metadata:
   version: 1.0.0-rc.17
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.17"
   checksum: 10c0/5e840b20cc531910c093c1ca36e550952cf4936465a50d89f0a98fc9d0dfd7d319d06a10a5f4376209d89e9bf4d60af6cc8363ebf0dcc5e60842f7fef438b2f0
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -6624,17 +6643,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ungap/structured-clone@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "@ungap/structured-clone@npm:1.3.0"
-  checksum: 10c0/0fc3097c2540ada1fc340ee56d58d96b5b536a2a0dab6e3ec17d4bfc8c4c86db345f61a375a8185f9da96f01c69678f836a2b57eeaa9e4b8eeafd26428e57b0a
-  languageName: node
-  linkType: hard
-
-"@ungap/structured-clone@npm:^1.3.0":
-  version: 1.3.3
-  resolution: "@ungap/structured-clone@npm:1.3.3"
-  checksum: 10c0/b199e280ee06e9c447e0ccd38df60a65c2b2c13d3c77af50b1e6d77230aee1ea7da309d7b80c5a4850c8e22e4eee9e4b2813c6a33f8c360560d7f2e99a9f6e8f
+"@ungap/structured-clone@npm:^1.0.0, @ungap/structured-clone@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "@ungap/structured-clone@npm:1.4.0"
+  checksum: 10c0/be74a389850d02901c836c07f10c1070d7604dab4070ba3c4b77c91665b90b4175d9f186189a02a399cf054fc051d3251418238564a4491d0164969e05c802a2
   languageName: node
   linkType: hard
 
@@ -6998,39 +7010,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+"ajv@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
   languageName: node
   linkType: hard
 
-"ajv@npm:~8.12.0":
-  version: 8.12.0
-  resolution: "ajv@npm:8.12.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.2.2"
-  checksum: 10c0/ac4f72adf727ee425e049bc9d8b31d4a57e1c90da8d28bcd23d60781b12fcd6fc3d68db5df16994c57b78b94eed7988f5a6b482fd376dc5b084125e20a0a622e
-  languageName: node
-  linkType: hard
-
-"ajv@npm:~8.13.0":
-  version: 8.13.0
-  resolution: "ajv@npm:8.13.0"
+"ajv@npm:^8.0.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.4.1"
-  checksum: 10c0/14c6497b6f72843986d7344175a1aa0e2c35b1e7f7475e55bc582cddb765fca7e6bf950f465dc7846f817776d9541b706f4b5b3fbedd8dfdeb5fce6f22864264
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 
@@ -7533,30 +7533,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.11.12":
-  version: 2.11.19
-  resolution: "baseline-browser-mapping@npm:2.11.19"
+"baseline-browser-mapping@npm:^2.11.20":
+  version: 2.11.21
+  resolution: "baseline-browser-mapping@npm:2.11.21"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/827e60717e1652d80471cc69e61c85966b7934cde4aab94f9eb21b9b8f864f094a810717c569fdec5b372fc4c9b7bbf99c27c5ceddb3a57313238fc6be355d93
-  languageName: node
-  linkType: hard
-
-"baseline-browser-mapping@npm:^2.8.3":
-  version: 2.8.9
-  resolution: "baseline-browser-mapping@npm:2.8.9"
-  bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/c54356eb90cf251f351708f151fa42d0331814c03baa7bdcc802767f721fd9fe069eea88ae42395984bfddcae0c2fba2e5ee25d7921ce7cdcefc2f47440673d4
-  languageName: node
-  linkType: hard
-
-"baseline-browser-mapping@npm:^2.8.9":
-  version: 2.8.11
-  resolution: "baseline-browser-mapping@npm:2.8.11"
-  bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/9c345d41152782c20cc11ad0aff273d252d6063efdfc45a602abd8798b50d81deeb89aa3ab6eedd33dce2ad714d16de96783e248f850e95b6063e81cd2ea62ba
+  checksum: 10c0/1110ca70b60de9fa673e6d71154cbb2752225c28e069266c2f455f5a26367efc0e5b47a52afba22c9ef1e06d56a6c81aa964dda1fbc66c487e65c18a7c1e11c4
   languageName: node
   linkType: hard
 
@@ -7708,21 +7690,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
@@ -7735,48 +7717,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.20.4":
-  version: 4.26.3
-  resolution: "browserslist@npm:4.26.3"
+"browserslist@npm:^4.20.4, browserslist@npm:^4.24.0, browserslist@npm:^4.25.0, browserslist@npm:^4.25.3":
+  version: 4.28.9
+  resolution: "browserslist@npm:4.28.9"
   dependencies:
-    baseline-browser-mapping: "npm:^2.8.9"
-    caniuse-lite: "npm:^1.0.30001746"
-    electron-to-chromium: "npm:^1.5.227"
-    node-releases: "npm:^2.0.21"
-    update-browserslist-db: "npm:^1.1.3"
+    baseline-browser-mapping: "npm:^2.11.20"
+    caniuse-lite: "npm:^1.0.30001810"
+    electron-to-chromium: "npm:^1.5.420"
+    node-releases: "npm:^2.0.54"
+    update-browserslist-db: "npm:^1.3.2"
   bin:
     browserslist: cli.js
-  checksum: 10c0/3899ee3b7fd205ece4ffe4392697c3f2b120b68f3741ef1789212b4971771aee3f66cf37c5c3accf86ce59c0605b5980c0f132711abbcc9e62c132e6e0ee45f3
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.24.0, browserslist@npm:^4.25.3":
-  version: 4.26.2
-  resolution: "browserslist@npm:4.26.2"
-  dependencies:
-    baseline-browser-mapping: "npm:^2.8.3"
-    caniuse-lite: "npm:^1.0.30001741"
-    electron-to-chromium: "npm:^1.5.218"
-    node-releases: "npm:^2.0.21"
-    update-browserslist-db: "npm:^1.1.3"
-  bin:
-    browserslist: cli.js
-  checksum: 10c0/1146339dad33fda77786b11ea07f1c40c48899edd897d73a9114ee0dbb1ee6475bb4abda263a678c104508bdca8e66760ff8e10be1947d3e20d34bae01d8b89b
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.25.0":
-  version: 4.28.8
-  resolution: "browserslist@npm:4.28.8"
-  dependencies:
-    baseline-browser-mapping: "npm:^2.11.12"
-    caniuse-lite: "npm:^1.0.30001809"
-    electron-to-chromium: "npm:^1.5.402"
-    node-releases: "npm:^2.0.53"
-    update-browserslist-db: "npm:^1.3.0"
-  bin:
-    browserslist: cli.js
-  checksum: 10c0/047dd517c8d1f1f56a253d752c3127b8ad01c58e4cbb7e21cb5cd07ebd13e083a2237c3afb13eb60674282c9132bd4534aea2c3ff7c6f7d29be0687a00cbd537
+  checksum: 10c0/c4c7457cccb188bb904bb84566ff2d09e6f45ccf48619333111e5d60dfad456522a64e3e4af7c7608bc171371fc006f32bcc296877b0586bf80fb9f60841a110
   languageName: node
   linkType: hard
 
@@ -7910,21 +7862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001741":
-  version: 1.0.30001746
-  resolution: "caniuse-lite@npm:1.0.30001746"
-  checksum: 10c0/e656a9dc811be2316e3b6dbd3bf25d0e32dbce645b1284821b4ec93fb81dc3e3f73b9473e2f66c921b620ea8b25ebbae9ee70c3d13dad85f8dd69d6bb2c91d46
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001746":
-  version: 1.0.30001747
-  resolution: "caniuse-lite@npm:1.0.30001747"
-  checksum: 10c0/cef0c7fff34d4c0ac3edc33660f07785301c98858bb4a6b8702b7b09ca2b0fd5457a7772af7b9fc3591fdd13862f649e57eed824f4cb6cf4aedf563e58fc7d0c
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001809":
+"caniuse-lite@npm:^1.0.30001810":
   version: 1.0.30001810
   resolution: "caniuse-lite@npm:1.0.30001810"
   checksum: 10c0/d29bc73f33c888025d54c7ff2984372d3b350b15a6a9e174884fb40976175e9177f202e2a72c2d428dddfc032784bc8ba635a31d168fcab9fac65756d7b3d6b4
@@ -8681,9 +8619,9 @@ __metadata:
   linkType: hard
 
 "diff@npm:~8.0.2":
-  version: 8.0.2
-  resolution: "diff@npm:8.0.2"
-  checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
+  version: 8.0.4
+  resolution: "diff@npm:8.0.4"
+  checksum: 10c0/7ee5d03926db4039be7252ac3b0abaae1bd122a2ca971e5ca7270e444e36ff83dd906fad1a719740ca347e97ed5dc8f458a76a8391dbcd7aff363bdafb348a00
   languageName: node
   linkType: hard
 
@@ -8781,24 +8719,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.218":
-  version: 1.5.227
-  resolution: "electron-to-chromium@npm:1.5.227"
-  checksum: 10c0/6b220ea024bcdd1560ffaca6b6b4c220d789b3e9c580c37509e8c176f369c93a4de8497a6e25cbfd9619ab9d129069368e4a4317dec0335d3a0cb61c2353e6f1
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.5.227":
-  version: 1.5.230
-  resolution: "electron-to-chromium@npm:1.5.230"
-  checksum: 10c0/b8bf382868b2780fa0c7ba3bce0644e94ec21af8f9b199ee094273904a575b46c8705fa4c10a22a0ed90e42dbbf72efbc3089bbecf8324a9db099c8c6c1c1101
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.5.402":
-  version: 1.5.414
-  resolution: "electron-to-chromium@npm:1.5.414"
-  checksum: 10c0/83097cfd6ed0260119d822f29a11f72ede28aa567a80b61af3c9c1e9499b4d50b3da15e578864bc968cc56356b237fe70db292071b9a9eb2843887c246a78ab9
+"electron-to-chromium@npm:^1.5.420":
+  version: 1.5.424
+  resolution: "electron-to-chromium@npm:1.5.424"
+  checksum: 10c0/f554fdf32be2d9d487f95bc3d7203fcf7eaf09550b56deb28ca8a77c2628e44759654a0f9cc23053b1980aa8e88dcee213013b497495ec2bca4ec6ac728e9d7b
   languageName: node
   linkType: hard
 
@@ -9544,7 +9468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
@@ -9588,9 +9512,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 
@@ -10140,8 +10064,8 @@ __metadata:
   linkType: hard
 
 "glob@npm:^10.2.2":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^3.1.2"
@@ -10151,7 +10075,7 @@ __metadata:
     path-scurry: "npm:^1.11.1"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
   languageName: node
   linkType: hard
 
@@ -10893,9 +10817,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "ip-address@npm:10.0.1"
-  checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843
+  version: 10.7.0
+  resolution: "ip-address@npm:10.7.0"
+  checksum: 10c0/bb6f514708b84ec75ad4d8156f3d571a5b8e592a15359386100f4f8d7366a4b7723d54b88a30d80b3f51ca5f4dee239e94ef4b53765b9c41a8ea46b421307d14
   languageName: node
   linkType: hard
 
@@ -11403,25 +11327,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
+  version: 3.15.2
+  resolution: "js-yaml@npm:3.15.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  checksum: 10c0/e341df211dece9d4b784849647ad7568b5b6a58a9ee58ead750482316d83276387343649fe4b71522705dc6c76acf97718588f23dc19443833ef3e75033af967
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 
@@ -11822,7 +11746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss@npm:^1.30.1":
+"lightningcss@npm:^1.30.1, lightningcss@npm:^1.33.0":
   version: 1.33.0
   resolution: "lightningcss@npm:1.33.0"
   dependencies:
@@ -11922,10 +11846,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:~4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 
@@ -13639,15 +13563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.0.3":
-  version: 10.0.3
-  resolution: "minimatch@npm:10.0.3"
-  dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -13657,7 +13572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
+"minimatch@npm:10.2.6, minimatch@npm:^10.2.2":
   version: 10.2.6
   resolution: "minimatch@npm:10.2.6"
   dependencies:
@@ -13667,29 +13582,29 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
   languageName: node
   linkType: hard
 
 "minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -13839,16 +13754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.18":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -13940,17 +13846,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.21":
-  version: 2.0.21
-  resolution: "node-releases@npm:2.0.21"
-  checksum: 10c0/0eb94916eeebbda9d51da6a9ea47428a12b2bb0dd94930c949632b0c859356abf53b2e5a2792021f96c5fda4f791a8e195f2375b78ae7dba8d8bc3141baa1469
-  languageName: node
-  linkType: hard
-
-"node-releases@npm:^2.0.53":
-  version: 2.0.53
-  resolution: "node-releases@npm:2.0.53"
-  checksum: 10c0/db9fb29b21ec12e223ead8bd9406100ff14fce01678a9a4865e288098456b84869431421a739f216aa520b6f57d9425f6537662501ae8a2d9e1771bfa87751bc
+"node-releases@npm:^2.0.54":
+  version: 2.0.54
+  resolution: "node-releases@npm:2.0.54"
+  checksum: 10c0/196b54ab06fd03b742816b6ca8185c69af42735b283083036e2579682c430b8f9ff89046891fe8c625557e5885793a2032d28070100bb2e57e6d6586b2f483c1
   languageName: node
   linkType: hard
 
@@ -14765,16 +14664,16 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10c0/beb6ae02c43ae44e84883b90830196d9046b1726ead292adcf7f57945e0bb0d992d68563d87e03b484b6f3c9a5c6defda7523477f047d7f0e663f126cc01787f
   languageName: node
   linkType: hard
 
@@ -14841,25 +14740,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10":
-  version: 8.5.12
-  resolution: "postcss@npm:8.5.12"
+"postcss@npm:^8.5.10, postcss@npm:^8.5.14, postcss@npm:^8.5.26, postcss@npm:^8.5.6":
+  version: 8.5.28
+  resolution: "postcss@npm:8.5.28"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.18"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.14, postcss@npm:^8.5.6":
-  version: 8.5.26
-  resolution: "postcss@npm:8.5.26"
-  dependencies:
-    nanoid: "npm:^3.3.17"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
+  checksum: 10c0/9fe44215a6628d89c8a75184b92f5b2f77e16f9e5b13b39b9009bb7e8e6eccddf82c8854bae922db1f17ace6ef3445073fe38abff513caeb03e5285b1b55620a
   languageName: node
   linkType: hard
 
@@ -14964,13 +14852,6 @@ __metadata:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
   checksum: 10c0/ada5cdf1d813065bbc99aa2c393b8f6beee73b5de2890a8754c9f488d7323ffd2ca5f5a0943b48934e3fcbd97637d0337369c3c631aeb9614915db629f1c75c9
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^2.1.0":
-  version: 2.3.1
-  resolution: "punycode@npm:2.3.1"
-  checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
   languageName: node
   linkType: hard
 
@@ -15570,20 +15451,20 @@ __metadata:
   linkType: hard
 
 "react-router-dom@npm:^7.13.2":
-  version: 7.14.2
-  resolution: "react-router-dom@npm:7.14.2"
+  version: 7.18.3
+  resolution: "react-router-dom@npm:7.18.3"
   dependencies:
-    react-router: "npm:7.14.2"
+    react-router: "npm:7.18.3"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10c0/94b294e7e47247d52358415a4b76e629680485b81bbaa649138b04277580276370f0b380b84bb1ffda21c330ed8c5cb36fb77ba5e173dcaaf06b5bfc44d9ac4e
+  checksum: 10c0/1d04bb38f64e9c429d4f162ca6c5ffc163a02c0a5c08748440a58fc0e9b1e8c8edc2bc4509e9966dcd0873e57fc6a090fd356244d581567737aac1ae6236e799
   languageName: node
   linkType: hard
 
-"react-router@npm:7.14.2":
-  version: 7.14.2
-  resolution: "react-router@npm:7.14.2"
+"react-router@npm:7.18.3":
+  version: 7.18.3
+  resolution: "react-router@npm:7.18.3"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -15593,7 +15474,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/83dc99158ff4c6513f2df358ca0e9920ba836672e491824ff9cf8d2218049db2859fafce147834f5c990cfe516cfdeefb5ffc3f49f917c0b30c2b22697ed96b7
+  checksum: 10c0/77686cad916f8928e6c4aeafe5f8dc26384e84897849ff7d771ddee67af02b788c103503d029ffa442f7bf42aa47b3779440e70fc1aeae90532120fae4036b0f
   languageName: node
   linkType: hard
 
@@ -16155,6 +16036,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.2.4":
+  version: 1.2.7
+  resolution: "rolldown@npm:1.2.7"
+  dependencies:
+    "@oxc-project/types": "npm:=0.148.0"
+    "@rolldown/binding-android-arm-eabi": "npm:1.2.7"
+    "@rolldown/binding-android-arm64": "npm:1.2.7"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.7"
+    "@rolldown/binding-darwin-x64": "npm:1.2.7"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.7"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.7"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.7"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.7"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.7"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.7"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.7"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.7"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.7"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.7"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.7"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm-eabi":
+      optional: true
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/e3b73addf51981d8b8430990ff59c14197994cfe9e1aae443dce47d353b409e7ffd478946185a15769588ab2e3d504557319fd58ab650ac9ac37c299384da10a
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.43.0":
   version: 4.63.1
   resolution: "rollup@npm:4.63.1"
@@ -16562,14 +16501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.3, shell-quote@npm:^1.8.4":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
@@ -17182,15 +17114,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.1
-  resolution: "tar@npm:7.5.1"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/0dad0596a61586180981133b20c32cfd93c5863c5b7140d646714e6ea8ec84583b879e5dc3928a4d683be6e6109ad7ea3de1cf71986d5194f81b3a016c8858c9
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 
@@ -17274,6 +17206,16 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
   languageName: node
   linkType: hard
 
@@ -17725,9 +17667,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "update-browserslist-db@npm:1.1.3"
+"update-browserslist-db@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "update-browserslist-db@npm:1.3.2"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -17735,30 +17677,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10c0/682e8ecbf9de474a626f6462aa85927936cdd256fe584c6df2508b0df9f7362c44c957e9970df55dfe44d3623807d26316ea2c7d26b80bb76a16c56c37233c32
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "update-browserslist-db@npm:1.3.1"
-  dependencies:
-    escalade: "npm:^3.2.0"
-    picocolors: "npm:^1.1.1"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 10c0/2a924f5aa283af2d918e5cd941c7e8d77b05adf2ffbe5ca461506b1ff05fee6e8bca74c0f1ba37eb28f00ec93b15e80de24c7222825835aec2dd7bf0a0f6a417
-  languageName: node
-  linkType: hard
-
-"uri-js@npm:^4.2.2, uri-js@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "uri-js@npm:4.4.1"
-  dependencies:
-    punycode: "npm:^2.1.0"
-  checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  checksum: 10c0/837b4ea8c4934228c5c2a922ea747a54b0ec9d1c408d2fbc9220a9b98327c04109776e6ea1206fa056ea61ed8534863af472d9f2cfce569d35f04e98c95db739
   languageName: node
   linkType: hard
 
@@ -17886,7 +17805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:8.0.10, vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+"vite@npm:8.0.10":
   version: 8.0.10
   resolution: "vite@npm:8.0.10"
   dependencies:
@@ -17940,6 +17859,63 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/92188b82654f856dbe562a1b679de695bb6ca18c0f43c4c276f84a869fb78e22dedb7c2df83b5617d6afdca979c059d654b5f61a0936a45f49917f352b9325ca
+  languageName: node
+  linkType: hard
+
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.2.2
+  resolution: "vite@npm:8.2.2"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.26"
+    rolldown: "npm:~1.2.4"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0 || ^0.5.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/94cbbbdc38ad500dcb86b6202ddd14aa41d05c80739766cada9bbe250b410d1a27be433c9c491ed39744019471ac1e27a59908616a88c42f9787bdb6bdca49d2
   languageName: node
   linkType: hard
 
@@ -18249,17 +18225,17 @@ __metadata:
   linkType: hard
 
 "ws@npm:^6.2.3":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
+  version: 6.2.6
+  resolution: "ws@npm:6.2.6"
   dependencies:
     async-limiter: "npm:~1.0.0"
-  checksum: 10c0/56a35b9799993cea7ce2260197e7879f21bbbb194a967f31acbbda6f7f46ecda4365951966fb062044c95197e19fb2f053be6f65c172435455186835f494de41
+  checksum: 10c0/24245efc3c09b6175df32ddb4a06f85432c4c88abb0e75f43f2551c1d5de456218b1b6c7685c414b8e03a68a167488e4aadf04a895681c8e01502025ce505742
   languageName: node
   linkType: hard
 
 "ws@npm:^7, ws@npm:^7.5.10":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+  version: 7.5.13
+  resolution: "ws@npm:7.5.13"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -18268,7 +18244,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  checksum: 10c0/e223726bbda5768ed58ec9252d04eda7018ef380ea122bb94e595a4d7a02b5baeb423933936576fddb8fa51b642375f7ae814bf0f6f5d9a3ce290566578a8c5a
   languageName: node
   linkType: hard
 
@@ -18363,21 +18339,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.9.0, yaml@npm:^2.9.0":
+"yaml@npm:2.9.0, yaml@npm:^2.2.1, yaml@npm:^2.6.1, yaml@npm:^2.9.0":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
   checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.2.1, yaml@npm:^2.6.1":
-  version: 2.8.1
-  resolution: "yaml@npm:2.8.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Prepare the 2.0 contract for stable release by fixing defects found against main `879a562` / `2.0.0-rc.5`. Fixes are split into feature commits.

- Fix first-install iOS permission settlement, watcher initialization, cancellation failures, and stopped/StrictMode watch delivery.
- Implement the existing Android notification color and stop-action options; prevent stale notifications from stopping newer tracking runs.
- Honor native background accuracy/granularity, preserve storage/activity settings across restarts, and prevent invalid numeric options from crashing or skipping uploads.
- Apply persisted Android geofencing defaults, preserve restart policy for stale notification actions, and keep fractional/nonfinite/subnormal storage limits from becoming unbounded after numeric conversion or restart.
- Correct the RC contract by excluding the never-implemented iOS deferred-delivery options from public types and configuration snapshots. The migration guide now documents all eight 2.0 changes.
- Fix GA documentation promotion and add an isolated stable-build rehearsal to CI, including 1.x archive routes and redirects for existing RC links.
- Replace ambiguous duplicate `Unit Tests` status names with distinct suites and one fail-closed legacy gate; test all 16 success/failure/cancelled/skipped combinations. Superseded CI runs are cancelled automatically.

Full roadmap mapping, findings, evidence, and release gates: [2.0.0 audit](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/fix/v2-release-readiness/docs/release-audit-2.0.0.md).

## Type of Change

- [x] Bug fix
- [x] Breaking change within the 2.0 release-candidate contract
- [x] Documentation update

## Validation

- Final head `29a3317`: [complete CI run](https://github.com/jingjing2222/react-native-nitro-geolocation/actions/runs/34279448321) **SUCCESS**, including Android unit/checksum tests, the aggregate `Unit Tests` gate, and the RN 0.87 SwiftPM consumer build. [Documentation CI](https://github.com/jingjing2222/react-native-nitro-geolocation/actions/runs/34279448359) and [Changeset CI](https://github.com/jingjing2222/react-native-nitro-geolocation/actions/runs/34279448368) also pass. All changes are organized in **19 feature-scoped commits**.
- 213 JS/React/browser tests; 21 release/SwiftPM/CI contracts.
- Randomized JavaScript test order: 213/213 for seeds `20260909` and `17`; fixed a test assumption that opaque watch tokens sort in registration order.
- 103 Android JVM/Robolectric tests and arm64 Release APK build pass.
- iOS Swift lifecycle/permission/watch/numeric contracts and source Release simulator build pass.
- Workspace typecheck, package builds, package checks, and doctor pass.
- Isolated stable 2.0 docs build passes (42 mirrored sources, 24 routes).
- Actual Changesets 3 `pre exit` + `version` rehearsal in a detached temporary worktree generates exactly `2.0.0`; its real docs build, archive/redirect checks, and 583-file npm dry-run pass. No publication occurred.
- Android and iOS prebuilt checksum/fallback contract tests pass.
- Rozenite behavior E2E passes 10/10 cases.
- Complete native sweep after the core fixes: iOS **31/31**, all first attempt; Android **45/45**, with initial launcher/task-removal failures retried (permission-details on attempt 3, geocoding on attempt 2). Logs show those processes were removed before React/Nitro initialization, not failed geolocation assertions.
- Final source Release rebuild: permission-details, geocoding, and strengthened background configuration contracts **3/3 on each platform**, all first attempt. These cover the later background-policy corrections and the corrected test launch sequence.
- iOS background long-run storage/event drain and native cleanup pass; iOS web success and denied flows pass (2/2), also rechecked against the patched Vite 8.0.16 server.
- Android background long-run, Headless JS, geofence transitions, **actual emulator reboot** and post-reboot location/geofence restoration pass. GPS-offline and all three web flows pass first attempt.
- Android no-Headless-JS Release variant passes foreground callbacks without unregistered-task warnings, first attempt. The normal Release app was restored afterward.

## Release boundary

This PR does not publish npm packages and is not unconditional approval to publish immediately. Merge only after required checks and the recorded E2E evidence pass. Generate the exact 2.0.0 version commit, stage via `ga-candidate`, verify matching release assets, and manually promote using the existing workflow. Physical-device background/OEM/battery acceptance remains separate from simulator proof.

Repository-control preflight: the `main` ruleset is **disabled**, classic branch protection is absent, and no GitHub environments exist yet. Naming `npm-latest` in the workflow does not establish an approval gate. Configure the intended branch checks and environment reviewers before relying on those protections. The `NPM_TOKEN` secret name exists; its value, scope, and validity were not inspected or tested by publishing. No repository protection settings were changed by this PR.

Workspace security audit: compatible refreshes reduce production-tree advisory/deprecation records from 117 to 42. The subsequent **all-environment** audit, including development-only roots, is **43 records / zero critical** (10 high / 27 moderate / 6 low), after also patching a critical Android CLI XML-parser finding. Remaining records include upstream Electron and packages without compatible fixed releases; they are **not** suppressed or claimed fixed. The published geolocation package has peer dependencies but no runtime `dependencies`. See [dependency audit and exposure boundaries](https://github.com/jingjing2222/react-native-nitro-geolocation/blob/fix/v2-release-readiness/docs/release-audit-dependencies-2.0.0.md).

References #98, #195, #206, #207. The 1.x backport and new authorization/custom-action APIs remain separate work; this PR fixes the existing stop action without claiming arbitrary actions are implemented.
