### PR TITLE
fix(ios): close first-launch state race and provide 1.4.3 backport

### DIFF
--- a/.changeset/ios-main-thread-state.md
+++ b/.changeset/ios-main-thread-state.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Keep the location manager property read on the main thread when checking accuracy authorization, closing a remaining race with first-launch initialization. Add a tested patch-package backport for apps that must stay on 1.4.3.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         run: |
           scripts/test-ios-location-lifecycle.sh
 
+      - name: Verify stable iOS race backport
+        run: bash scripts/test-ios-143-backport.sh
+
       - name: Verify iOS prebuilt checksums
         run: ruby tests/ruby/prebuilt_ios_checksum_test.rb
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ storage recovery, Headless JS, and HTTP sync.
 
 ## 📘 Documentation
 
+Apps pinned to 1.4.3 and affected by the iOS first-launch crash in #206 can use
+the [1.4.3 main-thread backport](patches/README.md).
+
 Full documentation available at:
 👉 [https://react-native-nitro-geolocation.pages.dev](https://react-native-nitro-geolocation.pages.dev)
 

--- a/packages/react-native-nitro-geolocation/ios/IOSGeolocationConversions.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSGeolocationConversions.swift
@@ -37,13 +37,10 @@ func currentAccuracyAuthorization(from locationManager: CLLocationManager?) -> A
 }
 
 func currentAccuracyAuthorizationOnMain(
-    from locationManager: CLLocationManager?
+    from locationManager: @autoclosure () -> CLLocationManager?
 ) -> AccuracyAuthorization {
-    if Thread.isMainThread {
-        return currentAccuracyAuthorization(from: locationManager)
-    }
-    return DispatchQueue.main.sync {
-        currentAccuracyAuthorization(from: locationManager)
+    return withLocationStateOnMain {
+        currentAccuracyAuthorization(from: locationManager())
     }
 }
 

--- a/packages/react-native-nitro-geolocation/ios/IOSLocationState.swift
+++ b/packages/react-native-nitro-geolocation/ios/IOSLocationState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Evaluate both the state read and its consumers on Core Location's queue.
+/// Passing an already-read property into a dispatch helper still races writers.
+internal func withLocationStateOnMain<T>(_ operation: () -> T) -> T {
+    if Thread.isMainThread { return operation() }
+    return DispatchQueue.main.sync(execute: operation)
+}

--- a/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
+++ b/packages/react-native-nitro-geolocation/ios/NitroGeolocation+CurrentPosition.swift
@@ -89,11 +89,7 @@ extension NitroGeolocation {
     }
 
     internal func runLocationOperationOnMainSync(_ operation: () -> Void) {
-        if Thread.isMainThread {
-            operation()
-        } else {
-            DispatchQueue.main.sync(execute: operation)
-        }
+        withLocationStateOnMain(operation)
     }
 }
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,32 @@
+# iOS first-launch crash on 1.4.3
+
+[Issue #206](https://github.com/jingjing2222/react-native-nitro-geolocation/issues/206)
+reports a race between JS calls and Core Location's initial authorization
+callback. The 2.0 implementation confines request and subscription state to the
+main queue. Apps staying on **exactly 1.4.3** can apply the adjacent
+`react-native-nitro-geolocation+1.4.3.patch` until a patched 1.x release is available.
+This patch does not require adopting the 2.0 API.
+
+1. Copy that patch into your app's `patches/` directory.
+2. Install `patch-package` as a development dependency using your package manager.
+3. Add `patch-package` to your `postinstall` script, preserving any existing steps,
+   and run it once to patch the installed package.
+4. Rebuild the iOS application from source. Disable any cached/prebuilt copy of
+   the native library so the patched Swift source is compiled.
+
+The patch queues mutable location/heading operations on the main queue, including
+manager creation, configuration, request registration, and cleanup. Tokens still
+return synchronously, while registration and removal retain queue order. It also
+keeps temporary-accuracy manager access on main and ignores the initial
+`notDetermined` callback while a permission request is pending. It does not modify
+Android or the package's JavaScript API.
+
+Run `bash scripts/test-ios-143-backport.sh` from this repository to verify the
+patch against the published npm archive and parse the resulting Swift source.
+That check requires npm, network access, and Xcode. Run the native stress contract
+with `bash scripts/test-ios-location-lifecycle.sh`.
+
+For device verification, enable Thread Sanitizer, reset location permissions,
+and exercise concurrent permission, current-position, heading, and immediate
+watch/unwatch calls on first launch. Repeat with permission allowed and denied.
+Remove this version-specific patch when upgrading to a fixed release.

--- a/patches/react-native-nitro-geolocation+1.4.3.patch
+++ b/patches/react-native-nitro-geolocation+1.4.3.patch
@@ -1,0 +1,458 @@
+diff --git a/node_modules/react-native-nitro-geolocation/ios/NitroGeolocation.swift b/node_modules/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+index 814da31..242a01f 100644
+--- a/node_modules/react-native-nitro-geolocation/ios/NitroGeolocation.swift
++++ b/node_modules/react-native-nitro-geolocation/ios/NitroGeolocation.swift
+@@ -37,7 +37,9 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+     // MARK: - Configuration
+ 
+     func setConfiguration(config: GeolocationConfiguration) {
+-        self.configuration = config
++        DispatchQueue.main.async {
++            self.configuration = config
++        }
+     }
+ 
+     // MARK: - Permission API
+@@ -53,23 +55,25 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+         success: @escaping (PermissionStatus) -> Void,
+         error: ((LocationError) -> Void)?
+     ) throws -> Void {
+-        self.initializeLocationManagerIfNeeded()
++        DispatchQueue.main.async {
++            self.initializeLocationManagerIfNeeded()
+ 
+-        let currentStatus = CLLocationManager.authorizationStatus()
++            let currentStatus = CLLocationManager.authorizationStatus()
+ 
+-        // Already determined
+-        if currentStatus != .notDetermined {
+-            let status = self.mapCLAuthorizationStatus(currentStatus)
+-            success(status)
+-            return
+-        }
++            // Already determined
++            if currentStatus != .notDetermined {
++                let status = self.mapCLAuthorizationStatus(currentStatus)
++                success(status)
++                return
++            }
+ 
+-        // Queue resolver
+-        self.pendingPermissionResolvers.append(success)
++            // Queue resolver
++            self.pendingPermissionResolvers.append(success)
+ 
+-        // Request permission
+-        let authLevel = self.determineAuthorizationLevel()
+-        self.requestSystemPermission(for: authLevel)
++            // Request permission
++            let authLevel = self.determineAuthorizationLevel()
++            self.requestSystemPermission(for: authLevel)
++        }
+     }
+ 
+     // MARK: - Provider/Settings API
+@@ -151,9 +155,8 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+             return
+         }
+ 
+-        initializeLocationManagerIfNeeded()
+-
+         DispatchQueue.main.async {
++            self.initializeLocationManagerIfNeeded()
+             guard #available(iOS 14.0, *), let manager = self.locationManager else {
+                 success(.unknown)
+                 return
+@@ -175,7 +178,9 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+                     return
+                 }
+ 
+-                success(self.getCurrentAccuracyAuthorization())
++                DispatchQueue.main.async {
++                    success(self.getCurrentAccuracyAuthorization())
++                }
+             }
+         }
+     }
+@@ -187,64 +192,66 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+         options: LocationRequestOptions,
+         error: ((LocationError) -> Void)?
+     ) throws -> Void {
+-        // Check permission
+-        let status = CLLocationManager.authorizationStatus()
+-        if status == .denied || status == .restricted {
+-            let message = status == .restricted
+-                ? "This application is not authorized to use location services"
+-                : "User denied access to location services."
+-            error?(createLocationError(
+-                code: PERMISSION_DENIED,
+-                message: message
+-            ))
+-            return
+-        }
++        DispatchQueue.main.async {
++            // Check permission
++            let status = CLLocationManager.authorizationStatus()
++            if status == .denied || status == .restricted {
++                let message = status == .restricted
++                    ? "This application is not authorized to use location services"
++                    : "User denied access to location services."
++                error?(createLocationError(
++                    code: PERMISSION_DENIED,
++                    message: message
++                ))
++                return
++            }
+ 
+-        if !CLLocationManager.locationServicesEnabled() {
+-            error?(createLocationError(
+-                code: SETTINGS_NOT_SATISFIED,
+-                message: "Location services disabled."
+-            ))
+-            return
+-        }
++            if !CLLocationManager.locationServicesEnabled() {
++                error?(createLocationError(
++                    code: SETTINGS_NOT_SATISFIED,
++                    message: "Location services disabled."
++                ))
++                return
++            }
+ 
+-        self.initializeLocationManagerIfNeeded()
++            self.initializeLocationManagerIfNeeded()
+ 
+-        let parsedOptions = ParsedOptions.parse(from: options)
++            let parsedOptions = ParsedOptions.parse(from: options)
+ 
+-        // Check cached location
+-        if let cached = self.getBestCachedLocation(options: parsedOptions) {
+-            self.lastLocation = cached
+-            let position = self.locationToPosition(cached)
+-            success(position)
+-            return
+-        }
++            // Check cached location
++            if let cached = self.getBestCachedLocation(options: parsedOptions) {
++                self.lastLocation = cached
++                let position = self.locationToPosition(cached)
++                success(position)
++                return
++            }
+ 
+-        // Create position request
+-        let id = UUID()
+-        var request = PositionRequest(
+-            success: success,
+-            error: { locationError in
+-                error?(locationError)
+-            },
+-            options: parsedOptions,
+-            timer: nil
+-        )
++            // Create position request
++            let id = UUID()
++            var request = PositionRequest(
++                success: success,
++                error: { locationError in
++                    error?(locationError)
++                },
++                options: parsedOptions,
++                timer: nil
++            )
+ 
+-        // Setup timeout
+-        let timer = DispatchSource.makeTimerSource(queue: .main)
+-        timer.schedule(deadline: .now() + parsedOptions.timeout / 1000.0)
+-        timer.setEventHandler { [weak self] in
+-            self?.handlePositionTimeout(requestId: id)
+-        }
+-        timer.resume()
+-        request.timer = timer
++            // Setup timeout
++            let timer = DispatchSource.makeTimerSource(queue: .main)
++            timer.schedule(deadline: .now() + parsedOptions.timeout / 1000.0)
++            timer.setEventHandler { [weak self] in
++                self?.handlePositionTimeout(requestId: id)
++            }
++            timer.resume()
++            request.timer = timer
+ 
+-        self.pendingPositionRequests[id] = request
++            self.pendingPositionRequests[id] = request
+ 
+-        // Update configuration and start monitoring
+-        self.updateLocationManagerConfiguration()
+-        self.startMonitoring()
++            // Update configuration and start monitoring
++            self.updateLocationManagerConfiguration()
++            self.startMonitoring()
++        }
+     }
+ 
+     func getLastKnownPosition(
+@@ -252,29 +259,31 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+         options: LocationRequestOptions,
+         error: ((LocationError) -> Void)?
+     ) throws -> Void {
+-        let status = CLLocationManager.authorizationStatus()
+-        if status == .denied || status == .restricted {
+-            let message = status == .restricted
+-                ? "This application is not authorized to use location services"
+-                : "User denied access to location services."
+-            error?(createLocationError(
+-                code: PERMISSION_DENIED,
+-                message: message
+-            ))
+-            return
+-        }
++        DispatchQueue.main.async {
++            let status = CLLocationManager.authorizationStatus()
++            if status == .denied || status == .restricted {
++                let message = status == .restricted
++                    ? "This application is not authorized to use location services"
++                    : "User denied access to location services."
++                error?(createLocationError(
++                    code: PERMISSION_DENIED,
++                    message: message
++                ))
++                return
++            }
+ 
+-        let parsedOptions = ParsedOptions.parseLastKnown(from: options)
+-        guard let cached = self.getBestCachedLocation(options: parsedOptions) else {
+-            error?(createLocationError(
+-                code: POSITION_UNAVAILABLE,
+-                message: "No cached location available."
+-            ))
+-            return
+-        }
++            let parsedOptions = ParsedOptions.parseLastKnown(from: options)
++            guard let cached = self.getBestCachedLocation(options: parsedOptions) else {
++                error?(createLocationError(
++                    code: POSITION_UNAVAILABLE,
++                    message: "No cached location available."
++                ))
++                return
++            }
+ 
+-        self.lastLocation = cached
+-        success(self.locationToPosition(cached))
++            self.lastLocation = cached
++            success(self.locationToPosition(cached))
++        }
+     }
+ 
+     // MARK: - Geocoding
+@@ -380,30 +389,32 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+         success: @escaping (Heading) -> Void,
+         error: ((LocationError) -> Void)?
+     ) throws -> Void {
+-        guard validateHeadingAvailability(error: error) else { return }
++        DispatchQueue.main.async {
++            guard self.validateHeadingAvailability(error: error) else { return }
+ 
+-        initializeLocationManagerIfNeeded()
++            self.initializeLocationManagerIfNeeded()
+ 
+-        let id = UUID()
+-        var request = HeadingRequest(
+-            success: success,
+-            error: { headingError in
+-                error?(headingError)
+-            },
+-            timer: nil
+-        )
++            let id = UUID()
++            var request = HeadingRequest(
++                success: success,
++                error: { headingError in
++                    error?(headingError)
++                },
++                timer: nil
++            )
+ 
+-        let timer = DispatchSource.makeTimerSource(queue: .main)
+-        timer.schedule(deadline: .now() + DEFAULT_HEADING_TIMEOUT_MS / 1000.0)
+-        timer.setEventHandler { [weak self] in
+-            self?.handleHeadingTimeout(requestId: id)
+-        }
+-        timer.resume()
+-        request.timer = timer
++            let timer = DispatchSource.makeTimerSource(queue: .main)
++            timer.schedule(deadline: .now() + DEFAULT_HEADING_TIMEOUT_MS / 1000.0)
++            timer.setEventHandler { [weak self] in
++                self?.handleHeadingTimeout(requestId: id)
++            }
++            timer.resume()
++            request.timer = timer
+ 
+-        pendingHeadingRequests[id] = request
+-        updateHeadingConfiguration()
+-        startHeadingMonitoring()
++            self.pendingHeadingRequests[id] = request
++            self.updateHeadingConfiguration()
++            self.startHeadingMonitoring()
++        }
+     }
+ 
+     func watchHeading(
+@@ -433,11 +444,13 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+             lastDeliveredHeading: nil
+         )
+ 
+-        headingSubscriptions[token] = subscription
++        DispatchQueue.main.async {
++            self.headingSubscriptions[token] = subscription
+ 
+-        initializeLocationManagerIfNeeded()
+-        updateHeadingConfiguration()
+-        startHeadingMonitoring()
++            self.initializeLocationManagerIfNeeded()
++            self.updateHeadingConfiguration()
++            self.startHeadingMonitoring()
++        }
+ 
+         return token
+     }
+@@ -458,55 +471,64 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+             options: parsedOptions
+         )
+ 
+-        watchSubscriptions[token] = subscription
++        DispatchQueue.main.async {
++            self.watchSubscriptions[token] = subscription
+ 
+-        initializeLocationManagerIfNeeded()
+-        updateLocationManagerConfiguration()
+-        startMonitoring()
++            self.initializeLocationManagerIfNeeded()
++            self.updateLocationManagerConfiguration()
++            self.startMonitoring()
++        }
+ 
+         return token
+     }
+ 
+     func unwatch(token: String) {
+-        watchSubscriptions.removeValue(forKey: token)
+-        headingSubscriptions.removeValue(forKey: token)
++        DispatchQueue.main.async {
++            self.watchSubscriptions.removeValue(forKey: token)
++            self.headingSubscriptions.removeValue(forKey: token)
+ 
+-        // Stop monitoring if no more subscriptions or pending requests
+-        if watchSubscriptions.isEmpty && pendingPositionRequests.isEmpty {
+-            stopMonitoring()
+-        } else {
+-            updateLocationManagerConfiguration()
+-        }
++            // Stop monitoring if no more subscriptions or pending requests
++            if self.watchSubscriptions.isEmpty && self.pendingPositionRequests.isEmpty {
++                self.stopMonitoring()
++            } else {
++                self.updateLocationManagerConfiguration()
++            }
+ 
+-        if headingSubscriptions.isEmpty && pendingHeadingRequests.isEmpty {
+-            stopHeadingMonitoring()
+-        } else {
+-            updateHeadingConfiguration()
++            if self.headingSubscriptions.isEmpty && self.pendingHeadingRequests.isEmpty {
++                self.stopHeadingMonitoring()
++            } else {
++                self.updateHeadingConfiguration()
++            }
+         }
+     }
+ 
+     func stopObserving() {
+-        watchSubscriptions.removeAll()
+-        headingSubscriptions.removeAll()
++        DispatchQueue.main.async {
++            self.watchSubscriptions.removeAll()
++            self.headingSubscriptions.removeAll()
+ 
+-        // Stop monitoring if no pending requests
+-        if pendingPositionRequests.isEmpty {
+-            stopMonitoring()
+-        } else {
+-            updateLocationManagerConfiguration()
+-        }
++            // Stop monitoring if no pending requests
++            if self.pendingPositionRequests.isEmpty {
++                self.stopMonitoring()
++            } else {
++                self.updateLocationManagerConfiguration()
++            }
+ 
+-        if pendingHeadingRequests.isEmpty {
+-            stopHeadingMonitoring()
+-        } else {
+-            updateHeadingConfiguration()
++            if self.pendingHeadingRequests.isEmpty {
++                self.stopHeadingMonitoring()
++            } else {
++                self.updateHeadingConfiguration()
++            }
+         }
+     }
+ 
+     // MARK: - Location Manager Callbacks
+ 
+     func handleAuthorizationChange(_ manager: CLLocationManager) {
++        dispatchPrecondition(condition: .onQueue(.main))
+         let status = getCurrentAuthorizationStatus(from: manager)
++        // The initial delegate notification is not a permission decision.
++        guard status != .notDetermined else { return }
+         let mappedStatus = mapCLAuthorizationStatus(status)
+ 
+         // Snapshot state before invoking JS callbacks because they can re-enter this instance.
+@@ -524,6 +546,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+     }
+ 
+     func handleLocationUpdate(_ locations: [CLLocation]) {
++        dispatchPrecondition(condition: .onQueue(.main))
+         guard let location = locations.last else { return }
+ 
+         lastLocation = location
+@@ -550,6 +573,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+     }
+ 
+     func handleLocationError(_ error: Error) {
++        dispatchPrecondition(condition: .onQueue(.main))
+         let locationError: LocationError
+ 
+         if let clError = error as? CLError {
+@@ -592,6 +616,7 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+     }
+ 
+     func handleHeadingUpdate(_ clHeading: CLHeading) {
++        dispatchPrecondition(condition: .onQueue(.main))
+         let heading = headingToResponse(clHeading)
+ 
+         for (id, request) in Array(pendingHeadingRequests) {
+@@ -629,19 +654,11 @@ class NitroGeolocation: HybridNitroGeolocationSpec {
+     // MARK: - Helper Functions
+ 
+     private func initializeLocationManagerIfNeeded() {
++        dispatchPrecondition(condition: .onQueue(.main))
+         guard locationManager == nil else { return }
+-
+-        if Thread.isMainThread {
+-            locationManager = CLLocationManager()
+-            locationManagerDelegate = LocationManagerDelegate(geolocation: self)
+-            locationManager?.delegate = locationManagerDelegate
+-        } else {
+-            DispatchQueue.main.sync {
+-                locationManager = CLLocationManager()
+-                locationManagerDelegate = LocationManagerDelegate(geolocation: self)
+-                locationManager?.delegate = locationManagerDelegate
+-            }
+-        }
++        locationManager = CLLocationManager()
++        locationManagerDelegate = LocationManagerDelegate(geolocation: self)
++        locationManager?.delegate = locationManagerDelegate
+     }
+ 
+     private func validateHeadingAvailability(

--- a/scripts/test-ios-143-backport.sh
+++ b/scripts/test-ios-143-backport.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_dir="$(mktemp -d /tmp/nitro-ios-143-backport.XXXXXX)"
+trap 'rm -rf -- "$test_dir"' EXIT
+
+if [[ -z "${DEVELOPER_DIR:-}" && -d /Applications/Xcode.app/Contents/Developer ]]; then
+  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+
+npm pack react-native-nitro-geolocation@1.4.3 --ignore-scripts --loglevel=error --pack-destination "$test_dir" >/dev/null
+mkdir -p "$test_dir/node_modules/react-native-nitro-geolocation"
+tar -xzf "$test_dir/react-native-nitro-geolocation-1.4.3.tgz" \
+  -C "$test_dir/node_modules/react-native-nitro-geolocation" --strip-components=1
+git -C "$test_dir" apply --check "$repo_root/patches/react-native-nitro-geolocation+1.4.3.patch"
+git -C "$test_dir" apply "$repo_root/patches/react-native-nitro-geolocation+1.4.3.patch"
+xcrun swiftc -frontend -parse \
+  "$test_dir/node_modules/react-native-nitro-geolocation/ios/NitroGeolocation.swift"
+echo "Published 1.4.3 backport applies cleanly and Swift parsing passed"

--- a/scripts/test-ios-location-lifecycle.sh
+++ b/scripts/test-ios-location-lifecycle.sh
@@ -35,6 +35,15 @@ xcrun swiftc \
 
 xcrun swiftc \
   -parse-as-library \
+  "$repo_root/packages/react-native-nitro-geolocation/ios/IOSLocationState.swift" \
+  "$repo_root/packages/react-native-nitro-geolocation/ios/IOSPermissionRequestQueue.swift" \
+  "$repo_root/tests/ios/IOSLocationStateContract.swift" \
+  -o "$test_dir/ios-location-state-contract"
+
+"$test_dir/ios-location-state-contract"
+
+xcrun swiftc \
+  -parse-as-library \
   "$repo_root/packages/react-native-nitro-geolocation/ios/IOSNumericOptions.swift" \
   "$repo_root/tests/ios/IOSNumericOptionsContract.swift" \
   -o "$test_dir/ios-numeric-options-contract"

--- a/tests/ios/IOSLocationStateContract.swift
+++ b/tests/ios/IOSLocationStateContract.swift
@@ -1,0 +1,42 @@
+import CoreLocation
+import Foundation
+
+@main
+struct IOSLocationStateContract {
+    static func main() {
+        // Main-thread callers, including callbacks that synchronously re-enter,
+        // must execute inline rather than deadlock on main.sync.
+        let nested = withLocationStateOnMain { withLocationStateOnMain { 42 } }
+        precondition(nested == 42)
+
+        let permissions = IOSPermissionRequestQueue()
+        var state: [Int: Int] = [:]
+        var resolved = 0
+        var completed = false
+        DispatchQueue.global().async {
+            DispatchQueue.concurrentPerform(iterations: 2_000) { index in
+                withLocationStateOnMain {
+                    dispatchPrecondition(condition: .onQueue(.main))
+                    state[index] = index
+                    permissions.append { _ in resolved += 1 }
+                    permissions.resolve(.notDetermined)
+                    precondition(state[index] == index)
+                }
+            }
+            withLocationStateOnMain {
+                permissions.resolve(.authorizedAlways)
+                precondition(resolved == 2_000)
+                precondition(state.count == 2_000)
+                permissions.resolve(.authorizedAlways)
+                precondition(resolved == 2_000)
+                completed = true
+            }
+        }
+        let deadline = Date().addingTimeInterval(30)
+        while !completed && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        precondition(completed, "Background callers must complete without blocking the run loop")
+        print("iOS main-thread state and first-authorization stress contract passed")
+    }
+}


### PR DESCRIPTION
## Description

`getAccuracyAuthorization()` evaluated `self.locationManager` on the Promise worker before dispatching to main, leaving a property-read race with first-launch initialization. Defer that evaluation with an autoclosure and share the synchronous main-thread state helper with watch cleanup.

For apps that must stay on 1.4.3, include a patch-package backport that confines location/heading state to main and keeps the initial `notDetermined` callback from consuming pending permission requests. The patch is checked against the actual published npm tarball in CI. This PR targets **main**; it does not publish a 1.4.4 release.

Closes #206.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Documentation update

## Checklist

- [x] Project style and changeset
- [x] Local build, typecheck, lint, format, package/dead-code guardrails
- [x] Documentation updated

## Testing

- Swift lifecycle, permission queue, numeric options, and 2,000 concurrent state operations: passed.
- The concurrent state test also passed with Thread Sanitizer.
- Published npm 1.4.3 archive: patch applies cleanly and patched Swift parses.
- JavaScript unit tests and release tests: passed.
- Workspace build and typecheck: passed.
- iOS Release native module build for the arm64 simulator: passed.

## E2E Test Results

The iOS Release native module compiles successfully. Maestro and physical-device first-install testing have not been run for this branch; the included instructions describe the device/Thread Sanitizer reproduction.

**Platform tested:** iOS native Swift contracts on macOS. Android unchanged.

**Test artifacts:** reproducible scripts in `scripts/test-ios-location-lifecycle.sh` and `scripts/test-ios-143-backport.sh`.
