### PR TITLE
fix(android): align NDK version with root project

### DIFF
--- a/.changeset/fix-android-ndk.md
+++ b/.changeset/fix-android-ndk.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Align the Android NDK version with the root project to prevent libc++ runtime mismatches.

--- a/packages/react-native-nitro-geolocation/android/build.gradle
+++ b/packages/react-native-nitro-geolocation/android/build.gradle
@@ -185,6 +185,8 @@ android {
 
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
+  ndkVersion getExtOrDefault("ndkVersion")
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")


### PR DESCRIPTION
## Summary

Fixes an Android runtime crash caused by NitroGeolocation being built with a different NDK version than the application and NitroModules.

With React Native 0.87.1 and NitroModules 0.37.1, NitroGeolocation was being built from source with NDK 28.2, while the application and NitroModules were using NDK 27.1.

This resulted in a libc++ mismatch and the application crashed on startup with:

```text
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__cxa_init_primary_exception"
referenced by "libnitrogeolocation.so"
```

Explicitly setting:
```gradle
ndkVersion getExtOrDefault("ndkVersion")
```
aligns NitroGeolocation with the root project’s NDK version and prevents the incompatible native runtime from being used.

Tested

* React Native 0.87.1
* react-native-nitro-modules 0.37.1
* react-native-nitro-geolocation 2.0.0
* Android
* New Architecture
* Clean native rebuild
* Application starts successfully without the UnsatisfiedLinkError