### PR TITLE
fix(ios): disable incompatible prebuilt binaries

### DIFF
--- a/.changeset/fix-ios-prebuilt-compatibility.md
+++ b/.changeset/fix-ios-prebuilt-compatibility.md
@@ -1,0 +1,5 @@
+---
+"react-native-nitro-geolocation": patch
+---
+
+Disable incompatible iOS prebuilt binaries when the consumer React Native or NitroModules version does not match the prebuilt target, falling back to a source build.

--- a/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
+++ b/packages/react-native-nitro-geolocation/scripts/prebuilt_ios.rb
@@ -28,11 +28,68 @@ module NitroGeolocationPrebuiltIOS
     false
   end
 
+  def parse_major_minor(version)
+    match = version.to_s.match(/^[^0-9]*(\d+)\.(\d+)/)
+    match ? "#{match[1]}.#{match[2]}" : nil
+  end
+
+  def find_node_module_package_json(package_dir, module_name)
+    current_dir = File.expand_path(package_dir)
+
+    loop do
+      candidate = File.join(current_dir, "node_modules", module_name, "package.json")
+      return candidate if File.file?(candidate)
+
+      parent_dir = File.dirname(current_dir)
+      break if parent_dir == current_dir
+
+      current_dir = parent_dir
+    end
+
+    nil
+  end
+
+  def read_node_module_version(package_dir, module_name)
+    package_json_path = find_node_module_package_json(package_dir, module_name)
+    return nil unless package_json_path
+
+    JSON.parse(File.read(package_json_path))["version"]
+  rescue StandardError
+    nil
+  end
+
+  def prebuilt_abi_compatible?(package_dir)
+    package = JSON.parse(File.read(File.join(package_dir, "package.json")))
+
+    bundled_react_native_version = package.dig("devDependencies", "react-native")
+    bundled_nitro_modules_version = package.dig("devDependencies", "react-native-nitro-modules")
+
+    consumer_react_native_version = read_node_module_version(package_dir, "react-native")
+    consumer_nitro_modules_version = read_node_module_version(package_dir, "react-native-nitro-modules")
+
+    compatible =
+      parse_major_minor(consumer_react_native_version) == parse_major_minor(bundled_react_native_version) &&
+      parse_major_minor(consumer_nitro_modules_version) == parse_major_minor(bundled_nitro_modules_version)
+
+    unless compatible
+      Pod::UI.puts(
+        "[NitroGeolocation] iOS prebuilt disabled for React Native #{consumer_react_native_version || 'unknown'} " \
+        "and NitroModules #{consumer_nitro_modules_version || 'unknown'}; " \
+        "assets target React Native #{bundled_react_native_version} and NitroModules #{bundled_nitro_modules_version}."
+      )
+    end
+
+    compatible
+  rescue StandardError
+    false
+  end
+
   def use_prebuilt?(package_dir)
     value = ENV[env_name("usePrebuilt")]
-    return !false_like?(value) unless value.nil?
+    should_attempt_prebuilt = value.nil? ? !source_checkout?(package_dir) : !false_like?(value)
+    return false unless should_attempt_prebuilt
 
-    !source_checkout?(package_dir)
+    prebuilt_abi_compatible?(package_dir)
   end
 
   def string_config(name, default_value)


### PR DESCRIPTION
## Problem

`react-native-nitro-geolocation@2.0.1` fails to link on iOS when used with React Native 0.87.1 and `react-native-nitro-modules` 0.37.1 with the default prebuilt binary enabled.

The CocoaPods install itself succeeds, but the application fails during the final link step with unresolved JSI symbols such as:

```text
Undefined symbol: facebook::jsi::JSError::JSError(...)
Undefined symbol: facebook::jsi::Value::toString(...)
Undefined symbol: facebook::jsi::Value::asObject(...)
Undefined symbol: facebook::jsi::Value::asString(...) const &
Undefined symbol: facebook::jsi::Value::asString(...) &&
Undefined symbol: facebook::jsi::Object::asFunction(...) &&
Undefined symbol: facebook::jsi::Object::asArray(...) &&
Linker command failed with exit code 1
```

The undefined references come from the prebuilt NitroGeolocation framework, for example:

```text
NitroGeolocation[arm64](HybridNitroBackgroundLocationSpec-....o)
```

Building NitroGeolocation from source instead fixes the issue:

```bash
cd ios
NITRO_GEOLOCATION_USE_PREBUILT=0 bundle exec pod install
cd ..
yarn ios
```

## Root cause

The iOS prebuilt XCFramework is currently built using the React Native 0.81.1 example:

```text
examples/v0.81.1
```

The package itself declares support for a much wider React Native range.

React Native changed the relevant JSI ABI starting with 0.86.

Inspecting the symbols in the packaged XCFramework shows that it references JSI methods using:

```text
facebook::jsi::Runtime&
```
while a source build against React Native 0.87.1 references:

```text
facebook::jsi::IRuntime&
```

For example:

```diff
-JSError(Runtime&, ...)
+JSError(IRuntime&, ...)
```
The same difference exists for toString, asObject, asString, asFunction, and asArray.

I also checked the React Native headers across versions:

* React Native 0.81.x–0.85.x use Runtime&
* React Native 0.86.x–0.87.x use IRuntime&

So the prebuilt binary produced against React Native 0.81.1 is not ABI-compatible with React Native 0.86+.

## Existing Android behavior

Android already protects its prebuilt binaries from this type of mismatch.

It compares the consumer React Native and NitroModules major/minor versions against the versions used to build the package prebuilts:

```gradle
def bundledReactNativeVersion = packageJson.devDependencies["react-native"]
def bundledNitroModulesVersion = packageJson.devDependencies["react-native-nitro-modules"]
def consumerReactNativeVersion = readNodeModuleVersion("react-native")
def consumerNitroModulesVersion = readNodeModuleVersion("react-native-nitro-modules")
```

and only uses the prebuilt when both match.

The bundled versions currently are:

```text
React Native: 0.81.1
NitroModules: 0.35.10
```

## Fix

This PR applies the same compatibility policy to the iOS prebuilt.

Before using the XCFramework, the CocoaPods helper now reads the consumer versions of:

* react-native
* react-native-nitro-modules

and compares their major/minor versions against the versions used to build the prebuilt.

If they do not match, the prebuilt is disabled and the existing source-build path is used automatically.

For example, with React Native 0.87.1 and NitroModules 0.37.1:

```text
[NitroGeolocation] iOS prebuilt disabled for React Native 0.87.1 and NitroModules 0.37.1; assets target React Native 0.81.1 and NitroModules 0.35.10.
```

No Podfile or environment variable changes are required.

## Reproduction

Using:

```text
react-native: 0.87.1
react-native-nitro-modules: 0.37.1
react-native-nitro-geolocation: 2.0.1
```

with the released package:

```bash
bundle exec pod install
yarn ios
```
results in the JSI linker errors above when the packaged XCFramework is selected.

Using:

```bash
NITRO_GEOLOCATION_USE_PREBUILT=0 bundle exec pod install
```

builds from source and succeeds.

## Verification

I tested this PR from a Git dependency in an existing React Native 0.87.1 application.

With a normal:

```bash
bundle exec pod install
```

the compatibility check produced:

```text
[NitroGeolocation] iOS prebuilt disabled for React Native 0.87.1 and NitroModules 0.37.1; assets target React Native 0.81.1 and NitroModules 0.35.10.
```

CocoaPods then installed NitroGeolocation through the source-build path. After that built successfully and the application launched successfully.
